### PR TITLE
FOS: Update zkevm_pcode_defs Dependency To Public Repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/zkevm_opcode_defs.git", branch = "v1.3.2" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_defs.git", branch = "v1.3.2" }
 u256 = { package = "primitive-types", version = "0.12.1" }
 enum_dispatch = "0.3"
 arbitrary = { version = "1", features = ["derive"] }


### PR DESCRIPTION
### What

This PR updates the cargo.toml of the branch to refer to the public dependency.