### PR TITLE
fix: Fix decommitment cost divergence

### DIFF
--- a/eravm-stable-interface/src/tracer_interface.rs
+++ b/eravm-stable-interface/src/tracer_interface.rs
@@ -53,17 +53,18 @@ macro_rules! pub_struct {
 }
 
 pub mod opcodes {
+    use super::{CallingMode, ReturnType};
+    use std::marker::PhantomData;
+
     forall_simple_opcodes!(pub_struct);
-    pub struct FarCall<M: TypeLevelCallingMode>(M);
-    pub struct Ret<T: TypeLevelReturnType>(T);
+    pub struct FarCall<M: TypeLevelCallingMode>(PhantomData<M>);
+    pub struct Ret<T: TypeLevelReturnType>(PhantomData<T>);
 
     pub struct Normal;
     pub struct Delegate;
     pub struct Mimic;
     pub struct Revert;
     pub struct Panic;
-
-    use super::{CallingMode, ReturnType};
 
     pub trait TypeLevelCallingMode {
         const VALUE: CallingMode;

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -10,7 +10,7 @@ use eravm_stable_interface::HeapId;
 use u256::H160;
 use zkevm_opcode_defs::system_params::{NEW_FRAME_MEMORY_STIPEND, NEW_KERNEL_FRAME_MEMORY_STIPEND};
 
-#[derive(PartialEq, Debug)]
+#[derive(Debug)]
 pub struct Callframe<T, W> {
     pub address: H160,
     pub code_address: H160,
@@ -257,5 +257,30 @@ impl<T, W> Clone for Callframe<T, W> {
             heaps_i_am_keeping_alive: self.heaps_i_am_keeping_alive.clone(),
             world_before_this_frame: self.world_before_this_frame.clone(),
         }
+    }
+}
+
+impl<T, W> PartialEq for Callframe<T, W> {
+    fn eq(&self, other: &Self) -> bool {
+        self.address == other.address
+            && self.code_address == other.code_address
+            && self.caller == other.caller
+            && self.exception_handler == other.exception_handler
+            && self.context_u128 == other.context_u128
+            && self.is_static == other.is_static
+            && self.stack == other.stack
+            && self.sp == other.sp
+            && self.gas == other.gas
+            && self.stipend == other.stipend
+            && self.near_calls == other.near_calls
+            && self.pc == other.pc
+            && self.program == other.program
+            && self.heap == other.heap
+            && self.aux_heap == other.aux_heap
+            && self.heap_size == other.heap_size
+            && self.aux_heap_size == other.aux_heap_size
+            && self.calldata_heap == other.calldata_heap
+            && self.heaps_i_am_keeping_alive == other.heaps_i_am_keeping_alive
+            && self.world_before_this_frame == other.world_before_this_frame
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use u256::{H160, U256};
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Debug)]
 pub struct State<T, W> {
     pub registers: [U256; 16],
     pub(crate) register_pointer_flags: u16,
@@ -143,6 +143,34 @@ impl<T, W> State<T, W> {
 
     pub(crate) fn delete_history(&mut self) {
         self.heaps.delete_history();
+    }
+}
+
+impl<T, W> Clone for State<T, W> {
+    fn clone(&self) -> Self {
+        Self {
+            registers: self.registers,
+            register_pointer_flags: self.register_pointer_flags,
+            flags: self.flags.clone(),
+            current_frame: self.current_frame.clone(),
+            previous_frames: self.previous_frames.clone(),
+            heaps: self.heaps.clone(),
+            transaction_number: self.transaction_number,
+            context_u128: self.context_u128,
+        }
+    }
+}
+
+impl<T, W> PartialEq for State<T, W> {
+    fn eq(&self, other: &Self) -> bool {
+        self.registers == other.registers
+            && self.register_pointer_flags == other.register_pointer_flags
+            && self.flags == other.flags
+            && self.transaction_number == other.transaction_number
+            && self.context_u128 == other.context_u128
+            && self.current_frame == other.current_frame
+            && self.previous_frames == other.previous_frames
+            && self.heaps == other.heaps
     }
 }
 

--- a/src/testworld.rs
+++ b/src/testworld.rs
@@ -9,6 +9,7 @@ use zkevm_opcode_defs::{
     ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW,
 };
 
+#[derive(Debug)]
 pub struct TestWorld<T> {
     pub address_to_hash: BTreeMap<U256, U256>,
     pub hash_to_contract: BTreeMap<U256, Program<T, Self>>,

--- a/tests/far_call_decommitment.rs
+++ b/tests/far_call_decommitment.rs
@@ -1,0 +1,196 @@
+#![cfg(not(feature = "single_instruction_test"))]
+
+use eravm_stable_interface::opcodes;
+use std::collections::HashSet;
+use u256::{H160, U256};
+use vm2::addressing_modes::{
+    Arguments, CodePage, Immediate1, Register, Register1, Register2, RegisterAndImmediate,
+};
+use vm2::instruction_handlers::Heap;
+use vm2::testworld::TestWorld;
+use vm2::{
+    initial_decommit, ExecutionEnd, Instruction, ModeRequirements, Predicate, Program,
+    VirtualMachine,
+};
+use zkevm_opcode_defs::ethereum_types::Address;
+
+const GAS_TO_PASS: u32 = 10_000;
+const LARGE_BYTECODE_LEN: usize = 10_000;
+const MAIN_ADDRESS: Address = Address::repeat_byte(0x23);
+const CALLED_ADDRESS: Address = H160([
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xee, 0xee, 0xee, 0xee,
+]);
+
+fn create_test_world() -> TestWorld<()> {
+    let r0 = Register::new(0);
+    let r1 = Register::new(1);
+    let r2 = Register::new(2);
+
+    let mut abi = U256::zero();
+    abi.0[3] = GAS_TO_PASS.into();
+
+    let main_program = Program::new(
+        vec![
+            // 0..=2: Prepare and execute far call
+            Instruction::from_binop::<opcodes::Add>(
+                CodePage(RegisterAndImmediate {
+                    immediate: 0,
+                    register: r0,
+                })
+                .into(),
+                Register2(r0),
+                Register1(r1).into(),
+                (),
+                Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
+                false,
+                false,
+            ),
+            Instruction::from_binop::<opcodes::Add>(
+                CodePage(RegisterAndImmediate {
+                    immediate: 1,
+                    register: r0,
+                })
+                .into(),
+                Register2(r0),
+                Register1(r2).into(),
+                (),
+                Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
+                false,
+                false,
+            ),
+            Instruction::from_far_call::<opcodes::Normal>(
+                Register1(r1),
+                Register2(r2),
+                Immediate1(5), // revert exception handler
+                false,
+                false,
+                Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+            ),
+            // 3: Hook (0)
+            Instruction::from_store::<Heap>(
+                Register1(r0).into(),
+                Register2(r0),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+                true,
+            ),
+            // 4: Jump to program start
+            Instruction::from_jump(
+                Immediate1(0).into(),
+                Register1(r0),
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+            ),
+            // 5: Revert exception handler
+            Instruction::from_revert(
+                Register1(r0),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+            ),
+        ],
+        vec![abi, CALLED_ADDRESS.to_low_u64_be().into()],
+    );
+
+    let called_program = Program::new(
+        vec![
+            Instruction::from_binop::<opcodes::Add>(
+                Register1(r0).into(),
+                Register2(r0),
+                Register1(r0).into(),
+                (),
+                Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
+                false,
+                false,
+            ),
+            Instruction::from_ret(
+                Register1(Register::new(0)),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+            ),
+        ],
+        vec![U256::zero(); LARGE_BYTECODE_LEN],
+    );
+
+    TestWorld::new(&[
+        (CALLED_ADDRESS, called_program),
+        (MAIN_ADDRESS, main_program),
+    ])
+}
+
+#[test]
+fn test() {
+    let mut world = create_test_world();
+    let main_program = initial_decommit(&mut world, MAIN_ADDRESS);
+    let initial_gas = 1_000_000;
+    let mut vm = VirtualMachine::new(
+        MAIN_ADDRESS,
+        main_program,
+        Address::zero(),
+        vec![],
+        initial_gas,
+        vm2::Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+        },
+    );
+
+    let result = vm.run(&mut world, &mut ());
+    let remaining_gas = vm.state.current_frame.gas;
+    assert_eq!(result, ExecutionEnd::SuspendedOnHook(0));
+    let expected_decommit_cost = LARGE_BYTECODE_LEN as u32 * 4;
+    assert!(
+        remaining_gas < initial_gas - expected_decommit_cost,
+        "{remaining_gas}"
+    );
+
+    // Check that the decommitment is not charged when the decommitment happens the second time.
+    vm.run(&mut world, &mut ());
+    let new_remaining_gas = vm.state.current_frame.gas;
+    assert_eq!(result, ExecutionEnd::SuspendedOnHook(0));
+    assert!(
+        remaining_gas - new_remaining_gas < expected_decommit_cost,
+        "{remaining_gas}, {new_remaining_gas}"
+    );
+}
+
+#[test]
+fn test_with_initial_out_of_gas_error() {
+    let mut world = create_test_world();
+    let main_program = initial_decommit(&mut world, MAIN_ADDRESS);
+    let mut vm = VirtualMachine::new(
+        MAIN_ADDRESS,
+        main_program,
+        Address::zero(),
+        vec![],
+        10_000,
+        vm2::Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+        },
+    );
+
+    let result = vm.run(&mut world, &mut ());
+    assert_eq!(result, ExecutionEnd::Reverted(vec![]));
+    // Unsuccessful decommit should still be returned in `decommitted_hashes()`
+    let decommitted: HashSet<_> = vm.world_diff.decommitted_hashes().collect();
+    let called_bytecode_hash = world.address_to_hash[&CALLED_ADDRESS.to_low_u64_be().into()];
+    assert!(
+        decommitted.contains(&called_bytecode_hash),
+        "{decommitted:?}"
+    );
+
+    // Recover the VM and increase the amount of gas passed to the far call.
+    vm.state.current_frame.set_pc_from_u16(0);
+    vm.state.current_frame.gas = 1_000_000;
+
+    let initial_gas = vm.state.current_frame.gas;
+    let result = vm.run(&mut world, &mut ());
+    let remaining_gas = vm.state.current_frame.gas;
+    assert_eq!(result, ExecutionEnd::SuspendedOnHook(0));
+    let expected_decommit_cost = LARGE_BYTECODE_LEN as u32 * 4;
+    assert!(
+        remaining_gas < initial_gas - expected_decommit_cost,
+        "{remaining_gas}"
+    );
+}

--- a/tests/stipend.rs
+++ b/tests/stipend.rs
@@ -97,7 +97,7 @@ fn test_scenario(gas_to_pass: u32) -> (ExecutionEnd, u32) {
         (interpreter_address, interpreter),
         (main_address, main_program),
     ]);
-    let intepreter_hash = world.address_to_hash[&address_into_u256(interpreter_address)].into();
+    let interpreter_hash = world.address_to_hash[&address_into_u256(interpreter_address)].into();
 
     let mut ethereum_hash = [0; 32];
     ethereum_hash[0] = 2;
@@ -115,7 +115,7 @@ fn test_scenario(gas_to_pass: u32) -> (ExecutionEnd, u32) {
         INITIAL_GAS,
         vm2::Settings {
             default_aa_code_hash: [0; 32],
-            evm_interpreter_code_hash: intepreter_hash,
+            evm_interpreter_code_hash: interpreter_hash,
             hook_address: 0,
         },
     );


### PR DESCRIPTION
# What ❔

Fixes decommitment cost divergence introduced after fixing the previous VM divergence.

## Why ❔

As of now, bytecode decommitment cost is now not charged even if decommitment failed; this is incorrect. The easiest fix implemented in this PR is to track decommitment status (successful / failed) for all bytecodes.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and `cargo clippy`.