### PR TITLE
feat: Track `storage_refunds` and `pubdata_costs` stats

### DIFF
--- a/src/decommit.rs
+++ b/src/decommit.rs
@@ -77,11 +77,12 @@ impl WorldDiff {
         Some((UnpaidDecommit { cost, code_key }, is_evm))
     }
 
-    pub(crate) fn decommit_opcode(&mut self, world: &mut dyn World, code_hash: U256) -> Vec<u8> {
-        let mut code_info_bytes = [0; 32];
-        code_hash.to_big_endian(&mut code_info_bytes);
-        self.decommitted_hashes.insert(code_hash, ());
-        world.decommit_code(code_hash)
+    /// Returns the decommitted contract code and a flag set to `true` if this is a fresh decommit (i.e.,
+    /// the code wasn't decommitted previously in the same VM run).
+    #[doc(hidden)] // should be used for testing purposes only; can break VM operation otherwise
+    pub fn decommit_opcode(&mut self, world: &mut dyn World, code_hash: U256) -> (Vec<u8>, bool) {
+        let was_decommitted = self.decommitted_hashes.insert(code_hash, ()).is_some();
+        (world.decommit_code(code_hash), !was_decommitted)
     }
 
     pub(crate) fn pay_for_decommit(

--- a/src/decommit.rs
+++ b/src/decommit.rs
@@ -19,8 +19,8 @@ impl WorldDiff {
         let mut is_evm = false;
 
         let mut code_info = {
-            let (code_info, _) =
-                self.read_storage(world, deployer_system_contract_address, address);
+            let code_info =
+                self.read_storage_without_refund(world, deployer_system_contract_address, address);
             let mut code_info_bytes = [0; 32];
             code_info.to_big_endian(&mut code_info_bytes);
 

--- a/src/instruction_handlers/decommit.rs
+++ b/src/instruction_handlers/decommit.rs
@@ -33,7 +33,10 @@ fn decommit(
             return;
         }
 
-        let program = vm.world_diff.decommit_opcode(world, code_hash);
+        let (program, is_fresh) = vm.world_diff.decommit_opcode(world, code_hash);
+        if !is_fresh {
+            vm.state.current_frame.gas += extra_cost;
+        }
 
         let heap = vm.state.heaps.allocate();
         vm.state.current_frame.heaps_i_am_keeping_alive.push(heap);
@@ -49,6 +52,7 @@ fn decommit(
         Register1::set_fat_ptr(args, &mut vm.state, value);
     })
 }
+
 impl Instruction {
     pub fn from_decommit(
         abi: Register1,

--- a/src/instruction_handlers/ret.rs
+++ b/src/instruction_handlers/ret.rs
@@ -132,7 +132,7 @@ fn ret<const RETURN_TYPE: u8, const TO_LABEL: bool>(
     };
 
     if return_type.is_failure() {
-        vm.world_diff.rollback(snapshot);
+        vm.world_diff.rollback(snapshot, false);
     }
 
     vm.state.flags = Flags::new(return_type == ReturnType::Panic, false, false);

--- a/src/instruction_handlers/ret.rs
+++ b/src/instruction_handlers/ret.rs
@@ -132,7 +132,7 @@ fn ret<const RETURN_TYPE: u8, const TO_LABEL: bool>(
     };
 
     if return_type.is_failure() {
-        vm.world_diff.rollback(snapshot, false);
+        vm.world_diff.rollback(snapshot);
     }
 
     vm.state.flags = Flags::new(return_type == ReturnType::Panic, false, false);

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -252,8 +252,9 @@ impl WorldDiff {
         self.l2_to_l1_logs.logs_after(snapshot.l2_to_l1_logs)
     }
 
-    pub fn get_decommitted_hashes(&self) -> &BTreeMap<U256, ()> {
-        self.decommitted_hashes.as_ref()
+    /// Returns hashes of decommitted contract bytecodes in no particular order.
+    pub fn decommitted_hashes(&self) -> impl Iterator<Item = U256> + '_ {
+        self.decommitted_hashes.as_ref().keys().copied()
     }
 
     /// Get a snapshot for selecting which logs [Self::events_after] & Co output.


### PR DESCRIPTION
# What ❔

- Tracks `storage_refunds` and `pubdata_costs` in `WorldDiff` in order to fill in the corresponding data in the VM glue code.
- Fixes decommit opcode semantics, refunding extra gas cost if the decommitted bytecode is not fresh (i.e., was decommitted previously).

## Why ❔

- `storage_refunds` and `pubdata_costs` data is not read directly on the EN, but is persisted for each batch in the state keeper. By design, this data is expected to filled in by the state keeper, so filling it retrospectively could be a problem.
- Divergency in decommit opcode semantics is easily observable (e.g., by gas costs).

fix: Fix decommit opcode semantics