### PR TITLE
fix: report correct heap sizes in ContextMeta

### DIFF
--- a/src/fat_pointer.rs
+++ b/src/fat_pointer.rs
@@ -2,7 +2,7 @@ use crate::heap::HeapId;
 use u256::U256;
 
 #[repr(C)]
-pub(crate) struct FatPointer {
+pub struct FatPointer {
     pub offset: u32,
     pub memory_page: HeapId,
     pub start: u32,

--- a/src/fat_pointer.rs
+++ b/src/fat_pointer.rs
@@ -1,9 +1,10 @@
+use crate::heap::HeapId;
 use u256::U256;
 
 #[repr(C)]
 pub(crate) struct FatPointer {
     pub offset: u32,
-    pub memory_page: u32,
+    pub memory_page: HeapId,
     pub start: u32,
     pub length: u32,
 }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,0 +1,67 @@
+use std::ops::{Index, IndexMut};
+
+use zkevm_opcode_defs::system_params::NEW_FRAME_MEMORY_STIPEND;
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct HeapId(u32);
+
+impl HeapId {
+    /// Only for dealing with external data structures, never use internally.
+    pub(crate) fn from_u32_unchecked(value: u32) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn to_u32(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Heaps(Vec<Vec<u8>>);
+
+pub(crate) const CALLDATA_HEAP: HeapId = HeapId(1);
+pub const FIRST_HEAP: HeapId = HeapId(2);
+pub(crate) const FIRST_AUX_HEAP: HeapId = HeapId(3);
+
+impl Heaps {
+    pub(crate) fn new(calldata: Vec<u8>) -> Self {
+        // The first heap can never be used because heap zero
+        // means the current heap in precompile calls
+        Self(vec![vec![], calldata, vec![], vec![]])
+    }
+
+    pub(crate) fn allocate(&mut self) -> HeapId {
+        let id = HeapId(self.0.len() as u32);
+        self.0.push(vec![0; NEW_FRAME_MEMORY_STIPEND as usize]);
+        id
+    }
+
+    pub(crate) fn deallocate(&mut self, heap: HeapId) {
+        self.0[heap.0 as usize] = vec![];
+    }
+}
+
+impl Index<HeapId> for Heaps {
+    type Output = Vec<u8>;
+
+    fn index(&self, index: HeapId) -> &Self::Output {
+        &self.0[index.0 as usize]
+    }
+}
+
+impl IndexMut<HeapId> for Heaps {
+    fn index_mut(&mut self, index: HeapId) -> &mut Self::Output {
+        &mut self.0[index.0 as usize]
+    }
+}
+
+impl PartialEq for Heaps {
+    fn eq(&self, other: &Self) -> bool {
+        for i in 0..self.0.len().max(other.0.len()) {
+            if self.0.get(i).unwrap_or(&vec![]) != other.0.get(i).unwrap_or(&vec![]) {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -7,11 +7,11 @@ pub struct HeapId(u32);
 
 impl HeapId {
     /// Only for dealing with external data structures, never use internally.
-    pub(crate) fn from_u32_unchecked(value: u32) -> Self {
+    pub fn from_u32_unchecked(value: u32) -> Self {
         Self(value)
     }
 
-    pub(crate) fn to_u32(self) -> u32 {
+    pub fn to_u32(self) -> u32 {
         self.0
     }
 }

--- a/src/instruction_handlers/context.rs
+++ b/src/instruction_handlers/context.rs
@@ -73,8 +73,8 @@ struct Meta;
 impl ContextOp for Meta {
     fn get(state: &State) -> U256 {
         VmMetaParameters {
-            heap_size: state.heaps[state.current_frame.heap].len() as u32,
-            aux_heap_size: state.heaps[state.current_frame.aux_heap].len() as u32,
+            heap_size: state.current_frame.heap_size,
+            aux_heap_size: state.current_frame.aux_heap_size,
             this_shard_id: 0, // TODO properly implement shards
             caller_shard_id: 0,
             code_shard_id: 0,

--- a/src/instruction_handlers/precompiles.rs
+++ b/src/instruction_handlers/precompiles.rs
@@ -1,8 +1,8 @@
 use super::{common::instruction_boilerplate_with_panic, PANIC};
 use crate::{
     addressing_modes::{Arguments, Destination, Register1, Register2, Source},
+    heap::{HeapId, Heaps},
     instruction::InstructionResult,
-    state::Heaps,
     Instruction, VirtualMachine, World,
 };
 use u256::U256;
@@ -42,10 +42,10 @@ fn precompile_call(
 
         let mut abi = PrecompileCallABI::from_u256(Register1::get(args, &mut vm.state));
         if abi.memory_page_to_read == 0 {
-            abi.memory_page_to_read = vm.state.current_frame.heap;
+            abi.memory_page_to_read = vm.state.current_frame.heap.to_u32();
         }
         if abi.memory_page_to_write == 0 {
-            abi.memory_page_to_write = vm.state.current_frame.heap;
+            abi.memory_page_to_write = vm.state.current_frame.heap.to_u32();
         }
 
         let query = LogQuery {
@@ -95,7 +95,8 @@ impl Memory for Heaps {
         _monotonic_cycle_counter: u32,
         mut query: zk_evm_abstractions::queries::MemoryQuery,
     ) -> zk_evm_abstractions::queries::MemoryQuery {
-        let page = query.location.page.0;
+        let page = HeapId::from_u32_unchecked(query.location.page.0);
+
         let start = query.location.index.0 as usize * 32;
         let range = start..start + 32;
         if query.rw_flag {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod callframe;
 pub mod decode;
 mod decommit;
 mod fat_pointer;
+mod heap;
 mod instruction;
 pub mod instruction_handlers;
 mod modified_world;
@@ -21,11 +22,12 @@ use u256::{H160, U256};
 
 pub use decommit::address_into_u256;
 pub use decommit::initial_decommit;
+pub use heap::FIRST_HEAP;
 pub use instruction::{jump_to_beginning, ExecutionEnd, Instruction};
 pub use modified_world::{Event, L2ToL1Log, WorldDiff};
 pub use predication::Predicate;
 pub use program::Program;
-pub use state::{State, FIRST_HEAP};
+pub use state::State;
 pub use vm::{Settings, VirtualMachine, VmSnapshot as Snapshot};
 
 pub trait World {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod bitset;
 mod callframe;
 pub mod decode;
 mod decommit;
-mod fat_pointer;
+pub mod fat_pointer;
 mod heap;
 mod instruction;
 pub mod instruction_handlers;
@@ -22,7 +22,7 @@ use u256::{H160, U256};
 
 pub use decommit::address_into_u256;
 pub use decommit::initial_decommit;
-pub use heap::FIRST_HEAP;
+pub use heap::{HeapId, FIRST_HEAP};
 pub use instruction::{jump_to_beginning, ExecutionEnd, Instruction};
 pub use modified_world::{Event, L2ToL1Log, WorldDiff};
 pub use predication::Predicate;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,14 @@
 use crate::{
-    addressing_modes::Addressable, bitset::Bitset, callframe::Callframe, fat_pointer::FatPointer,
-    modified_world::Snapshot, predication::Flags, program::Program, stack::Stack,
+    addressing_modes::Addressable,
+    bitset::Bitset,
+    callframe::Callframe,
+    fat_pointer::FatPointer,
+    heap::{Heaps, CALLDATA_HEAP, FIRST_AUX_HEAP, FIRST_HEAP},
+    modified_world::Snapshot,
+    predication::Flags,
+    program::Program,
+    stack::Stack,
 };
-use std::ops::{Index, IndexMut};
 use u256::{H160, U256};
 
 #[derive(Clone, PartialEq, Debug)]
@@ -25,8 +31,6 @@ pub struct State {
     pub(crate) context_u128: u128,
 }
 
-pub const FIRST_HEAP: u32 = 2;
-
 impl State {
     pub(crate) fn new(
         address: H160,
@@ -39,7 +43,7 @@ impl State {
     ) -> Self {
         let mut registers: [U256; 16] = Default::default();
         registers[1] = FatPointer {
-            memory_page: 1,
+            memory_page: CALLDATA_HEAP,
             offset: 0,
             start: 0,
             length: calldata.len() as u32,
@@ -57,8 +61,8 @@ impl State {
                 program,
                 stack,
                 FIRST_HEAP,
-                3,
-                1,
+                FIRST_AUX_HEAP,
+                CALLDATA_HEAP,
                 gas,
                 0,
                 0,
@@ -68,9 +72,7 @@ impl State {
             ),
             previous_frames: vec![],
 
-            // The first heap can never be used because heap zero
-            // means the current heap in precompile calls
-            heaps: Heaps(vec![vec![], calldata, vec![], vec![]]),
+            heaps: Heaps::new(calldata),
 
             transaction_number: 0,
             context_u128: 0,
@@ -129,39 +131,5 @@ impl Addressable for State {
     }
     fn code_page(&self) -> &[U256] {
         self.current_frame.program.code_page()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct Heaps(pub(crate) Vec<Vec<u8>>);
-
-impl Heaps {
-    pub(crate) fn deallocate(&mut self, heap: u32) {
-        self.0[heap as usize] = vec![];
-    }
-}
-
-impl Index<u32> for Heaps {
-    type Output = Vec<u8>;
-
-    fn index(&self, index: u32) -> &Self::Output {
-        &self.0[index as usize]
-    }
-}
-
-impl IndexMut<u32> for Heaps {
-    fn index_mut(&mut self, index: u32) -> &mut Self::Output {
-        &mut self.0[index as usize]
-    }
-}
-
-impl PartialEq for Heaps {
-    fn eq(&self, other: &Self) -> bool {
-        for i in 0..self.0.len().max(other.0.len()) {
-            if self.0.get(i).unwrap_or(&vec![]) != other.0.get(i).unwrap_or(&vec![]) {
-                return false;
-            }
-        }
-        true
     }
 }


### PR DESCRIPTION
- use HeapId instead of plain u32
- store heap size as a separate variable to avoid actually allocating u32::MAX for the bootloader
- return that variable from ContextMeta