### PR TITLE
fix: revert pubdata on failed near call, too

### DIFF
--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -21,8 +21,6 @@ pub struct Callframe {
     pub gas: u32,
     pub stipend: u32,
 
-    pub total_pubdata_spent: i32,
-
     near_calls: Vec<NearCallFrame>,
 
     pub(crate) program: Program,
@@ -102,7 +100,6 @@ impl Callframe {
             exception_handler,
             near_calls: vec![],
             world_before_this_frame,
-            total_pubdata_spent: 0,
         }
     }
 
@@ -132,7 +129,6 @@ impl Callframe {
                 program_counter: f.call_instruction,
                 exception_handler: f.exception_handler,
                 snapshot: f.world_before_this_frame,
-                total_pubdata_spent: 0,
             }
         })
     }
@@ -163,5 +159,4 @@ pub(crate) struct FrameRemnant {
     pub(crate) program_counter: u16,
     pub(crate) exception_handler: u16,
     pub(crate) snapshot: Snapshot,
-    pub(crate) total_pubdata_spent: i32,
 }

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -1,6 +1,6 @@
 use crate::{
-    address_into_u256, decommit::is_kernel, heap::HeapId, modified_world::Snapshot,
-    program::Program, stack::Stack, Instruction,
+    address_into_u256, decommit::is_kernel, heap::HeapId, program::Program, stack::Stack,
+    world_diff::Snapshot, Instruction,
 };
 use u256::H160;
 use zkevm_opcode_defs::system_params::{NEW_FRAME_MEMORY_STIPEND, NEW_KERNEL_FRAME_MEMORY_STIPEND};

