### PR TITLE
perf: Implement segmented heap

### DIFF
--- a/src/heap.rs
+++ b/src/heap.rs
@@ -90,8 +90,7 @@ impl Heap {
         let mut bytes = [0; 32];
         value.to_big_endian(&mut bytes);
 
-        let offset = start_address as usize;
-        let (page_idx, offset_in_page) = (offset >> 12, offset & (HEAP_PAGE_SIZE - 1));
+        let (page_idx, offset_in_page) = address_to_page_offset(start_address);
         let len_in_page = 32.min(HEAP_PAGE_SIZE - offset_in_page);
         let page = self.get_or_insert_page(page_idx, recycled_pages);
         page.0[offset_in_page..(offset_in_page + len_in_page)]
@@ -104,25 +103,50 @@ impl Heap {
     }
 }
 
+#[inline(always)]
+fn address_to_page_offset(address: u32) -> (usize, usize) {
+    let offset = address as usize;
+    (offset >> 12, offset & (HEAP_PAGE_SIZE - 1))
+}
+
 impl HeapInterface for Heap {
     fn read_u256(&self, start_address: u32) -> U256 {
-        self.read_u256_partially(start_address..start_address + 32)
+        let (page_idx, offset_in_page) = address_to_page_offset(start_address);
+        let bytes_in_page = HEAP_PAGE_SIZE - offset_in_page;
+
+        if bytes_in_page >= 32 {
+            if let Some(page) = self.page(page_idx) {
+                U256::from_big_endian(&page.0[offset_in_page..offset_in_page + 32])
+            } else {
+                U256::zero()
+            }
+        } else {
+            let mut result = [0_u8; 32];
+            if let Some(page) = self.page(page_idx) {
+                result[0..bytes_in_page]
+                    .copy_from_slice(&page.0[offset_in_page..(offset_in_page + bytes_in_page)]);
+            }
+            if let Some(page) = self.page(page_idx + 1) {
+                result[bytes_in_page..32].copy_from_slice(&page.0[..32 - bytes_in_page]);
+            }
+            U256::from_big_endian(&result)
+        }
     }
 
     fn read_u256_partially(&self, range: Range<u32>) -> U256 {
-        let offset = range.start as usize;
-        let (page_idx, offset_in_page) = (offset >> 12, offset & (HEAP_PAGE_SIZE - 1));
+        let (page_idx, offset_in_page) = address_to_page_offset(range.start);
+        let length = range.len();
+        let len_in_page = length.min(HEAP_PAGE_SIZE - offset_in_page);
+
         let mut result = [0_u8; 32];
-        let len_in_page = range.len().min(HEAP_PAGE_SIZE - offset_in_page);
         if let Some(page) = self.page(page_idx) {
             result[0..len_in_page]
                 .copy_from_slice(&page.0[offset_in_page..(offset_in_page + len_in_page)]);
         }
 
-        if len_in_page < range.len() {
+        if len_in_page < length {
             if let Some(page) = self.page(page_idx + 1) {
-                result[len_in_page..range.len()]
-                    .copy_from_slice(&page.0[..range.len() - len_in_page]);
+                result[len_in_page..length].copy_from_slice(&page.0[..length - len_in_page]);
             }
         }
         U256::from_big_endian(&result)

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -146,10 +146,9 @@ impl HeapInterface for Heap {
     }
 
     fn read_range_big_endian(&self, range: Range<u32>) -> Vec<u8> {
-        let offset = range.start as usize;
-        let length = (range.end - range.start) as usize;
+        let length = range.len() as usize;
 
-        let (mut page_idx, mut offset_in_page) = (offset >> 12, offset & (HEAP_PAGE_SIZE - 1));
+        let (mut page_idx, mut offset_in_page) = address_to_page_offset(range.start);
         let mut result = Vec::with_capacity(length);
         while result.len() < length {
             let len_in_page = (length - result.len()).min(HEAP_PAGE_SIZE - offset_in_page);

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -23,11 +23,12 @@ const HEAP_PAGE_SIZE: usize = 1 << 12;
 
 /// Heap page.
 #[derive(Debug, Clone, PartialEq)]
-struct HeapPage(Box<[u8]>);
+struct HeapPage(Box<[u8; HEAP_PAGE_SIZE]>);
 
 impl Default for HeapPage {
     fn default() -> Self {
-        Self(vec![0_u8; HEAP_PAGE_SIZE].into())
+        let boxed_slice: Box<[u8]> = vec![0_u8; HEAP_PAGE_SIZE].into();
+        Self(boxed_slice.try_into().unwrap()) // FIXME: bench `unwrap_unchecked()`?
     }
 }
 
@@ -48,7 +49,7 @@ impl Heap {
                 } else {
                     let mut boxed_slice: Box<[u8]> = vec![0_u8; HEAP_PAGE_SIZE].into();
                     boxed_slice[..bytes.len()].copy_from_slice(bytes);
-                    HeapPage(boxed_slice)
+                    HeapPage(boxed_slice.try_into().unwrap())
                 })
             })
             .collect();

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -146,7 +146,7 @@ impl HeapInterface for Heap {
     }
 
     fn read_range_big_endian(&self, range: Range<u32>) -> Vec<u8> {
-        let length = range.len() as usize;
+        let length = range.len();
 
         let (mut page_idx, mut offset_in_page) = address_to_page_offset(range.start);
         let mut result = Vec::with_capacity(length);

--- a/src/heap.rs
+++ b/src/heap.rs
@@ -1,8 +1,6 @@
-use crate::{hash_for_debugging, instruction_handlers::HeapInterface};
-use std::{
-    fmt, mem,
-    ops::{Index, Range},
-};
+use crate::{instruction_handlers::HeapInterface};
+use std::{ops::{Index, Range}};
+use std::collections::HashMap;
 use u256::U256;
 use zkevm_opcode_defs::system_params::NEW_FRAME_MEMORY_STIPEND;
 
@@ -20,50 +18,63 @@ impl HeapId {
     }
 }
 
-#[derive(Clone)]
-pub struct Heap(Vec<u8>);
+/// Heap page size in bytes.
+const HEAP_PAGE_SIZE: usize = 1 << 12;
 
-impl fmt::Debug for Heap {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        const MAX_DEBUGGED_LEN: usize = 256;
+/// Heap page.
+#[derive(Debug, Clone, PartialEq)]
+struct HeapPage(Box<[u8]>);
 
-        if self.0.len() <= MAX_DEBUGGED_LEN {
-            formatter.debug_tuple("Heap").field(&self.0).finish()
-        } else {
-            formatter
-                .debug_struct("Heap")
-                .field("len", &self.0.len())
-                .field("start", &&self.0[..MAX_DEBUGGED_LEN])
-                .field("hash", &hash_for_debugging(&self.0))
-                .finish_non_exhaustive()
-        }
+impl Default for HeapPage {
+    fn default() -> Self {
+        // FIXME: try reusing pages (w/ thread-local arena tied to execution?)
+        Self(vec![0_u8; HEAP_PAGE_SIZE].into())
     }
 }
 
-// Two heaps are considered equal even if one of them has greater size allocated (provided that all additional bytes
-// are zeroed). This is to account for the case when a bootloader heap is rolled back; heap is never shrunk.
-impl PartialEq for Heap {
-    fn eq(&self, other: &Self) -> bool {
-        let mut shorter_bytes = &self.0;
-        let mut longer_bytes = &other.0;
-        if shorter_bytes.len() > longer_bytes.len() {
-            mem::swap(&mut shorter_bytes, &mut longer_bytes);
-        }
-        shorter_bytes[..] == longer_bytes[..shorter_bytes.len()]
-            && longer_bytes[shorter_bytes.len()..]
-                .iter()
-                .all(|&byte| byte == 0)
-    }
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Heap {
+    // FIXME: try other data structs?
+    pages: HashMap<usize, HeapPage>,
 }
 
 impl Heap {
-    fn write_u256(&mut self, start_address: u32, value: U256) {
-        let end = (start_address + 32) as usize;
-        if end > self.0.len() {
-            self.0.resize(end, 0);
-        }
+    fn from_bytes(bytes: &[u8]) -> Self {
+        let pages = bytes
+            .chunks(HEAP_PAGE_SIZE)
+            .map(|bytes| {
+                let mut boxed_slice: Box<[u8]> = vec![0_u8; HEAP_PAGE_SIZE].into();
+                boxed_slice[..bytes.len()].copy_from_slice(bytes);
+                HeapPage(boxed_slice)
+            })
+            .enumerate()
+            .collect();
+        Self { pages }
+    }
 
-        value.to_big_endian(&mut self.0[start_address as usize..end]);
+    fn with_capacity(capacity: usize) -> Self {
+        let end_page = capacity.saturating_sub(1) >> 12;
+        let pages = (0..=end_page)
+            .map(|idx| (idx, HeapPage::default()))
+            .collect();
+        Self { pages }
+    }
+
+    fn write_u256(&mut self, start_address: u32, value: U256) {
+        let mut bytes = [0; 32];
+        value.to_big_endian(&mut bytes);
+
+        let offset = start_address as usize;
+        let (page_idx, offset_in_page) = (offset >> 12, offset & (HEAP_PAGE_SIZE - 1));
+        let len_in_page = 32.min(HEAP_PAGE_SIZE - offset_in_page);
+        let page = self.pages.entry(page_idx).or_default();
+        page.0[offset_in_page..(offset_in_page + len_in_page)]
+            .copy_from_slice(&bytes[..len_in_page]);
+
+        if len_in_page < 32 {
+            let page = self.pages.entry(page_idx + 1).or_default();
+            page.0[..32 - len_in_page].copy_from_slice(&bytes[len_in_page..]);
+        }
     }
 }
 
@@ -71,20 +82,41 @@ impl HeapInterface for Heap {
     fn read_u256(&self, start_address: u32) -> U256 {
         self.read_u256_partially(start_address..start_address + 32)
     }
-    fn read_u256_partially(&self, range: Range<u32>) -> U256 {
-        let end = (range.end as usize).min(self.0.len());
 
-        let mut bytes = [0; 32];
-        for (i, j) in (range.start as usize..end).enumerate() {
-            bytes[i] = self.0[j];
+    fn read_u256_partially(&self, range: Range<u32>) -> U256 {
+        let offset = range.start as usize;
+        let (page_idx, offset_in_page) = (offset >> 12, offset & (HEAP_PAGE_SIZE - 1));
+        let mut result = [0_u8; 32];
+        let len_in_page = range.len().min(HEAP_PAGE_SIZE - offset_in_page);
+        if let Some(page) = self.pages.get(&page_idx) {
+            result[0..len_in_page]
+                .copy_from_slice(&page.0[offset_in_page..(offset_in_page + len_in_page)]);
         }
-        U256::from_big_endian(&bytes)
+
+        if len_in_page < range.len() {
+            if let Some(page) = self.pages.get(&(page_idx + 1)) {
+                result[len_in_page..range.len()]
+                    .copy_from_slice(&page.0[..range.len() - len_in_page]);
+            }
+        }
+        U256::from_big_endian(&result)
     }
+
     fn read_range_big_endian(&self, range: Range<u32>) -> Vec<u8> {
-        let end = (range.end as usize).min(self.0.len());
-        let mut result = vec![0; range.len()];
-        for (i, j) in (range.start as usize..end).enumerate() {
-            result[i] = self.0[j];
+        let offset = range.start as usize;
+        let length = (range.end - range.start) as usize;
+
+        let (mut page_idx, mut offset_in_page) = (offset >> 12, offset & (HEAP_PAGE_SIZE - 1));
+        let mut result = Vec::with_capacity(length);
+        while result.len() < length {
+            let len_in_page = (length - result.len()).min(HEAP_PAGE_SIZE - offset_in_page);
+            if let Some(page) = self.pages.get(&page_idx) {
+                result.extend_from_slice(&page.0[offset_in_page..(offset_in_page + len_in_page)]);
+            } else {
+                result.resize(result.len() + len_in_page, 0);
+            }
+            page_idx += 1;
+            offset_in_page = 0;
         }
         result
     }
@@ -106,14 +138,16 @@ impl Heaps {
         // The first heap can never be used because heap zero
         // means the current heap in precompile calls
         Self {
-            heaps: vec![Heap(vec![]), Heap(calldata), Heap(vec![]), Heap(vec![])],
+            heaps: vec![Heap::default(), Heap::from_bytes(&calldata), Heap::default(), Heap::default()],
             bootloader_heap_rollback_info: vec![],
             bootloader_aux_rollback_info: vec![],
         }
     }
 
     pub(crate) fn allocate(&mut self) -> HeapId {
-        self.allocate_inner(vec![0; NEW_FRAME_MEMORY_STIPEND as usize])
+        let id = HeapId(self.heaps.len() as u32);
+        self.heaps.push(Heap::with_capacity(NEW_FRAME_MEMORY_STIPEND as usize));
+        id
     }
 
     pub(crate) fn allocate_with_content(&mut self, content: &[u8]) -> HeapId {
@@ -122,12 +156,12 @@ impl Heaps {
 
     fn allocate_inner(&mut self, memory: Vec<u8>) -> HeapId {
         let id = HeapId(self.heaps.len() as u32);
-        self.heaps.push(Heap(memory));
+        self.heaps.push(Heap::from_bytes(&memory));
         id
     }
 
     pub(crate) fn deallocate(&mut self, heap: HeapId) {
-        self.heaps[heap.0 as usize].0 = vec![];
+        self.heaps[heap.0 as usize] = Heap::default();
     }
 
     pub fn write_u256(&mut self, heap: HeapId, start_address: u32, value: U256) {
@@ -176,8 +210,8 @@ impl Index<HeapId> for Heaps {
 impl PartialEq for Heaps {
     fn eq(&self, other: &Self) -> bool {
         for i in 0..self.heaps.len().max(other.heaps.len()) {
-            if self.heaps.get(i).unwrap_or(&Heap(vec![]))
-                != other.heaps.get(i).unwrap_or(&Heap(vec![]))
+            if self.heaps.get(i).unwrap_or(&Heap::default())
+                != other.heaps.get(i).unwrap_or(&Heap::default())
             {
                 return false;
             }
@@ -190,16 +224,147 @@ impl PartialEq for Heaps {
 mod tests {
     use super::*;
 
+    fn repeat_byte(byte: u8) -> U256 {
+        U256::from_little_endian(&[byte; 32])
+    }
+
     #[test]
     fn heap_write_resizes() {
-        let mut heap = Heap(vec![]);
+        let mut heap = Heap::default();
         heap.write_u256(5, 1.into());
+        assert_eq!(heap.pages.len(), 1);
         assert_eq!(heap.read_u256(5), 1.into());
+
+        // Check writing at a page boundary
+        heap.write_u256(HEAP_PAGE_SIZE as u32 - 32, repeat_byte(0xaa));
+        assert_eq!(heap.pages.len(), 1);
+        assert_eq!(
+            heap.read_u256(HEAP_PAGE_SIZE as u32 - 32),
+            repeat_byte(0xaa)
+        );
+
+        for offset in (1..=31).rev() {
+            heap.write_u256(HEAP_PAGE_SIZE as u32 - offset, repeat_byte(offset as u8));
+            assert_eq!(heap.pages.len(), 2);
+            assert_eq!(
+                heap.read_u256(HEAP_PAGE_SIZE as u32 - offset),
+                repeat_byte(offset as u8)
+            );
+        }
+
+        // check reading at a page boundary from a missing page
+        for offset in 0..32 {
+            assert_eq!(heap.read_u256((1 << 20) - offset), 0.into());
+        }
+
+        heap.write_u256(1 << 20, repeat_byte(0xff));
+        assert_eq!(heap.pages.len(), 3);
+        assert_eq!(heap.read_u256(1 << 20), repeat_byte(0xff));
+    }
+
+    #[test]
+    fn reading_heap_range() {
+        let mut heap = Heap::default();
+        let offsets = [
+            0_u32,
+            10,
+            HEAP_PAGE_SIZE as u32 - 10,
+            HEAP_PAGE_SIZE as u32 + 10,
+            (1 << 20) - 10,
+            1 << 20,
+            (1 << 20) + 10,
+        ];
+        for offset in offsets {
+            for length in [0, 1, 10, 31, 32, 1_024, 32_768] {
+                let data = heap.read_range_big_endian(offset..offset + length);
+                assert_eq!(data.len(), length as usize);
+                assert!(data.iter().all(|&byte| byte == 0));
+            }
+        }
+
+        for (i, offset) in offsets.into_iter().enumerate() {
+            let bytes: Vec<_> = (i..i + 32).map(|byte| byte as u8).collect();
+            heap.write_u256(offset, U256::from_big_endian(&bytes));
+            for length in 1..=32 {
+                let data = heap.read_range_big_endian(offset..offset + length);
+                assert_eq!(data, bytes[..length as usize]);
+            }
+        }
+    }
+
+    #[test]
+    fn heap_partial_u256_reads() {
+        let mut heap = Heap::default();
+        let bytes: Vec<_> = (1..=32).collect();
+        heap.write_u256(0, U256::from_big_endian(&bytes));
+        for length in 1..=32 {
+            let read = heap.read_u256_partially(0..length);
+            // Mask is 0xff...ff00..00, where the number of `0xff` bytes is the number of read bytes
+            let mask = U256::MAX << (8 * (32 - length));
+            assert_eq!(read, U256::from_big_endian(&bytes) & mask);
+        }
+
+        // The same test at the page boundary.
+        let offset = HEAP_PAGE_SIZE as u32 - 10;
+        heap.write_u256(offset, U256::from_big_endian(&bytes));
+        for length in 1..=32 {
+            let read = heap.read_u256_partially(offset..offset + length);
+            let mask = U256::MAX << (8 * (32 - length));
+            assert_eq!(read, U256::from_big_endian(&bytes) & mask);
+        }
     }
 
     #[test]
     fn heap_read_out_of_bounds() {
-        let heap = Heap(vec![]);
+        let heap = Heap::default();
         assert_eq!(heap.read_u256(5), 0.into());
+    }
+
+    #[test]
+    fn default_new_heap_does_not_allocate_many_pages() {
+        let heap = Heap::with_capacity(NEW_FRAME_MEMORY_STIPEND as usize);
+        assert_eq!(heap.pages.len(), 1);
+        assert_eq!(*heap.pages[&0].0, [0_u8; 4096]);
+    }
+
+    #[test]
+    fn creating_heap_from_bytes() {
+        let bytes: Vec<_> = (0..=u8::MAX).collect();
+        let heap = Heap::from_bytes(&bytes);
+        assert_eq!(heap.pages.len(), 1);
+
+        assert_eq!(heap.read_range_big_endian(0..256), bytes);
+        for offset in 0..256 - 32 {
+            let value = heap.read_u256(offset as u32);
+            assert_eq!(value, U256::from_big_endian(&bytes[offset..offset + 32]));
+        }
+
+        // Test larger heap with multiple pages.
+        let bytes: Vec<_> = (0..HEAP_PAGE_SIZE * 5 / 2).map(|byte| byte as u8).collect();
+        let heap = Heap::from_bytes(&bytes);
+        assert_eq!(heap.pages.len(), 3);
+
+        assert_eq!(heap.read_range_big_endian(0..HEAP_PAGE_SIZE as u32 * 5 / 2), bytes);
+        for len in [
+            1,
+            10,
+            100,
+            HEAP_PAGE_SIZE / 3,
+            HEAP_PAGE_SIZE / 2,
+            HEAP_PAGE_SIZE,
+            2 * HEAP_PAGE_SIZE,
+        ] {
+            for offset in 0..(HEAP_PAGE_SIZE * 5 / 2 - len) {
+                assert_eq!(
+                    heap.read_range_big_endian(offset as u32..(offset + len) as u32),
+                    bytes[offset..offset + len]
+                );
+            }
+        }
+
+        for offset in 0..HEAP_PAGE_SIZE * 5 / 2 - 32 {
+            let value = heap.read_u256(offset as u32);
+            assert_eq!(value, U256::from_big_endian(&bytes[offset..offset + 32]));
+        }
     }
 }

--- a/src/instruction_handlers/heap_access.rs
+++ b/src/instruction_handlers/heap_access.rs
@@ -46,6 +46,7 @@ impl HeapFromState for AuxHeap {
 /// The last address to which 32 can be added without overflow.
 const LAST_ADDRESS: u32 = u32::MAX - 32;
 
+// Necessary because the obvious code compiles to a comparison of two 256-bit numbers.
 #[inline(always)]
 fn bigger_than_last_address(x: U256) -> bool {
     x.0[0] > LAST_ADDRESS.into() || x.0[1] != 0 || x.0[2] != 0 || x.0[3] != 0

--- a/src/instruction_handlers/heap_access.rs
+++ b/src/instruction_handlers/heap_access.rs
@@ -46,6 +46,11 @@ impl HeapFromState for AuxHeap {
 /// The last address to which 32 can be added without overflow.
 const LAST_ADDRESS: u32 = u32::MAX - 32;
 
+#[inline(always)]
+fn bigger_than_last_address(x: U256) -> bool {
+    x.0[0] > LAST_ADDRESS.into() || x.0[1] != 0 || x.0[2] != 0 || x.0[3] != 0
+}
+
 fn load<H: HeapFromState, In: Source, const INCREMENT: bool>(
     vm: &mut VirtualMachine,
     instruction: *const Instruction,
@@ -65,7 +70,7 @@ fn load<H: HeapFromState, In: Source, const INCREMENT: bool>(
 
         // The heap is always grown even when the index nonsensical.
         // TODO PLA-974 revert to not growing the heap on failure as soon as zk_evm is fixed
-        if pointer > LAST_ADDRESS.into() {
+        if bigger_than_last_address(pointer) {
             let _ = vm.state.use_gas(u32::MAX);
             return Ok(&PANIC);
         }
@@ -102,7 +107,7 @@ fn store<H: HeapFromState, In: Source, const INCREMENT: bool, const HOOKING_ENAB
 
         // The heap is always grown even when the index nonsensical.
         // TODO PLA-974 revert to not growing the heap on failure as soon as zk_evm is fixed
-        if pointer > LAST_ADDRESS.into() {
+        if bigger_than_last_address(pointer) {
             let _ = vm.state.use_gas(u32::MAX);
             return Ok(&PANIC);
         }

--- a/src/single_instruction_test/heap.rs
+++ b/src/single_instruction_test/heap.rs
@@ -58,7 +58,7 @@ pub const FIRST_HEAP: HeapId = HeapId(2);
 pub(crate) const FIRST_AUX_HEAP: HeapId = HeapId(3);
 
 impl Heaps {
-    pub(crate) fn new(_: Vec<u8>) -> Self {
+    pub(crate) fn new(_: &[u8]) -> Self {
         unimplemented!("Should use arbitrary heap, not fresh heap in testing.")
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -34,7 +34,7 @@ impl State {
     pub(crate) fn new(
         address: H160,
         caller: H160,
-        calldata: Vec<u8>,
+        calldata: &[u8],
         gas: u32,
         program: Program,
         world_before_this_frame: Snapshot,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -51,7 +51,7 @@ impl VirtualMachine {
             state: State::new(
                 address,
                 caller,
-                calldata,
+                &calldata,
                 gas,
                 program,
                 world_before_this_frame,


### PR DESCRIPTION
# What ❔

Another stab to segmented heap, similar to how it's implemented for old VMs (+ recycling heap pages).

## Why ❔

Leads to performance improvement compared to the current linear heap design, esp. for single-transaction execution.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and `cargo clippy`.