### PR TITLE
feat: statistics for circuit tracer

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -39,7 +39,7 @@ fn unimplemented_instruction(variant: Opcode) -> Instruction {
     let variant_as_number: u16 = unsafe { std::mem::transmute(variant) };
     Immediate1(variant_as_number).write_source(&mut arguments);
     Instruction {
-        opcode: Opcode::Invalid(zkevm_opcode_defs::InvalidOpcode),
+        opcode: Opcode::Nop(zkevm_opcode_defs::NopOpcode),
         handler: unimplemented_handler,
         arguments,
     }

--- a/src/decommit.rs
+++ b/src/decommit.rs
@@ -1,7 +1,4 @@
-use crate::{
-    program::Program, vm::STORAGE_READ_STORAGE_APPLICATION_CYCLES, world_diff::WorldDiff,
-    CircuitCycleStatistic, World,
-};
+use crate::{program::Program, world_diff::WorldDiff, CircuitCycleStatistic, World};
 use u256::{H160, U256};
 use zkevm_opcode_defs::{
     ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,5 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 
+use zkevm_opcode_defs::{NopOpcode, Opcode};
+
 use crate::{
     addressing_modes::Arguments, mode_requirements::ModeRequirements, vm::VirtualMachine,
     Predicate, World,
@@ -8,6 +10,7 @@ use crate::{
 pub struct Instruction {
     pub(crate) handler: Handler,
     pub(crate) arguments: Arguments,
+    pub(crate) opcode: Opcode,
 }
 
 impl Debug for Instruction {
@@ -37,6 +40,7 @@ pub fn jump_to_beginning() -> Instruction {
     Instruction {
         handler: jump_to_beginning_handler,
         arguments: Arguments::new(Predicate::Always, 0, ModeRequirements::none()),
+        opcode: Opcode::Nop(NopOpcode),
     }
 }
 fn jump_to_beginning_handler(

--- a/src/instruction_handlers/binop.rs
+++ b/src/instruction_handlers/binop.rs
@@ -10,6 +10,7 @@ use crate::{
     VirtualMachine, World,
 };
 use u256::U256;
+use zkevm_opcode_defs::Opcode;
 
 fn binop<Op: Binop, In1: Source, Out: Destination, const SWAP: bool, const SET_FLAGS: bool>(
     vm: &mut VirtualMachine,
@@ -205,6 +206,7 @@ use super::monomorphization::*;
 impl Instruction {
     #[inline(always)]
     pub fn from_binop<Op: Binop>(
+        opcode: Opcode,
         src1: AnySource,
         src2: Register2,
         out: AnyDestination,
@@ -214,6 +216,7 @@ impl Instruction {
         set_flags: bool,
     ) -> Self {
         Self {
+            opcode,
             handler: monomorphize!(binop [Op] match_source src1 match_destination out match_boolean swap match_boolean set_flags),
             arguments: arguments
                 .write_source(&src1)

--- a/src/instruction_handlers/context.rs
+++ b/src/instruction_handlers/context.rs
@@ -7,7 +7,7 @@ use crate::{
     Instruction, VirtualMachine, World,
 };
 use u256::U256;
-use zkevm_opcode_defs::VmMetaParameters;
+use zkevm_opcode_defs::{Opcode, VmMetaParameters};
 
 fn context<Op: ContextOp>(
     vm: &mut VirtualMachine,
@@ -123,51 +123,56 @@ fn aux_mutating(
 }
 
 impl Instruction {
-    fn from_context<Op: ContextOp>(out: Register1, arguments: Arguments) -> Self {
+    fn from_context<Op: ContextOp>(opcode: Opcode, out: Register1, arguments: Arguments) -> Self {
         Self {
+            opcode,
             handler: context::<Op>,
             arguments: arguments.write_destination(&out),
         }
     }
 
-    pub fn from_this(out: Register1, arguments: Arguments) -> Self {
-        Self::from_context::<This>(out, arguments)
+    pub fn from_this(opcode: Opcode, out: Register1, arguments: Arguments) -> Self {
+        Self::from_context::<This>(opcode, out, arguments)
     }
-    pub fn from_caller(out: Register1, arguments: Arguments) -> Self {
-        Self::from_context::<Caller>(out, arguments)
+    pub fn from_caller(opcode: Opcode, out: Register1, arguments: Arguments) -> Self {
+        Self::from_context::<Caller>(opcode, out, arguments)
     }
-    pub fn from_code_address(out: Register1, arguments: Arguments) -> Self {
-        Self::from_context::<CodeAddress>(out, arguments)
+    pub fn from_code_address(opcode: Opcode, out: Register1, arguments: Arguments) -> Self {
+        Self::from_context::<CodeAddress>(opcode, out, arguments)
     }
-    pub fn from_ergs_left(out: Register1, arguments: Arguments) -> Self {
-        Self::from_context::<ErgsLeft>(out, arguments)
+    pub fn from_ergs_left(opcode: Opcode, out: Register1, arguments: Arguments) -> Self {
+        Self::from_context::<ErgsLeft>(opcode, out, arguments)
     }
-    pub fn from_context_u128(out: Register1, arguments: Arguments) -> Self {
-        Self::from_context::<U128>(out, arguments)
+    pub fn from_context_u128(opcode: Opcode, out: Register1, arguments: Arguments) -> Self {
+        Self::from_context::<U128>(opcode, out, arguments)
     }
-    pub fn from_context_sp(out: Register1, arguments: Arguments) -> Self {
-        Self::from_context::<SP>(out, arguments)
+    pub fn from_context_sp(opcode: Opcode, out: Register1, arguments: Arguments) -> Self {
+        Self::from_context::<SP>(opcode, out, arguments)
     }
-    pub fn from_context_meta(out: Register1, arguments: Arguments) -> Self {
+    pub fn from_context_meta(opcode: Opcode, out: Register1, arguments: Arguments) -> Self {
         Self {
+            opcode,
             handler: context_meta,
             arguments: arguments.write_destination(&out),
         }
     }
-    pub fn from_set_context_u128(src: Register1, arguments: Arguments) -> Self {
+    pub fn from_set_context_u128(opcode: Opcode, src: Register1, arguments: Arguments) -> Self {
         Self {
+            opcode,
             handler: set_context_u128,
             arguments: arguments.write_source(&src),
         }
     }
-    pub fn from_increment_tx_number(arguments: Arguments) -> Self {
+    pub fn from_increment_tx_number(opcode: Opcode, arguments: Arguments) -> Self {
         Self {
+            opcode,
             handler: increment_tx_number,
             arguments,
         }
     }
-    pub fn from_aux_mutating(arguments: Arguments) -> Self {
+    pub fn from_aux_mutating(opcode: Opcode, arguments: Arguments) -> Self {
         Self {
+            opcode,
             handler: aux_mutating,
             arguments,
         }

--- a/src/instruction_handlers/event.rs
+++ b/src/instruction_handlers/event.rs
@@ -6,7 +6,7 @@ use crate::{
     Instruction, VirtualMachine, World,
 };
 use u256::H160;
-use zkevm_opcode_defs::ADDRESS_EVENT_WRITER;
+use zkevm_opcode_defs::{Opcode, ADDRESS_EVENT_WRITER};
 
 fn event(
     vm: &mut VirtualMachine,
@@ -52,12 +52,14 @@ fn l2_to_l1(
 
 impl Instruction {
     pub fn from_event(
+        opcode: Opcode,
         key: Register1,
         value: Register2,
         is_first: bool,
         arguments: Arguments,
     ) -> Self {
         Self {
+            opcode,
             handler: event,
             arguments: arguments
                 .write_source(&key)
@@ -67,12 +69,14 @@ impl Instruction {
     }
 
     pub fn from_l2_to_l1_message(
+        opcode: Opcode,
         key: Register1,
         value: Register2,
         is_service: bool,
         arguments: Arguments,
     ) -> Self {
         Self {
+            opcode,
             handler: l2_to_l1,
             arguments: arguments
                 .write_source(&key)

--- a/src/instruction_handlers/far_call.rs
+++ b/src/instruction_handlers/far_call.rs
@@ -9,9 +9,13 @@ use crate::{
     fat_pointer::FatPointer,
     instruction::InstructionResult,
     predication::Flags,
+    vm::STORAGE_READ_STORAGE_APPLICATION_CYCLES,
     Instruction, VirtualMachine, World,
 };
 use u256::U256;
+use zkevm_opcode_defs::{
+    ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW,
+};
 use zkevm_opcode_defs::{
     system_params::{EVM_SIMULATOR_STIPEND, MSG_VALUE_SIMULATOR_ADDITIVE_COST},
     Opcode, ADDRESS_MSG_VALUE,
@@ -59,6 +63,15 @@ fn far_call<const CALLING_MODE: u8, const IS_STATIC: bool, const IS_SHARD: bool>
     };
 
     let failing_part = (|| {
+        let deployer_system_contract_address =
+            Address::from_low_u64_be(DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW as u64);
+        if !vm
+            .world_diff
+            .read_storage_slots_ct
+            .contains(&(deployer_system_contract_address, destination_address))
+        {
+            vm.statistics.storage_application_cycles += STORAGE_READ_STORAGE_APPLICATION_CYCLES;
+        }
         let decommit_result = vm.world_diff.decommit(
             world,
             destination_address,

--- a/src/instruction_handlers/far_call.rs
+++ b/src/instruction_handlers/far_call.rs
@@ -9,13 +9,12 @@ use crate::{
     fat_pointer::FatPointer,
     instruction::InstructionResult,
     predication::Flags,
-    vm::STORAGE_READ_STORAGE_APPLICATION_CYCLES,
     Instruction, VirtualMachine, World,
 };
 use u256::U256;
 use zkevm_opcode_defs::{
     system_params::{EVM_SIMULATOR_STIPEND, MSG_VALUE_SIMULATOR_ADDITIVE_COST},
-    Opcode, ADDRESS_MSG_VALUE, DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW,
+    Opcode, ADDRESS_MSG_VALUE,
 };
 
 #[repr(u8)]
@@ -60,23 +59,6 @@ fn far_call<const CALLING_MODE: u8, const IS_STATIC: bool, const IS_SHARD: bool>
     };
 
     let failing_part = (|| {
-        let address = zkevm_opcode_defs::ethereum_types::Address::from_low_u64_be(
-            DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW as u64,
-        );
-        if !vm
-            .world_diff
-            .written_storage_slots
-            .contains(&(address, destination_address))
-            && !vm
-                .world_diff
-                .read_storage_slots
-                .contains(&(address, destination_address))
-            && !world.is_free_storage_slot(&address, &destination_address)
-        {
-            println!("> new vm read: {address} {destination_address:x}");
-            vm.statistics.storage_application_cycles += STORAGE_READ_STORAGE_APPLICATION_CYCLES;
-        }
-
         let decommit_result = vm.world_diff.decommit(
             world,
             destination_address,

--- a/src/instruction_handlers/heap_access.rs
+++ b/src/instruction_handlers/heap_access.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use std::ops::Range;
 use u256::U256;
+use zkevm_opcode_defs::Opcode;
 
 pub trait HeapInterface {
     fn read_u256(&self, start_address: u32) -> U256;
@@ -181,6 +182,7 @@ use super::monomorphization::*;
 impl Instruction {
     #[inline(always)]
     pub fn from_load<H: HeapFromState>(
+        opcode: Opcode,
         src: RegisterOrImmediate,
         out: Register1,
         incremented_out: Option<Register2>,
@@ -194,6 +196,7 @@ impl Instruction {
         }
 
         Self {
+            opcode,
             handler: monomorphize!(load [H] match_reg_imm src match_boolean increment),
             arguments,
         }
@@ -201,6 +204,7 @@ impl Instruction {
 
     #[inline(always)]
     pub fn from_store<H: HeapFromState>(
+        opcode: Opcode,
         src1: RegisterOrImmediate,
         src2: Register2,
         incremented_out: Option<Register1>,
@@ -209,6 +213,7 @@ impl Instruction {
     ) -> Self {
         let increment = incremented_out.is_some();
         Self {
+            opcode,
             handler: monomorphize!(store [H] match_reg_imm src1 match_boolean increment match_boolean should_hook),
             arguments: arguments
                 .write_source(&src1)
@@ -219,6 +224,7 @@ impl Instruction {
 
     #[inline(always)]
     pub fn from_load_pointer(
+        opcode: Opcode,
         src: Register1,
         out: Register1,
         incremented_out: Option<Register2>,
@@ -226,6 +232,7 @@ impl Instruction {
     ) -> Self {
         let increment = incremented_out.is_some();
         Self {
+            opcode,
             handler: monomorphize!(load_pointer match_boolean increment),
             arguments: arguments
                 .write_source(&src)

--- a/src/instruction_handlers/jump.rs
+++ b/src/instruction_handlers/jump.rs
@@ -1,3 +1,5 @@
+use zkevm_opcode_defs::Opcode;
+
 use super::ret::INVALID_INSTRUCTION;
 use crate::{
     addressing_modes::{
@@ -31,8 +33,14 @@ fn jump<In: Source>(
 use super::monomorphization::*;
 
 impl Instruction {
-    pub fn from_jump(source: AnySource, destination: Register1, arguments: Arguments) -> Self {
+    pub fn from_jump(
+        opcode: Opcode,
+        source: AnySource,
+        destination: Register1,
+        arguments: Arguments,
+    ) -> Self {
         Self {
+            opcode,
             handler: monomorphize!(jump match_source source),
             arguments: arguments
                 .write_source(&source)

--- a/src/instruction_handlers/near_call.rs
+++ b/src/instruction_handlers/near_call.rs
@@ -1,3 +1,5 @@
+use zkevm_opcode_defs::Opcode;
+
 use super::ret::INVALID_INSTRUCTION;
 use crate::{
     addressing_modes::{Arguments, Immediate1, Immediate2, Register1, Source},
@@ -41,12 +43,14 @@ fn near_call(
 
 impl Instruction {
     pub fn from_near_call(
+        opcode: Opcode,
         gas: Register1,
         destination: Immediate1,
         error_handler: Immediate2,
         arguments: Arguments,
     ) -> Self {
         Self {
+            opcode,
             handler: near_call,
             arguments: arguments
                 .write_source(&gas)

--- a/src/instruction_handlers/nop.rs
+++ b/src/instruction_handlers/nop.rs
@@ -1,3 +1,5 @@
+use zkevm_opcode_defs::Opcode;
+
 use super::common::instruction_boilerplate;
 use crate::{
     addressing_modes::{destination_stack_address, AdvanceStackPointer, Arguments, Source},
@@ -23,11 +25,13 @@ fn nop(
 
 impl Instruction {
     pub fn from_nop(
+        opcode: Opcode,
         pop: AdvanceStackPointer,
         push: AdvanceStackPointer,
         arguments: Arguments,
     ) -> Self {
         Self {
+            opcode,
             handler: nop,
             arguments: arguments.write_source(&pop).write_destination(&push),
         }

--- a/src/instruction_handlers/pointer.rs
+++ b/src/instruction_handlers/pointer.rs
@@ -9,6 +9,7 @@ use crate::{
     Instruction, VirtualMachine, World,
 };
 use u256::U256;
+use zkevm_opcode_defs::Opcode;
 
 fn ptr<Op: PtrOp, In1: Source, Out: Destination, const SWAP: bool>(
     vm: &mut VirtualMachine,
@@ -94,6 +95,7 @@ use super::monomorphization::*;
 impl Instruction {
     #[inline(always)]
     pub fn from_ptr<Op: PtrOp>(
+        opcode: Opcode,
         src1: AnySource,
         src2: Register2,
         out: AnyDestination,
@@ -101,6 +103,7 @@ impl Instruction {
         swap: bool,
     ) -> Self {
         Self {
+            opcode,
             handler: monomorphize!(ptr [Op] match_source src1 match_destination out match_boolean swap),
             arguments: arguments
                 .write_source(&src1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use mode_requirements::ModeRequirements;
 pub use predication::Predicate;
 pub use program::Program;
 pub use state::State;
-pub use vm::{Settings, VirtualMachine, VmSnapshot as Snapshot};
+pub use vm::{CircuitCycleStatistic, Settings, VirtualMachine, VmSnapshot as Snapshot};
 pub use world_diff::{Event, L2ToL1Log, WorldDiff};
 
 #[cfg(feature = "single_instruction_test")]

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -1,4 +1,4 @@
-use std::collections::{btree_map::Keys, BTreeMap};
+use std::collections::BTreeMap;
 
 /// A trait for things that can be rolled back to snapshots
 pub(crate) trait Rollback {
@@ -33,10 +33,6 @@ impl<K: Ord + Clone, V: Clone> RollbackableMap<K, V> {
                 .or_insert((old_value.clone(), self.map.get(key).unwrap().clone()));
         }
         changes
-    }
-
-    pub fn keys(&self) -> Keys<K, V> {
-        self.map.keys()
     }
 }
 

--- a/src/rollback.rs
+++ b/src/rollback.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{btree_map::Keys, BTreeMap};
 
 /// A trait for things that can be rolled back to snapshots
 pub(crate) trait Rollback {
@@ -8,7 +8,7 @@ pub(crate) trait Rollback {
     fn delete_history(&mut self);
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RollbackableMap<K: Ord, V> {
     map: BTreeMap<K, V>,
     old_entries: Vec<(K, Option<V>)>,
@@ -33,6 +33,10 @@ impl<K: Ord + Clone, V: Clone> RollbackableMap<K, V> {
                 .or_insert((old_value.clone(), self.map.get(key).unwrap().clone()));
         }
         changes
+    }
+
+    pub fn keys(&self) -> Keys<K, V> {
+        self.map.keys()
     }
 }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -85,7 +85,7 @@ pub struct VirtualMachine {
     pub(crate) stack_pool: StackPool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct CircuitCycleStatistic {
     pub main_vm_cycles: u32,
     pub ram_permutation_cycles: u32,
@@ -253,6 +253,7 @@ impl VirtualMachine {
         VmSnapshot {
             world_snapshot: self.world_diff.external_snapshot(),
             state_snapshot: self.state.snapshot(),
+            statistics: self.statistics.clone(),
         }
     }
 
@@ -267,6 +268,7 @@ impl VirtualMachine {
         );
         self.world_diff.external_rollback(snapshot.world_snapshot);
         self.state.rollback(snapshot.state_snapshot);
+        self.statistics = snapshot.statistics;
     }
 
     /// This must only be called when it is known that the VM cannot be rolled back,
@@ -276,6 +278,7 @@ impl VirtualMachine {
     pub fn delete_history(&mut self) {
         self.world_diff.delete_history();
         self.state.delete_history();
+        self.statistics = CircuitCycleStatistic::default();
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -397,6 +400,7 @@ impl VirtualMachine {
         self.statistics.main_vm_cycles += 1;
 
         let opcode = unsafe { (*instruction).opcode };
+        dbg!(opcode);
         match opcode {
             Opcode::Nop(_)
             | Opcode::Add(_)
@@ -477,4 +481,5 @@ impl VirtualMachine {
 pub struct VmSnapshot {
     world_snapshot: ExternalSnapshot,
     state_snapshot: StateSnapshot,
+    statistics: CircuitCycleStatistic,
 }

--- a/src/world_diff.rs
+++ b/src/world_diff.rs
@@ -26,8 +26,8 @@ pub struct WorldDiff {
 
     // The fields below are only rolled back when the whole VM is rolled back.
     pub(crate) decommitted_hashes: RollbackableSet<U256>,
-    read_storage_slots: RollbackableSet<(H160, U256)>,
-    written_storage_slots: RollbackableSet<(H160, U256)>,
+    pub read_storage_slots: RollbackableSet<(H160, U256)>,
+    pub written_storage_slots: RollbackableSet<(H160, U256)>,
 
     // This is never rolled back. It is just a cache to avoid asking these from DB every time.
     storage_initial_values: BTreeMap<(H160, U256), Option<U256>>,
@@ -106,9 +106,10 @@ impl WorldDiff {
         {
             WARM_READ_REFUND
         } else {
-            self.read_storage_slots.add((contract, key));
             0
         };
+        self.read_storage_slots.add((contract, key));
+
         self.pubdata_costs.push(0);
         (value, refund)
     }
@@ -128,6 +129,7 @@ impl WorldDiff {
             .entry((contract, key))
             .or_insert_with(|| world.read_storage(contract, key));
 
+        self.written_storage_slots.add((contract, key));
         if world.is_free_storage_slot(&contract, &key) {
             self.storage_refunds.push(WARM_WRITE_REFUND);
             self.pubdata_costs.push(0);


### PR DESCRIPTION
Statistics counting code implemented without the new tracer interface. Later has to be moved there. Only problem so far:
unimplemented static memory instructions lead to divergency on `zksync_state_keeper batch_executor::tests::bootloader_out_of_gas_for_any_tx` test because the way this patch substitutes unimplemented instructions with nop opcodes is wrong. This problem is supposed to go away with the new tracer interface hopefully.