--- a/src/decommit.rs
+++ b/src/decommit.rs
@@ -1,4 +1,4 @@
-use crate::{modified_world::WorldDiff, program::Program, World};
+use crate::{program::Program, world_diff::WorldDiff, World};
 use u256::{H160, U256};
 use zkevm_opcode_defs::{
     ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW,

--- a/src/instruction_handlers/event.rs
+++ b/src/instruction_handlers/event.rs
@@ -2,7 +2,7 @@ use super::{common::instruction_boilerplate_with_panic, free_panic};
 use crate::{
     addressing_modes::{Arguments, Immediate1, Register1, Register2, Source},
     instruction::InstructionResult,
-    modified_world::{Event, L2ToL1Log},
+    world_diff::{Event, L2ToL1Log},
     Instruction, VirtualMachine, World,
 };
 use u256::H160;

--- a/src/instruction_handlers/precompiles.rs
+++ b/src/instruction_handlers/precompiles.rs
@@ -37,7 +37,7 @@ fn precompile_call(
         let Ok(()) = vm.state.use_gas(aux_data.extra_ergs_cost) else {
             return Ok(&PANIC);
         };
-        vm.state.current_frame.total_pubdata_spent += aux_data.extra_pubdata_cost as i32;
+        vm.world_diff.pubdata.0 += aux_data.extra_pubdata_cost as i32;
 
         let mut abi = PrecompileCallABI::from_u256(Register1::get(args, &mut vm.state));
         if abi.memory_page_to_read == 0 {

--- a/src/instruction_handlers/ret.rs
+++ b/src/instruction_handlers/ret.rs
@@ -41,13 +41,11 @@ fn ret<const RETURN_TYPE: u8, const TO_LABEL: bool>(
     let mut return_type = ReturnType::from_u8(RETURN_TYPE);
     let near_call_leftover_gas = vm.state.current_frame.gas;
 
-    let (pc, snapshot, leftover_gas, total_pubdata_spent) = if let Some(FrameRemnant {
+    let (pc, snapshot, leftover_gas) = if let Some(FrameRemnant {
         program_counter,
         exception_handler,
         snapshot,
-        total_pubdata_spent,
-    }) =
-        vm.state.current_frame.pop_near_call()
+    }) = vm.state.current_frame.pop_near_call()
     {
         (
             if TO_LABEL {
@@ -59,7 +57,6 @@ fn ret<const RETURN_TYPE: u8, const TO_LABEL: bool>(
             },
             snapshot,
             near_call_leftover_gas,
-            total_pubdata_spent,
         )
     } else {
         let return_value_or_panic = if return_type == ReturnType::Panic {
@@ -88,7 +85,6 @@ fn ret<const RETURN_TYPE: u8, const TO_LABEL: bool>(
             program_counter,
             exception_handler,
             snapshot,
-            total_pubdata_spent,
         }) = vm.pop_frame(
             return_value_or_panic
                 .as_ref()
@@ -130,14 +126,11 @@ fn ret<const RETURN_TYPE: u8, const TO_LABEL: bool>(
             },
             snapshot,
             leftover_gas,
-            total_pubdata_spent,
         )
     };
 
     if return_type.is_failure() {
         vm.world_diff.rollback(snapshot);
-    } else {
-        vm.state.current_frame.total_pubdata_spent += total_pubdata_spent;
     }
 
     vm.state.flags = Flags::new(return_type == ReturnType::Panic, false, false);

--- a/src/instruction_handlers/storage.rs
+++ b/src/instruction_handlers/storage.rs
@@ -27,14 +27,12 @@ fn sstore(
             let key = Register1::get(args, &mut vm.state);
             let value = Register2::get(args, &mut vm.state);
 
-            let (refund, pubdata_change) =
+            let refund =
                 vm.world_diff
                     .write_storage(world, vm.state.current_frame.address, key, value);
 
             assert!(refund <= SSTORE_COST);
             vm.state.current_frame.gas += refund;
-
-            vm.state.current_frame.total_pubdata_spent += pubdata_change;
 
             continue_normally
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ pub mod fat_pointer;
 mod heap;
 mod instruction;
 pub mod instruction_handlers;
-mod modified_world;
 mod predication;
 mod program;
 mod rollback;
@@ -17,6 +16,7 @@ mod stack;
 mod state;
 pub mod testworld;
 mod vm;
+mod world_diff;
 
 use u256::{H160, U256};
 
@@ -24,11 +24,11 @@ pub use decommit::address_into_u256;
 pub use decommit::initial_decommit;
 pub use heap::{HeapId, FIRST_HEAP};
 pub use instruction::{jump_to_beginning, ExecutionEnd, Instruction};
-pub use modified_world::{Event, L2ToL1Log, WorldDiff};
 pub use predication::Predicate;
 pub use program::Program;
 pub use state::State;
 pub use vm::{Settings, VirtualMachine, VmSnapshot as Snapshot};
+pub use world_diff::{Event, L2ToL1Log, WorldDiff};
 
 pub trait World {
     /// This will be called *every* time a contract is called. Caching and decoding is

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -117,3 +117,21 @@ impl<T> AsRef<[T]> for RollbackableLog<T> {
         &self.entries
     }
 }
+
+/// Rollbackable Plain Old Data simply stores copies of itself in snapshots.
+#[derive(Default, Copy, Clone)]
+pub struct RollbackablePod<T: Copy>(pub T);
+
+impl<T: Copy> Rollback for RollbackablePod<T> {
+    type Snapshot = T;
+
+    fn snapshot(&self) -> Self::Snapshot {
+        self.0
+    }
+
+    fn rollback(&mut self, snapshot: Self::Snapshot) {
+        self.0 = snapshot
+    }
+
+    fn delete_history(&mut self) {}
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,10 +4,10 @@ use crate::{
     callframe::Callframe,
     fat_pointer::FatPointer,
     heap::{Heaps, CALLDATA_HEAP, FIRST_AUX_HEAP, FIRST_HEAP},
-    modified_world::Snapshot,
     predication::Flags,
     program::Program,
     stack::Stack,
+    world_diff::Snapshot,
 };
 use u256::{H160, U256};
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1,12 +1,12 @@
 use crate::heap::HeapId;
-use crate::modified_world::ExternalSnapshot;
+use crate::world_diff::ExternalSnapshot;
 use crate::{
     callframe::{Callframe, FrameRemnant},
     decommit::u256_into_address,
     instruction_handlers::{free_panic, CallingMode},
-    modified_world::{Snapshot, WorldDiff},
     stack::StackPool,
     state::State,
+    world_diff::{Snapshot, WorldDiff},
     ExecutionEnd, Instruction, Program, World,
 };
 use u256::H160;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -240,7 +240,6 @@ impl VirtualMachine {
                     exception_handler,
                     world_before_this_frame,
                     stack,
-                    total_pubdata_spent,
                     ..
                 } = frame;
 
@@ -255,7 +254,6 @@ impl VirtualMachine {
                     program_counter,
                     exception_handler,
                     snapshot: world_before_this_frame,
-                    total_pubdata_spent,
                 }
             })
     }

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -10,16 +10,16 @@ use zkevm_opcode_defs::system_params::{
     STORAGE_ACCESS_WARM_WRITE_COST,
 };
 
-/// The global state including pending modifications that are written only at
-/// the end of a block.
+/// Pending modifications to the global state that are executed at the end of a block.
+/// In other words, side effects.
 #[derive(Default)]
 pub struct WorldDiff {
     // These are rolled back on revert or panic (and when the whole VM is rolled back).
     storage_changes: RollbackableMap<(H160, U256), U256>,
+    paid_changes: RollbackableMap<(H160, U256), u32>,
     transient_storage_changes: RollbackableMap<(H160, U256), U256>,
     events: RollbackableLog<Event>,
     l2_to_l1_logs: RollbackableLog<L2ToL1Log>,
-    paid_changes: RollbackableMap<(H160, U256), u32>,
 
     // The fields below are only rolled back when the whole VM is rolled back.
     pub(crate) decommitted_hashes: RollbackableSet<U256>,


### PR DESCRIPTION
This is accomplished by making pubdata use the same rollback mechanism as everything else.

Another upside is that the total pubdata is now available without having to add together all callframes.