### PR TITLE
fix: record history for aux heap as well

### DIFF
--- a/src/heap.rs
+++ b/src/heap.rs
@@ -104,7 +104,7 @@ impl Heaps {
         self.heaps[heap.0 as usize].write_u256(start_address, value);
     }
 
-    pub(crate) fn snapshot(&self) -> usize {
+    pub(crate) fn snapshot(&self) -> (usize, usize) {
         (
             self.bootloader_heap_rollback_info.len(),
             self.bootloader_aux_rollback_info.len(),

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -29,10 +29,6 @@ impl Heap {
 
         value.to_big_endian(&mut self.0[start_address as usize..end]);
     }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
 }
 
 impl HeapInterface for Heap {
@@ -62,6 +58,7 @@ impl HeapInterface for Heap {
 pub struct Heaps {
     heaps: Vec<Heap>,
     bootloader_heap_rollback_info: Vec<(u32, U256)>,
+    bootloader_aux_rollback_info: Vec<(u32, U256)>,
 }
 
 pub(crate) const CALLDATA_HEAP: HeapId = HeapId(1);
@@ -100,22 +97,32 @@ impl Heaps {
         if heap == FIRST_HEAP {
             self.bootloader_heap_rollback_info
                 .push((start_address, self[heap].read_u256(start_address)));
+        } else if heap == FIRST_AUX_HEAP {
+            self.bootloader_aux_rollback_info
+                .push((start_address, self[heap].read_u256(start_address)));
         }
         self.heaps[heap.0 as usize].write_u256(start_address, value);
     }
 
     pub(crate) fn snapshot(&self) -> usize {
-        self.bootloader_heap_rollback_info.len()
+        (
+            self.bootloader_heap_rollback_info.len(),
+            self.bootloader_aux_rollback_info.len(),
+        )
     }
 
-    pub(crate) fn rollback(&mut self, snapshot: usize) {
-        for (address, value) in self.bootloader_heap_rollback_info.drain(snapshot..).rev() {
+    pub(crate) fn rollback(&mut self, (heap_snap, aux_snap): (usize, usize)) {
+        for (address, value) in self.bootloader_heap_rollback_info.drain(heap_snap..).rev() {
             self.heaps[FIRST_HEAP.0 as usize].write_u256(address, value);
+        }
+        for (address, value) in self.bootloader_aux_rollback_info.drain(aux_snap..).rev() {
+            self.heaps[FIRST_AUX_HEAP.0 as usize].write_u256(address, value);
         }
     }
 
     pub(crate) fn delete_history(&mut self) {
         self.bootloader_heap_rollback_info.clear();
+        self.bootloader_aux_rollback_info.clear();
     }
 }
 

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -72,6 +72,7 @@ impl Heaps {
         Self {
             heaps: vec![Heap(vec![]), Heap(calldata), Heap(vec![]), Heap(vec![])],
             bootloader_heap_rollback_info: vec![],
+            bootloader_aux_rollback_info: vec![],
         }
     }
 

--- a/src/single_instruction_test/heap.rs
+++ b/src/single_instruction_test/heap.rs
@@ -90,11 +90,11 @@ impl Heaps {
         self.read.get_mut(heap).write_u256(start_address, value);
     }
 
-    pub(crate) fn snapshot(&self) -> usize {
+    pub(crate) fn snapshot(&self) -> (usize, usize) {
         unimplemented!()
     }
 
-    pub(crate) fn rollback(&mut self, _: usize) {
+    pub(crate) fn rollback(&mut self, _: (usize, usize)) {
         unimplemented!()
     }
 

--- a/src/single_instruction_test/heap.rs
+++ b/src/single_instruction_test/heap.rs
@@ -15,10 +15,6 @@ impl Heap {
         assert!(self.write.is_none());
         self.write = Some((start_address, value));
     }
-
-    pub(crate) fn is_empty(&self) -> bool {
-        unimplemented!()
-    }
 }
 
 impl HeapInterface for Heap {

--- a/src/state.rs
+++ b/src/state.rs
@@ -191,7 +191,7 @@ pub(crate) struct StateSnapshot {
 
     bootloader_frame: CallframeSnapshot,
 
-    bootloader_heap_snapshot: usize,
+    bootloader_heap_snapshot: (usize, usize),
     transaction_number: u16,
 
     context_u128: u128,

--- a/src/state.rs
+++ b/src/state.rs
@@ -108,7 +108,6 @@ impl State {
     }
 
     pub(crate) fn snapshot(&self) -> StateSnapshot {
-        assert!(self.heaps[self.current_frame.aux_heap].is_empty());
         StateSnapshot {
             registers: self.registers,
             register_pointer_flags: self.register_pointer_flags,
@@ -121,7 +120,6 @@ impl State {
     }
 
     pub(crate) fn rollback(&mut self, snapshot: StateSnapshot) {
-        assert!(self.heaps[self.current_frame.aux_heap].is_empty());
         let StateSnapshot {
             registers,
             register_pointer_flags,


### PR DESCRIPTION
The aux heap isn't used by the bootloader but tests use it and the bootloader should use it in the future, so this is definitely better.