### PR TITLE
fix: fuzzer now makes short programs; fix crash in near call

### DIFF
--- a/src/instruction_handlers/near_call.rs
+++ b/src/instruction_handlers/near_call.rs
@@ -1,3 +1,4 @@
+use super::ret::INVALID_INSTRUCTION;
 use crate::{
     addressing_modes::{Arguments, Immediate1, Immediate2, Register1, Source},
     instruction::InstructionResult,
@@ -35,7 +36,7 @@ fn near_call(
         .current_frame
         .program
         .instruction(destination.low_u32() as u16)
-        .unwrap())
+        .unwrap_or(&INVALID_INSTRUCTION))
 }
 
 impl Instruction {

--- a/src/single_instruction_test/program.rs
+++ b/src/single_instruction_test/program.rs
@@ -26,10 +26,10 @@ impl<'a> Arbitrary<'a> for Program {
                 decode(raw_first_instruction, false),
                 Instruction::from_invalid(),
             ])),
-            other_instruction: MockRead::new(Rc::new(Some([
-                Instruction::from_invalid(),
-                Instruction::from_invalid(),
-            ]))),
+            other_instruction: MockRead::new(Rc::new(
+                u.arbitrary::<bool>()?
+                    .then_some([Instruction::from_invalid(), Instruction::from_invalid()]),
+            )),
             code_page: [u.arbitrary()?; 1].into(),
         })
     }


### PR DESCRIPTION
The fuzzer's random program generation was accidentally only generating programs that have instructions everywhere. The data structure had an Option but it was always Some.

Because of this a very simple crash in near call wasn't caught. It is fixed here.