### PR TITLE
fix: don't repeatedly get initial values

### DIFF
--- a/src/decommit.rs
+++ b/src/decommit.rs
@@ -78,8 +78,9 @@ impl WorldDiff {
 pub fn initial_decommit(world: &mut impl World, address: H160) -> Program {
     let deployer_system_contract_address =
         Address::from_low_u64_be(DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW as u64);
-    let code_info =
-        world.read_storage(deployer_system_contract_address, address_into_u256(address));
+    let code_info = world
+        .read_storage(deployer_system_contract_address, address_into_u256(address))
+        .unwrap_or_default();
 
     let mut code_info_bytes = [0; 32];
     code_info.to_big_endian(&mut code_info_bytes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,16 @@ pub trait World {
     fn decommit(&mut self, hash: U256) -> Program;
 
     /// There is no write_storage; [WorldDiff::get_storage_changes] gives a list of all storage changes.
-    fn read_storage(&mut self, contract: H160, key: U256) -> U256;
+    fn read_storage(&mut self, contract: H160, key: U256) -> Option<U256>;
 
     /// Computes the cost of writing a storage slot.
-    fn cost_of_writing_storage(&mut self, contract: H160, key: U256, new_value: U256) -> u32;
+    fn cost_of_writing_storage(
+        &mut self,
+        contract: H160,
+        key: U256,
+        initial_value: Option<U256>,
+        new_value: U256,
+    ) -> u32;
 
     /// Returns if the storage slot is free both in terms of gas and pubdata.
     fn is_free_storage_slot(&self, contract: &H160, key: &U256) -> bool;

--- a/src/testworld.rs
+++ b/src/testworld.rs
@@ -48,17 +48,19 @@ impl World for TestWorld {
         }
     }
 
-    fn read_storage(&mut self, contract: u256::H160, key: u256::U256) -> u256::U256 {
+    fn read_storage(&mut self, contract: u256::H160, key: u256::U256) -> Option<U256> {
         let deployer_system_contract_address =
             Address::from_low_u64_be(DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW as u64);
 
         if contract == deployer_system_contract_address {
-            self.address_to_hash
-                .get(&key)
-                .copied()
-                .unwrap_or(U256::zero())
+            Some(
+                self.address_to_hash
+                    .get(&key)
+                    .copied()
+                    .unwrap_or(U256::zero()),
+            )
         } else {
-            0.into()
+            None
         }
     }
 
@@ -66,6 +68,7 @@ impl World for TestWorld {
         &mut self,
         _contract: u256::H160,
         _key: U256,
+        _initial_value: Option<U256>,
         _new_value: U256,
     ) -> u32 {
         50


### PR DESCRIPTION
Previously multivm had to touch DB a lot to figure out whether writes are initial etc. This patch makes all that unnecessary.

Also, the previous version of `get_storage_changes` would have worked incorrectly, had history been deleted. `get_storage_changes_after` does not suffer from the same problem, as the snapshot it consumes guarantees that history after the snapshot exists.