### PR TITLE
perf: optimize external snapshots

### DIFF
--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -175,7 +175,7 @@ impl Callframe {
         }
     }
 
-    pub fn rollback(&mut self, snapshot: CallframeSnapshot) {
+    pub(crate) fn rollback(&mut self, snapshot: CallframeSnapshot) {
         let CallframeSnapshot {
             stack,
             context_u128,
@@ -208,7 +208,7 @@ pub(crate) struct FrameRemnant {
 }
 
 /// Only contains the fields that can change (other than via tracer).
-pub struct CallframeSnapshot {
+pub(crate) struct CallframeSnapshot {
     stack: StackSnapshot,
 
     context_u128: u128,

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -171,7 +171,6 @@ impl Callframe {
             heap_size: self.heap_size,
             aux_heap_size: self.aux_heap_size,
             heaps_i_am_keeping_alive: self.heaps_i_am_keeping_alive.clone(),
-            world_before_this_frame: self.world_before_this_frame.clone(),
         }
     }
 
@@ -185,7 +184,6 @@ impl Callframe {
             heap_size,
             aux_heap_size,
             heaps_i_am_keeping_alive,
-            world_before_this_frame,
         } = snapshot;
 
         self.stack.rollback(stack);
@@ -197,7 +195,6 @@ impl Callframe {
         self.heap_size = heap_size;
         self.aux_heap_size = aux_heap_size;
         self.heaps_i_am_keeping_alive = heaps_i_am_keeping_alive;
-        self.world_before_this_frame = world_before_this_frame;
     }
 }
 
@@ -220,5 +217,4 @@ pub(crate) struct CallframeSnapshot {
     aux_heap_size: u32,
 
     heaps_i_am_keeping_alive: Vec<HeapId>,
-    world_before_this_frame: Snapshot,
 }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -29,6 +29,10 @@ impl Heap {
 
         value.to_big_endian(&mut self.0[start_address as usize..end]);
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl HeapInterface for Heap {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -57,9 +57,6 @@ impl HeapInterface for Heap {
         }
         result
     }
-    fn memset(&mut self, src: &[u8]) {
-        self.0 = src.to_vec();
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -83,15 +80,16 @@ impl Heaps {
     }
 
     pub(crate) fn allocate(&mut self) -> HeapId {
-        let id = HeapId(self.heaps.len() as u32);
-        self.heaps
-            .push(Heap(vec![0; NEW_FRAME_MEMORY_STIPEND as usize]));
-        id
+        self.allocate_inner(vec![0; NEW_FRAME_MEMORY_STIPEND as usize])
     }
 
     pub(crate) fn allocate_with_content(&mut self, content: &[u8]) -> HeapId {
-        let id = self.allocate();
-        self.heaps[id.0 as usize].memset(content);
+        self.allocate_inner(content.to_vec())
+    }
+
+    fn allocate_inner(&mut self, memory: Vec<u8>) -> HeapId {
+        let id = HeapId(self.heaps.len() as u32);
+        self.heaps.push(Heap(memory));
         id
     }
 

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -76,12 +76,10 @@ impl Heaps {
     pub(crate) fn new(calldata: Vec<u8>) -> Self {
         // The first heap can never be used because heap zero
         // means the current heap in precompile calls
-        Self{heaps:vec![
-            Heap(vec![]),
-            Heap(calldata),
-            Heap(vec![]),
-            Heap(vec![]),
-        ], bootloader_heap_rollback_info: vec![]}
+        Self {
+            heaps: vec![Heap(vec![]), Heap(calldata), Heap(vec![]), Heap(vec![])],
+            bootloader_heap_rollback_info: vec![],
+        }
     }
 
     pub(crate) fn allocate(&mut self) -> HeapId {
@@ -137,7 +135,9 @@ impl IndexMut<HeapId> for Heaps {
 impl PartialEq for Heaps {
     fn eq(&self, other: &Self) -> bool {
         for i in 0..self.heaps.len().max(other.heaps.len()) {
-            if self.heaps.get(i).unwrap_or(&Heap(vec![])) != other.heaps.get(i).unwrap_or(&Heap(vec![])) {
+            if self.heaps.get(i).unwrap_or(&Heap(vec![]))
+                != other.heaps.get(i).unwrap_or(&Heap(vec![]))
+            {
                 return false;
             }
         }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -27,9 +27,7 @@ impl Heap {
             self.0.resize(end, 0);
         }
 
-        let mut bytes = [0; 32];
-        value.to_big_endian(&mut bytes);
-        self.0[start_address as usize..end].copy_from_slice(&bytes);
+        value.to_big_endian(&mut self.0[start_address as usize..end]);
     }
 }
 
@@ -107,7 +105,7 @@ impl Heaps {
     }
 
     pub(crate) fn rollback(&mut self, snapshot: usize) {
-        for (address, value) in self.bootloader_heap_rollback_info.drain(snapshot..) {
+        for (address, value) in self.bootloader_heap_rollback_info.drain(snapshot..).rev() {
             self.heaps[FIRST_HEAP.0 as usize].write_u256(address, value);
         }
     }

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,5 +1,5 @@
 use crate::instruction_handlers::HeapInterface;
-use std::ops::{Index, IndexMut, Range};
+use std::ops::{Index, Range};
 use u256::U256;
 use zkevm_opcode_defs::system_params::NEW_FRAME_MEMORY_STIPEND;
 
@@ -19,12 +19,6 @@ impl HeapId {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Heap(Vec<u8>);
-
-impl Heap {
-    pub fn reserve(&mut self, additional: usize) {
-        self.0.reserve_exact(additional);
-    }
-}
 
 impl HeapInterface for Heap {
     fn read_u256(&self, start_address: u32) -> U256 {
@@ -121,12 +115,6 @@ impl Index<HeapId> for Heaps {
 
     fn index(&self, index: HeapId) -> &Self::Output {
         &self.heaps[index.0 as usize]
-    }
-}
-
-impl IndexMut<HeapId> for Heaps {
-    fn index_mut(&mut self, index: HeapId) -> &mut Self::Output {
-        &mut self.heaps[index.0 as usize]
     }
 }
 

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -113,6 +113,10 @@ impl Heaps {
             self.heaps[FIRST_HEAP.0 as usize].write_u256(address, value);
         }
     }
+
+    pub(crate) fn delete_history(&mut self) {
+        self.bootloader_heap_rollback_info.clear();
+    }
 }
 
 impl Index<HeapId> for Heaps {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -20,6 +20,19 @@ impl HeapId {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Heap(Vec<u8>);
 
+impl Heap {
+    fn write_u256(&mut self, start_address: u32, value: U256) {
+        let end = (start_address + 32) as usize;
+        if end > self.0.len() {
+            self.0.resize(end, 0);
+        }
+
+        let mut bytes = [0; 32];
+        value.to_big_endian(&mut bytes);
+        self.0[start_address as usize..end].copy_from_slice(&bytes);
+    }
+}
+
 impl HeapInterface for Heap {
     fn read_u256(&self, start_address: u32) -> U256 {
         self.read_u256_partially(start_address..start_address + 32)
@@ -32,16 +45,6 @@ impl HeapInterface for Heap {
             bytes[i] = self.0[j];
         }
         U256::from_big_endian(&bytes)
-    }
-    fn write_u256(&mut self, start_address: u32, value: U256) {
-        let end = (start_address + 32) as usize;
-        if end > self.0.len() {
-            self.0.resize(end, 0);
-        }
-
-        let mut bytes = [0; 32];
-        value.to_big_endian(&mut bytes);
-        self.0[start_address as usize..end].copy_from_slice(&bytes);
     }
     fn read_range_big_endian(&self, range: Range<u32>) -> Vec<u8> {
         let end = (range.end as usize).min(self.0.len());

--- a/src/instruction_handlers/decommit.rs
+++ b/src/instruction_handlers/decommit.rs
@@ -8,7 +8,7 @@ use crate::{
     Instruction, VirtualMachine, World,
 };
 
-use super::{common::instruction_boilerplate, HeapInterface};
+use super::common::instruction_boilerplate;
 
 fn decommit(
     vm: &mut VirtualMachine,
@@ -38,9 +38,8 @@ fn decommit(
             vm.state.current_frame.gas += extra_cost;
         }
 
-        let heap = vm.state.heaps.allocate();
+        let heap = vm.state.heaps.allocate_with_content(program.as_ref());
         vm.state.current_frame.heaps_i_am_keeping_alive.push(heap);
-        vm.state.heaps[heap].memset(program.as_ref());
 
         let value = FatPointer {
             offset: 0,

--- a/src/instruction_handlers/heap_access.rs
+++ b/src/instruction_handlers/heap_access.rs
@@ -17,7 +17,6 @@ pub trait HeapInterface {
     fn read_u256_partially(&self, range: Range<u32>) -> U256;
     fn write_u256(&mut self, start_address: u32, value: U256);
     fn read_range_big_endian(&self, range: Range<u32>) -> Vec<u8>;
-    fn memset(&mut self, memory: &[u8]);
 }
 
 pub trait HeapFromState {

--- a/src/instruction_handlers/heap_access.rs
+++ b/src/instruction_handlers/heap_access.rs
@@ -15,7 +15,6 @@ use u256::U256;
 pub trait HeapInterface {
     fn read_u256(&self, start_address: u32) -> U256;
     fn read_u256_partially(&self, range: Range<u32>) -> U256;
-    fn write_u256(&mut self, start_address: u32, value: U256);
     fn read_range_big_endian(&self, range: Range<u32>) -> Vec<u8>;
 }
 

--- a/src/instruction_handlers/precompiles.rs
+++ b/src/instruction_handlers/precompiles.rs
@@ -96,7 +96,7 @@ impl Memory for Heaps {
 
         let start = query.location.index.0 * 32;
         if query.rw_flag {
-            self[page].write_u256(start, query.value);
+            self.write_u256(page, start, query.value);
         } else {
             query.value = self[page].read_u256(start);
             query.value_is_pointer = false;

--- a/src/single_instruction_test/heap.rs
+++ b/src/single_instruction_test/heap.rs
@@ -101,6 +101,10 @@ impl Heaps {
     pub(crate) fn rollback(&mut self, _: usize) {
         unimplemented!()
     }
+
+    pub(crate) fn delete_history(&mut self) {
+        unimplemented!()
+    }
 }
 
 impl Index<HeapId> for Heaps {

--- a/src/single_instruction_test/heap.rs
+++ b/src/single_instruction_test/heap.rs
@@ -34,11 +34,6 @@ impl HeapInterface for Heap {
         // This is wrong, but this method is only used to get the final return value.
         vec![]
     }
-
-    fn memset(&mut self, src: &[u8]) {
-        let u = U256::from_big_endian(src);
-        self.write_u256(0, u);
-    }
 }
 
 impl<'a> Arbitrary<'a> for Heap {
@@ -71,7 +66,9 @@ impl Heaps {
 
     pub(crate) fn allocate_with_content(&mut self, content: &[u8]) -> HeapId {
         let id = self.allocate();
-        self.read.get_mut(id).memset(content);
+        self.read
+            .get_mut(id)
+            .write_u256(0, U256::from_big_endian(content));
         id
     }
 

--- a/src/single_instruction_test/heap.rs
+++ b/src/single_instruction_test/heap.rs
@@ -15,6 +15,10 @@ impl Heap {
         assert!(self.write.is_none());
         self.write = Some((start_address, value));
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        unimplemented!()
+    }
 }
 
 impl HeapInterface for Heap {

--- a/src/single_instruction_test/heap.rs
+++ b/src/single_instruction_test/heap.rs
@@ -1,7 +1,7 @@
 use super::mock_array::MockRead;
 use crate::instruction_handlers::HeapInterface;
 use arbitrary::Arbitrary;
-use std::ops::{Index, IndexMut};
+use std::ops::Index;
 use u256::U256;
 
 #[derive(Debug, Clone)]
@@ -69,6 +69,12 @@ impl Heaps {
         self.heap_id
     }
 
+    pub(crate) fn allocate_with_content(&mut self, content: &[u8]) -> HeapId {
+        let id = self.allocate();
+        self.read.get_mut(id).memset(content);
+        id
+    }
+
     pub(crate) fn deallocate(&mut self, _: HeapId) {}
 
     pub(crate) fn from_id(
@@ -80,6 +86,18 @@ impl Heaps {
             read: u.arbitrary()?,
         })
     }
+
+    pub fn write_u256(&mut self, heap: HeapId, start_address: u32, value: U256) {
+        self.read.get_mut(heap).write_u256(start_address, value);
+    }
+
+    pub(crate) fn snapshot(&self) -> usize {
+        unimplemented!()
+    }
+
+    pub(crate) fn rollback(&mut self, _: usize) {
+        unimplemented!()
+    }
 }
 
 impl Index<HeapId> for Heaps {
@@ -87,12 +105,6 @@ impl Index<HeapId> for Heaps {
 
     fn index(&self, index: HeapId) -> &Self::Output {
         self.read.get(index)
-    }
-}
-
-impl IndexMut<HeapId> for Heaps {
-    fn index_mut(&mut self, index: HeapId) -> &mut Self::Output {
-        self.read.get_mut(index)
     }
 }
 

--- a/src/single_instruction_test/heap.rs
+++ b/src/single_instruction_test/heap.rs
@@ -10,6 +10,13 @@ pub struct Heap {
     pub(crate) write: Option<(u32, U256)>,
 }
 
+impl Heap {
+    fn write_u256(&mut self, start_address: u32, value: U256) {
+        assert!(self.write.is_none());
+        self.write = Some((start_address, value));
+    }
+}
+
 impl HeapInterface for Heap {
     fn read_u256(&self, start_address: u32) -> U256 {
         assert!(self.write.is_none());
@@ -23,11 +30,6 @@ impl HeapInterface for Heap {
             *byte = 0;
         }
         U256::from_little_endian(&result)
-    }
-
-    fn write_u256(&mut self, start_address: u32, value: U256) {
-        assert!(self.write.is_none());
-        self.write = Some((start_address, value));
     }
 
     fn read_range_big_endian(&self, _: std::ops::Range<u32>) -> Vec<u8> {

--- a/src/single_instruction_test/stack.rs
+++ b/src/single_instruction_test/stack.rs
@@ -72,6 +72,14 @@ impl Stack {
             && (self.slot_written.is_none()
                 || is_valid_tagged_value((self.value_written, self.pointer_tag_written)))
     }
+
+    pub(crate) fn snapshot(&self) -> StackSnapshot {
+        unimplemented!()
+    }
+
+    pub(crate) fn rollback(&mut self, _: StackSnapshot) {
+        unimplemented!()
+    }
 }
 
 #[derive(Default, Debug)]
@@ -91,3 +99,5 @@ impl StackPool {
 
     pub fn recycle(&mut self, _: Box<Stack>) {}
 }
+
+pub(crate) struct StackSnapshot;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -55,12 +55,7 @@ impl Stack {
     }
 
     pub(crate) fn snapshot(&self) -> StackSnapshot {
-        let mut dirty_prefix_end = 0;
-        for i in 0..NUMBER_OF_DIRTY_AREAS {
-            if self.dirty_areas & (1 << i) != 0 {
-                dirty_prefix_end = i + 1;
-            }
-        }
+        let dirty_prefix_end = NUMBER_OF_DIRTY_AREAS - self.dirty_areas.leading_zeros() as usize;
 
         StackSnapshot {
             pointer_flags: self.pointer_flags.clone(),

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -75,9 +75,7 @@ impl Stack {
 
         self.pointer_flags = pointer_flags;
         self.dirty_areas = dirty_areas;
-        for (me, snapshot) in self.slots.iter_mut().zip(slots.iter()) {
-            *me = *snapshot;
-        }
+        self.slots[..slots.len()].copy_from_slice(&slots);
     }
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -108,7 +108,7 @@ impl State {
     }
 
     pub(crate) fn snapshot(&self) -> StateSnapshot {
-        //assert!(self.heaps[self.current_frame.aux_heap].is_empty());
+        assert!(self.heaps[self.current_frame.aux_heap].is_empty());
         StateSnapshot {
             registers: self.registers,
             register_pointer_flags: self.register_pointer_flags,
@@ -121,7 +121,7 @@ impl State {
     }
 
     pub(crate) fn rollback(&mut self, snapshot: StateSnapshot) {
-        //assert!(self.heaps[self.current_frame.aux_heap].is_empty());
+        assert!(self.heaps[self.current_frame.aux_heap].is_empty());
         let StateSnapshot {
             registers,
             register_pointer_flags,

--- a/src/state.rs
+++ b/src/state.rs
@@ -113,7 +113,7 @@ impl State {
             registers: self.registers,
             register_pointer_flags: self.register_pointer_flags,
             flags: self.flags.clone(),
-            current_frame: self.current_frame.snapshot(),
+            bootloader_frame: self.current_frame.snapshot(),
             bootloader_heap_snapshot: self.heaps.snapshot(),
             transaction_number: self.transaction_number,
             context_u128: self.context_u128,
@@ -126,19 +126,23 @@ impl State {
             registers,
             register_pointer_flags,
             flags,
-            current_frame,
+            bootloader_frame,
             bootloader_heap_snapshot,
             transaction_number,
             context_u128,
         } = snapshot;
 
-        self.current_frame.rollback(current_frame);
+        self.current_frame.rollback(bootloader_frame);
         self.heaps.rollback(bootloader_heap_snapshot);
         self.registers = registers;
         self.register_pointer_flags = register_pointer_flags;
         self.flags = flags;
         self.transaction_number = transaction_number;
         self.context_u128 = context_u128;
+    }
+
+    pub(crate) fn delete_history(&mut self) {
+        self.heaps.delete_history();
     }
 }
 
@@ -185,7 +189,7 @@ pub(crate) struct StateSnapshot {
 
     flags: Flags,
 
-    current_frame: CallframeSnapshot,
+    bootloader_frame: CallframeSnapshot,
 
     bootloader_heap_snapshot: usize,
     transaction_number: u16,

--- a/src/state.rs
+++ b/src/state.rs
@@ -132,7 +132,9 @@ impl State {
             context_u128,
         } = snapshot;
 
-        self.current_frame.rollback(bootloader_frame);
+        for heap in self.current_frame.rollback(bootloader_frame) {
+            self.heaps.deallocate(heap);
+        }
         self.heaps.rollback(bootloader_heap_snapshot);
         self.registers = registers;
         self.register_pointer_flags = register_pointer_flags;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -197,6 +197,15 @@ impl VirtualMachine {
         self.state.rollback(snapshot.state_snapshot);
     }
 
+    /// This must only be called when it is known that the VM cannot be rolled back,
+    /// so there must not be any external snapshots and the callstack
+    /// should ideally be empty, though in practice it sometimes contains
+    /// a near call inside the bootloader.
+    pub fn delete_history(&mut self) {
+        self.world_diff.delete_history();
+        self.state.delete_history();
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn push_frame<const CALLING_MODE: u8>(
         &mut self,

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -317,7 +317,13 @@ impl WorldDiff {
 
     pub(crate) fn delete_history(&mut self) {
         self.storage_changes.delete_history();
+        self.paid_changes.delete_history();
+        self.transient_storage_changes.delete_history();
         self.events.delete_history();
+        self.l2_to_l1_logs.delete_history();
+        self.pubdata.delete_history();
+        self.storage_refunds.delete_history();
+        self.pubdata_costs.delete_history();
         self.decommitted_hashes.delete_history();
         self.read_storage_slots.delete_history();
         self.written_storage_slots.delete_history();

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -315,11 +315,7 @@ impl WorldDiff {
             .rollback(snapshot.written_storage_slots);
     }
 
-    /// This must only be called when it is known that the VM cannot be rolled back,
-    /// so there must not be any external snapshots and the callstack
-    /// should ideally be empty, though in practice it sometimes contains
-    /// a near call inside the bootloader.
-    pub fn delete_history(&mut self) {
+    pub(crate) fn delete_history(&mut self) {
         self.storage_changes.delete_history();
         self.events.delete_history();
         self.decommitted_hashes.delete_history();


### PR DESCRIPTION
The bootloader only uses a small part of the stack and only changes small areas of its heap, yet both are copied entirely when snapshotting. This fixes that.