### PR TITLE
fix: Fix `Heap` equality comparison

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,4 @@
 - [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
-- [ ] Code has been formatted via `zk fmt` and `zk lint`.
+- [ ] Code has been formatted via `cargo fmt` and `cargo clippy`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,10 @@ jobs:
       # Two runs are needed. One for normal VM, another for the mocked version
       - name: Run clippy
         run: |
-          cargo clippy -- -D warnings
-          cargo clippy --workspace -- -D warnings
+          # Check the main library with non-test features (needs to be tested in isolation since the fuzzing crate enables test features)
+          cargo clippy -p vm2 --all-targets -- -D warnings
+          # The benches in `vm2` don't compile with fuzzing enabled 
+          cargo clippy --workspace --all-features --lib --bins --tests -- -D warnings
 
       - name: Check formatting
         run: |
@@ -47,4 +49,4 @@ jobs:
 
       - name: Run Tests
         run: |
-          cargo test
+          cargo test -p vm2 --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-workspace = { members = ["afl-fuzz"] }
 [package]
 name = "vm2"
 version = "0.1.0"
@@ -12,6 +11,8 @@ zkevm_opcode_defs = { git = "https://github.com/matter-labs/era-zkevm_opcode_def
 zk_evm_abstractions = {git = "https://github.com/matter-labs/era-zk_evm_abstractions.git", branch = "v1.5.0" }
 u256 = { package = "primitive-types", version = "0.12.1" }
 enum_dispatch = "0.3"
+
+# Optional dependencies (used for fuzzing)
 arbitrary = { version = "1", features = ["derive"], optional = true }
 zk_evm = { git = "https://github.com/matter-labs/era-zk_evm.git", branch = "jms-remove-assert", optional = true }
 anyhow = { version = "1", optional = true }
@@ -25,5 +26,9 @@ name = "nested_near_call"
 harness = false
 
 [features]
-single_instruction_test = ["arbitrary", "u256/arbitrary", "zk_evm", "anyhow"]
+default = []
 trace = []
+single_instruction_test = ["arbitrary", "u256/arbitrary", "zk_evm", "anyhow"]
+
+[workspace]
+members = [".", "afl-fuzz"]

--- a/afl-fuzz/Cargo.toml
+++ b/afl-fuzz/Cargo.toml
@@ -2,6 +2,7 @@
 name = "differential_fuzzing"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 afl = "0.15"

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, Hash)]
 pub struct Bitset([u64; 1 << 10]);
 
 impl Bitset {

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -212,16 +212,14 @@ pub(crate) struct FrameRemnant {
 }
 
 /// Only contains the fields that can change (other than via tracer).
+#[derive(Debug)]
 pub(crate) struct CallframeSnapshot {
     stack: StackSnapshot,
-
     context_u128: u128,
     sp: u16,
     gas: u32,
     near_calls: Vec<NearCallFrame>,
-
     heap_size: u32,
     aux_heap_size: u32,
-
     heaps_i_was_keeping_alive: usize,
 }

--- a/src/fat_pointer.rs
+++ b/src/fat_pointer.rs
@@ -1,6 +1,7 @@
 use crate::heap::HeapId;
 use u256::U256;
 
+#[derive(Debug)]
 #[repr(C)]
 pub struct FatPointer {
     pub offset: u32,

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -49,7 +49,7 @@ impl PartialEq for Heap {
         if shorter_bytes.len() > longer_bytes.len() {
             mem::swap(&mut shorter_bytes, &mut longer_bytes);
         }
-        *shorter_bytes == longer_bytes[..shorter_bytes.len()]
+        shorter_bytes[..] == longer_bytes[..shorter_bytes.len()]
             && longer_bytes[shorter_bytes.len()..]
                 .iter()
                 .all(|&byte| byte == 0)
@@ -171,7 +171,8 @@ impl Index<HeapId> for Heaps {
     }
 }
 
-// Since we never remove `Heap`s (even after rollbacks), we allow additional empty heaps at the end of `Heaps`.
+// Since we never remove `Heap` entries (even after rollbacks – although we do deallocate heaps in this case),
+// we allow additional empty heaps at the end of `Heaps`.
 impl PartialEq for Heaps {
     fn eq(&self, other: &Self) -> bool {
         for i in 0..self.heaps.len().max(other.heaps.len()) {

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,5 +1,8 @@
-use crate::instruction_handlers::HeapInterface;
-use std::ops::{Index, Range};
+use crate::{hash_for_debugging, instruction_handlers::HeapInterface};
+use std::{
+    fmt, mem,
+    ops::{Index, Range},
+};
 use u256::U256;
 use zkevm_opcode_defs::system_params::NEW_FRAME_MEMORY_STIPEND;
 
@@ -19,6 +22,23 @@ impl HeapId {
 
 #[derive(Clone)]
 pub struct Heap(Vec<u8>);
+
+impl fmt::Debug for Heap {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const MAX_DEBUGGED_LEN: usize = 256;
+
+        if self.0.len() <= MAX_DEBUGGED_LEN {
+            formatter.debug_tuple("Heap").field(&self.0).finish()
+        } else {
+            formatter
+                .debug_struct("Heap")
+                .field("len", &self.0.len())
+                .field("start", &&self.0[..MAX_DEBUGGED_LEN])
+                .field("hash", &hash_for_debugging(&self.0))
+                .finish_non_exhaustive()
+        }
+    }
+}
 
 // Two heaps are considered equal even if one of them has greater size allocated (provided that all additional bytes
 // are zeroed). This is to account for the case when a bootloader heap is rolled back; heap is never shrunk.

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug, Formatter};
+use std::fmt;
 
 use crate::{
     addressing_modes::Arguments, mode_requirements::ModeRequirements, vm::VirtualMachine,
@@ -10,9 +10,12 @@ pub struct Instruction {
     pub(crate) arguments: Arguments,
 }
 
-impl Debug for Instruction {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Some handler with args {:?}", self.arguments)
+impl fmt::Debug for Instruction {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Instruction")
+            .field("arguments", &self.arguments)
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub trait World {
 
 /// Deterministic (across program runs and machines) hash that can be used for `Debug` implementations
 /// to concisely represent large amounts of data.
+#[cfg_attr(feature = "single_instruction_test", allow(dead_code))] // Currently used entirely in types overridden by `single_instruction_test` feature
 pub(crate) fn hash_for_debugging(value: &impl Hash) -> u64 {
     let mut hasher = DefaultHasher::new();
     value.hash(&mut hasher);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod testworld;
 mod vm;
 mod world_diff;
 
+use std::hash::{DefaultHasher, Hash, Hasher};
 use u256::{H160, U256};
 
 pub use decommit::address_into_u256;
@@ -60,4 +61,12 @@ pub trait World {
 
     /// Returns if the storage slot is free both in terms of gas and pubdata.
     fn is_free_storage_slot(&self, contract: &H160, key: &U256) -> bool;
+}
+
+/// Deterministic (across program runs and machines) hash that can be used for `Debug` implementations
+/// to concisely represent large amounts of data.
+pub(crate) fn hash_for_debugging(value: &impl Hash) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,16 +1,39 @@
-use crate::Instruction;
-use std::sync::Arc;
+use crate::{hash_for_debugging, Instruction};
+use std::{fmt, sync::Arc};
 use u256::U256;
 
 // An internal representation that doesn't need two Arcs would be better
 // but it would also require a lot of unsafe, so I made this wrapper to
 // enable changing the internals later.
 
-/// Cloning this is cheap. It is a handle to memory similar to [std::sync::Arc].
-#[derive(Clone, Debug)]
+/// Cloning this is cheap. It is a handle to memory similar to [`Arc`].
+#[derive(Clone)]
 pub struct Program {
     code_page: Arc<[U256]>,
     instructions: Arc<[Instruction]>,
+}
+
+impl fmt::Debug for Program {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const DEBUGGED_ITEMS: usize = 16;
+
+        let mut s = formatter.debug_struct("Program");
+        if self.code_page.len() <= DEBUGGED_ITEMS {
+            s.field("code_page", &self.code_page);
+        } else {
+            s.field("code_page.len", &self.code_page.len())
+                .field("code_page.start", &&self.code_page[..DEBUGGED_ITEMS])
+                .field("code_page.hash", &hash_for_debugging(&self.code_page));
+        }
+
+        if self.instructions.len() <= DEBUGGED_ITEMS {
+            s.field("instructions", &self.instructions);
+        } else {
+            s.field("instructions.len", &self.instructions.len())
+                .field("instructions.start", &&self.instructions[..DEBUGGED_ITEMS]);
+        }
+        s.finish_non_exhaustive()
+    }
 }
 
 impl Program {

--- a/src/single_instruction_test/program.rs
+++ b/src/single_instruction_test/program.rs
@@ -36,10 +36,6 @@ impl<'a> Arbitrary<'a> for Program {
 }
 
 impl Program {
-    pub fn new(_instructions: Vec<Instruction>, _code_page: Vec<U256>) -> Self {
-        unimplemented!("Not used during fuzzing")
-    }
-
     pub fn instruction(&self, n: u16) -> Option<&Instruction> {
         if n == 0 {
             Some(&self.first_instruction.get(n).as_ref()[0])

--- a/src/single_instruction_test/program.rs
+++ b/src/single_instruction_test/program.rs
@@ -36,6 +36,10 @@ impl<'a> Arbitrary<'a> for Program {
 }
 
 impl Program {
+    pub fn new(_instructions: Vec<Instruction>, _code_page: Vec<U256>) -> Self {
+        unimplemented!("Not used during fuzzing")
+    }
+
     pub fn instruction(&self, n: u16) -> Option<&Instruction> {
         if n == 0 {
             Some(&self.first_instruction.get(n).as_ref()[0])

--- a/src/single_instruction_test/stack.rs
+++ b/src/single_instruction_test/stack.rs
@@ -100,4 +100,5 @@ impl StackPool {
     pub fn recycle(&mut self, _: Box<Stack>) {}
 }
 
+#[derive(Debug)]
 pub(crate) struct StackSnapshot;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -5,49 +5,12 @@ use std::{
 };
 use u256::U256;
 
-/// Helper wrapper for debugging [`Stack`] / [`StackSnapshot`] contents.
-struct StackStart<I>(I);
-
-impl<I: Iterator<Item = (bool, U256)> + Clone> fmt::Debug for StackStart<I> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut list = formatter.debug_list();
-        for (is_pointer, slot) in self.0.clone() {
-            if is_pointer {
-                list.entry(&FatPointer::from(slot));
-            } else {
-                list.entry(&slot);
-            }
-        }
-        list.finish()
-    }
-}
-
 #[derive(PartialEq)]
 pub struct Stack {
-    /// set of slots that may be interpreted as [crate::fat_pointer::FatPointer].
+    /// set of slots that may be interpreted as [`FatPointer`].
     pointer_flags: Bitset,
     dirty_areas: u64,
     slots: [U256; 1 << 16],
-}
-
-impl fmt::Debug for Stack {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        const DEBUGGED_SLOTS: usize = 256;
-
-        let slots = (0_u16..)
-            .zip(&self.slots)
-            .map(|(idx, slot)| (self.pointer_flags.get(idx), *slot))
-            .take(DEBUGGED_SLOTS);
-        formatter
-            .debug_struct("Stack")
-            .field("start", &StackStart(slots))
-            .field(
-                "pointer_flags.hash",
-                &hash_for_debugging(&self.pointer_flags),
-            )
-            .field("slots.hash", &hash_for_debugging(&self.slots))
-            .finish_non_exhaustive()
-    }
 }
 
 const NUMBER_OF_DIRTY_AREAS: usize = 64;
@@ -125,27 +88,6 @@ pub(crate) struct StackSnapshot {
     slots: Box<[U256]>,
 }
 
-impl fmt::Debug for StackSnapshot {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        const DEBUGGED_SLOTS: usize = 256;
-
-        let slots = (0_u16..)
-            .zip(&self.slots[..])
-            .map(|(idx, slot)| (self.pointer_flags.get(idx), *slot))
-            .take(DEBUGGED_SLOTS);
-        formatter
-            .debug_struct("StackSnapshot")
-            .field("dirty_areas", &self.dirty_areas)
-            .field("start", &StackStart(slots))
-            .field(
-                "pointer_flags.hash",
-                &hash_for_debugging(&self.pointer_flags),
-            )
-            .field("slots.hash", &hash_for_debugging(&self.slots))
-            .finish_non_exhaustive()
-    }
-}
-
 impl Clone for Box<Stack> {
     fn clone(&self) -> Self {
         unsafe {
@@ -176,6 +118,67 @@ impl StackPool {
         self.stacks.push(stack);
     }
 }
+
+// region:Debug implementations
+
+/// Helper wrapper for debugging [`Stack`] / [`StackSnapshot`] contents.
+struct StackStart<I>(I);
+
+impl<I: Iterator<Item = (bool, U256)> + Clone> fmt::Debug for StackStart<I> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut list = formatter.debug_list();
+        for (is_pointer, slot) in self.0.clone() {
+            if is_pointer {
+                list.entry(&FatPointer::from(slot));
+            } else {
+                list.entry(&slot);
+            }
+        }
+        list.finish()
+    }
+}
+
+impl fmt::Debug for Stack {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const DEBUGGED_SLOTS: usize = 256;
+
+        let slots = (0_u16..)
+            .zip(&self.slots)
+            .map(|(idx, slot)| (self.pointer_flags.get(idx), *slot))
+            .take(DEBUGGED_SLOTS);
+        formatter
+            .debug_struct("Stack")
+            .field("start", &StackStart(slots))
+            .field(
+                "pointer_flags.hash",
+                &hash_for_debugging(&self.pointer_flags),
+            )
+            .field("slots.hash", &hash_for_debugging(&self.slots))
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for StackSnapshot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const DEBUGGED_SLOTS: usize = 256;
+
+        let slots = (0_u16..)
+            .zip(&self.slots[..])
+            .map(|(idx, slot)| (self.pointer_flags.get(idx), *slot))
+            .take(DEBUGGED_SLOTS);
+        formatter
+            .debug_struct("StackSnapshot")
+            .field("dirty_areas", &self.dirty_areas)
+            .field("start", &StackStart(slots))
+            .field(
+                "pointer_flags.hash",
+                &hash_for_debugging(&self.pointer_flags),
+            )
+            .field("slots.hash", &hash_for_debugging(&self.slots))
+            .finish_non_exhaustive()
+    }
+}
+// endregion
 
 #[cfg(test)]
 mod tests {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,13 +1,53 @@
-use crate::bitset::Bitset;
-use std::alloc::{alloc, alloc_zeroed, Layout};
+use crate::{bitset::Bitset, fat_pointer::FatPointer, hash_for_debugging};
+use std::{
+    alloc::{alloc, alloc_zeroed, Layout},
+    fmt,
+};
 use u256::U256;
 
-#[derive(PartialEq, Debug)]
+/// Helper wrapper for debugging [`Stack`] / [`StackSnapshot`] contents.
+struct StackStart<I>(I);
+
+impl<I: Iterator<Item = (bool, U256)> + Clone> fmt::Debug for StackStart<I> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut list = formatter.debug_list();
+        for (is_pointer, slot) in self.0.clone() {
+            if is_pointer {
+                list.entry(&FatPointer::from(slot));
+            } else {
+                list.entry(&slot);
+            }
+        }
+        list.finish()
+    }
+}
+
+#[derive(PartialEq)]
 pub struct Stack {
     /// set of slots that may be interpreted as [crate::fat_pointer::FatPointer].
     pointer_flags: Bitset,
     dirty_areas: u64,
     slots: [U256; 1 << 16],
+}
+
+impl fmt::Debug for Stack {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const DEBUGGED_SLOTS: usize = 256;
+
+        let slots = (0_u16..)
+            .zip(&self.slots)
+            .map(|(idx, slot)| (self.pointer_flags.get(idx), *slot))
+            .take(DEBUGGED_SLOTS);
+        formatter
+            .debug_struct("Stack")
+            .field("start", &StackStart(slots))
+            .field(
+                "pointer_flags.hash",
+                &hash_for_debugging(&self.pointer_flags),
+            )
+            .field("slots.hash", &hash_for_debugging(&self.slots))
+            .finish_non_exhaustive()
+    }
 }
 
 const NUMBER_OF_DIRTY_AREAS: usize = 64;
@@ -83,6 +123,27 @@ pub(crate) struct StackSnapshot {
     pointer_flags: Bitset,
     dirty_areas: u64,
     slots: Box<[U256]>,
+}
+
+impl fmt::Debug for StackSnapshot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        const DEBUGGED_SLOTS: usize = 256;
+
+        let slots = (0_u16..)
+            .zip(&self.slots[..])
+            .map(|(idx, slot)| (self.pointer_flags.get(idx), *slot))
+            .take(DEBUGGED_SLOTS);
+        formatter
+            .debug_struct("StackSnapshot")
+            .field("dirty_areas", &self.dirty_areas)
+            .field("start", &StackStart(slots))
+            .field(
+                "pointer_flags.hash",
+                &hash_for_debugging(&self.pointer_flags),
+            )
+            .field("slots.hash", &hash_for_debugging(&self.slots))
+            .finish_non_exhaustive()
+    }
 }
 
 impl Clone for Box<Stack> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -183,16 +183,13 @@ impl Addressable for State {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct StateSnapshot {
     registers: [U256; 16],
     register_pointer_flags: u16,
-
     flags: Flags,
-
     bootloader_frame: CallframeSnapshot,
-
     bootloader_heap_snapshot: (usize, usize),
     transaction_number: u16,
-
     context_u128: u128,
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -322,6 +322,7 @@ impl VirtualMachine {
     }
 }
 
+#[derive(Debug)]
 pub struct VmSnapshot {
     world_snapshot: ExternalSnapshot,
     state_snapshot: StateSnapshot,

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -370,11 +370,14 @@ mod tests {
             first_changes in arbitrary_storage_changes(),
             second_changes in arbitrary_storage_changes(),
         ) {
-            let mut world_diff = WorldDiff::default();
-            world_diff.storage_initial_values = initial_values
+            let storage_initial_values = initial_values
                 .iter()
                 .map(|(key, value)| (*key, Some(*value)))
                 .collect();
+            let mut world_diff = WorldDiff {
+                storage_initial_values,
+                ..WorldDiff::default()
+            };
 
             let checkpoint1 = world_diff.snapshot();
             for (key, value) in &first_changes {

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -394,7 +394,7 @@ mod tests {
                         StorageChange {
                             before: initial_values.get(key).copied(),
                             after: *value,
-                            is_initial: initial_values.get(key).is_none(),
+                            is_initial: !initial_values.contains_key(key),
                         }
                     ))
                     .collect()
@@ -415,7 +415,7 @@ mod tests {
                         StorageChange {
                             before: first_changes.get(key).or(initial_values.get(key)).copied(),
                             after: *value,
-                            is_initial: initial_values.get(key).is_none(),
+                            is_initial: !initial_values.contains_key(key),
                         }
                     ))
                     .collect()

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -33,6 +33,7 @@ pub struct WorldDiff {
     storage_initial_values: BTreeMap<(H160, U256), Option<U256>>,
 }
 
+#[derive(Debug)]
 pub struct ExternalSnapshot {
     internal_snapshot: Snapshot,
     pub(crate) decommitted_hashes: <RollbackableMap<U256, ()> as Rollback>::Snapshot,

--- a/tests/bytecode_behaviour.rs
+++ b/tests/bytecode_behaviour.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "single_instruction_test"))]
+
 use u256::U256;
 use vm2::{
     decode::decode_program, initial_decommit, testworld::TestWorld, ExecutionEnd, Program,

--- a/tests/bytecode_behaviour.rs
+++ b/tests/bytecode_behaviour.rs
@@ -16,7 +16,7 @@ fn program_from_file(filename: &str) -> Program {
             false,
         ),
         blob.chunks_exact(32)
-            .map(|chunk| U256::from_big_endian(chunk.try_into().unwrap()))
+            .map(U256::from_big_endian)
             .collect::<Vec<_>>(),
     )
 }

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "single_instruction_test"))]
+
 use proptest::prelude::*;
 use vm2::{
     addressing_modes::{Arguments, Immediate1, Immediate2, Register, Register1},

--- a/tests/stipend.rs
+++ b/tests/stipend.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "single_instruction_test"))]
+
 use u256::U256;
 use vm2::{
     address_into_u256,


### PR DESCRIPTION
# What ❔

- Fixes `Heap` equality comparison to allow for additional allocation after a rollback.
- Shortens `Debug` output for large amounts of data (e.g., `Stack`, `Heap`, `Program`) and adds `Debug` impl for a couple of types.

## Why ❔

- Equality comparison is used in `zksync_multivm` unit tests.
- More readable `Debug` implementations simplify debugging.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted.