### PR TITLE
refactor: Brush up repo for publishing (pt. 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# High-Performance ZKsync Era VM
+# High-Performance ZKsync Era VM (EraVM)
 
-A high-performance rewrite of the out-of-circuit VM for ZKsync Era.
+A high-performance rewrite of the out-of-circuit VM for ZKsync Era (aka EraVM).
+
+See [Era docs](https://github.com/matter-labs/zksync-era/tree/main/docs/specs/zk_evm) for the VM overview and formal specification.
 
 ## Overview
 

--- a/crates/vm2-interface/README.md
+++ b/crates/vm2-interface/README.md
@@ -1,6 +1,6 @@
 # Stable Interface for ZKsync Era VM
 
-This library provides a stable interface for the EraVM. It defines an interface for tracers that will never change but may be extended.
+This library provides a stable interface for EraVM. It defines an interface for tracers that will never change but may be extended.
 
 ## License
 

--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -10,7 +10,13 @@ pub trait StateInterface {
     fn callframe(&mut self, n: usize) -> impl CallframeInterface + '_;
 
     fn read_heap_byte(&self, heap: HeapId, index: u32) -> u8;
+    /// Reads an entire `U256` word in the big-endian order from the specified heap page / `index`
+    /// (which is the index of the most significant byte of the read value).
+    fn read_heap_u256(&self, heap: HeapId, index: u32) -> U256;
     fn write_heap_byte(&mut self, heap: HeapId, index: u32, byte: u8);
+    /// Writes an entire `U256` word in the big-endian order to the specified heap page at the specified `index`
+    /// (which is the index of the most significant byte of the written value).
+    fn write_heap_u256(&mut self, heap: HeapId, index: u32, value: U256);
 
     fn flags(&self) -> Flags;
     fn set_flags(&mut self, flags: Flags);
@@ -135,11 +141,11 @@ pub struct DummyState;
 
 #[cfg(test)]
 impl StateInterface for DummyState {
-    fn read_register(&self, _: u8) -> (primitive_types::U256, bool) {
+    fn read_register(&self, _: u8) -> (U256, bool) {
         unimplemented!()
     }
 
-    fn set_register(&mut self, _: u8, _: primitive_types::U256, _: bool) {
+    fn set_register(&mut self, _: u8, _: U256, _: bool) {
         unimplemented!()
     }
 
@@ -151,23 +157,31 @@ impl StateInterface for DummyState {
         unimplemented!()
     }
 
-    fn callframe(&mut self, _: usize) -> impl crate::CallframeInterface + '_ {
+    fn callframe(&mut self, _: usize) -> impl CallframeInterface + '_ {
         DummyState
     }
 
-    fn read_heap_byte(&self, _: crate::HeapId, _: u32) -> u8 {
+    fn read_heap_byte(&self, _: HeapId, _: u32) -> u8 {
         unimplemented!()
     }
 
-    fn write_heap_byte(&mut self, _: crate::HeapId, _: u32, _: u8) {
+    fn read_heap_u256(&self, _: HeapId, _: u32) -> U256 {
         unimplemented!()
     }
 
-    fn flags(&self) -> crate::Flags {
+    fn write_heap_byte(&mut self, _: HeapId, _: u32, _: u8) {
         unimplemented!()
     }
 
-    fn set_flags(&mut self, _: crate::Flags) {
+    fn write_heap_u256(&mut self, _: HeapId, _: u32, _: U256) {
+        unimplemented!()
+    }
+
+    fn flags(&self) -> Flags {
+        unimplemented!()
+    }
+
+    fn set_flags(&mut self, _: Flags) {
         unimplemented!()
     }
 
@@ -187,42 +201,19 @@ impl StateInterface for DummyState {
         unimplemented!()
     }
 
-    fn get_storage_state(
-        &self,
-    ) -> impl Iterator<
-        Item = (
-            (primitive_types::H160, primitive_types::U256),
-            primitive_types::U256,
-        ),
-    > {
+    fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
         std::iter::empty()
     }
 
-    fn get_transient_storage_state(
-        &self,
-    ) -> impl Iterator<
-        Item = (
-            (primitive_types::H160, primitive_types::U256),
-            primitive_types::U256,
-        ),
-    > {
+    fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
         std::iter::empty()
     }
 
-    fn get_transient_storage(
-        &self,
-        _: primitive_types::H160,
-        _: primitive_types::U256,
-    ) -> primitive_types::U256 {
+    fn get_transient_storage(&self, _: H160, _: U256) -> U256 {
         unimplemented!()
     }
 
-    fn write_transient_storage(
-        &mut self,
-        _: primitive_types::H160,
-        _: primitive_types::U256,
-        _: primitive_types::U256,
-    ) {
+    fn write_transient_storage(&mut self, _: H160, _: U256, _: U256) {
         unimplemented!()
     }
 
@@ -245,27 +236,27 @@ impl StateInterface for DummyState {
 
 #[cfg(test)]
 impl CallframeInterface for DummyState {
-    fn address(&self) -> primitive_types::H160 {
+    fn address(&self) -> H160 {
         unimplemented!()
     }
 
-    fn set_address(&mut self, _: primitive_types::H160) {
+    fn set_address(&mut self, _: H160) {
         unimplemented!()
     }
 
-    fn code_address(&self) -> primitive_types::H160 {
+    fn code_address(&self) -> H160 {
         unimplemented!()
     }
 
-    fn set_code_address(&mut self, _: primitive_types::H160) {
+    fn set_code_address(&mut self, _: H160) {
         unimplemented!()
     }
 
-    fn caller(&self) -> primitive_types::H160 {
+    fn caller(&self) -> H160 {
         unimplemented!()
     }
 
-    fn set_caller(&mut self, _: primitive_types::H160) {
+    fn set_caller(&mut self, _: H160) {
         unimplemented!()
     }
 
@@ -317,11 +308,11 @@ impl CallframeInterface for DummyState {
         unimplemented!()
     }
 
-    fn read_stack(&self, _: u16) -> (primitive_types::U256, bool) {
+    fn read_stack(&self, _: u16) -> (U256, bool) {
         unimplemented!()
     }
 
-    fn write_stack(&mut self, _: u16, _: primitive_types::U256, _: bool) {
+    fn write_stack(&mut self, _: u16, _: U256, _: bool) {
         unimplemented!()
     }
 
@@ -357,7 +348,7 @@ impl CallframeInterface for DummyState {
         unimplemented!()
     }
 
-    fn read_code_page(&self, _: u16) -> primitive_types::U256 {
+    fn read_code_page(&self, _: u16) -> U256 {
         unimplemented!()
     }
 }

--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -13,7 +13,6 @@ pub trait StateInterface {
     /// Reads an entire `U256` word in the big-endian order from the specified heap page / `index`
     /// (which is the index of the most significant byte of the read value).
     fn read_heap_u256(&self, heap: HeapId, index: u32) -> U256;
-    fn write_heap_byte(&mut self, heap: HeapId, index: u32, byte: u8);
     /// Writes an entire `U256` word in the big-endian order to the specified heap page at the specified `index`
     /// (which is the index of the most significant byte of the written value).
     fn write_heap_u256(&mut self, heap: HeapId, index: u32, value: U256);
@@ -166,10 +165,6 @@ impl StateInterface for DummyState {
     }
 
     fn read_heap_u256(&self, _: HeapId, _: u32) -> U256 {
-        unimplemented!()
-    }
-
-    fn write_heap_byte(&mut self, _: HeapId, _: u32, _: u8) {
         unimplemented!()
     }
 

--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -55,6 +55,7 @@ pub trait CallframeInterface {
     fn set_program_counter(&mut self, value: u16);
 
     fn exception_handler(&self) -> u16;
+    fn set_exception_handler(&mut self, value: u16);
 
     fn is_static(&self) -> bool;
     fn is_kernel(&self) -> bool;
@@ -85,16 +86,25 @@ pub trait CallframeInterface {
     fn read_code_page(&self, slot: u16) -> U256;
 }
 
+/// Identifier of a VM heap page.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct HeapId(u32);
 
 impl HeapId {
+    /// Identifier of the calldata heap page used by the first executed program (i.e., the bootloader).
+    pub const FIRST_CALLDATA: Self = Self(1);
+    /// Identifier of the heap page used by the first executed program (i.e., the bootloader).
+    pub const FIRST: Self = Self(2);
+    /// Identifier of the auxiliary heap page used by the first executed program (i.e., the bootloader)
+    pub const FIRST_AUX: Self = Self(3);
+
     /// Only for dealing with external data structures, never use internally.
+    #[doc(hidden)]
     pub const fn from_u32_unchecked(value: u32) -> Self {
         Self(value)
     }
 
-    pub const fn to_u32(self) -> u32 {
+    pub const fn as_u32(self) -> u32 {
         self.0
     }
 }
@@ -268,6 +278,10 @@ impl CallframeInterface for DummyState {
     }
 
     fn exception_handler(&self) -> u16 {
+        unimplemented!()
+    }
+
+    fn set_exception_handler(&mut self, _: u16) {
         unimplemented!()
     }
 

--- a/crates/vm2/src/addressing_modes.rs
+++ b/crates/vm2/src/addressing_modes.rs
@@ -1,4 +1,4 @@
-//! Addressing modes supported by the ZKsync Era VM.
+//! Addressing modes supported by EraVM.
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::{Arbitrary, Unstructured};
@@ -87,6 +87,7 @@ impl<T: DestinationWriter> DestinationWriter for Option<T> {
     }
 }
 
+/// Argument provided to an instruction in an EraVM bytecode.
 // It is important for performance that this fits into 8 bytes.
 #[derive(Debug)]
 pub struct Arguments {
@@ -169,13 +170,16 @@ impl Arguments {
     }
 }
 
-/// First register. This addressing mode should only be used when [`Register2`] is used as well.
+/// Register passed as a first instruction argument.
 ///
-/// It must not be used simultaneously with [`AbsoluteStack`] or [`RelativeStack`].
+/// It must not be used simultaneously with [`AbsoluteStack`], [`RelativeStack`], [`AdvanceStackPointer`],
+/// or [`CodePage`].
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct Register1(pub Register);
 
-/// Second register.
+/// Register passed as a second instruction argument.
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct Register2(pub Register);
 
@@ -238,10 +242,12 @@ impl DestinationWriter for Register2 {
 }
 
 /// Immediate value passed as a first instruction arg.
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct Immediate1(pub u16);
 
 /// Immediate value passed as a second instruction arg.
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct Immediate2(pub u16);
 
@@ -368,6 +374,7 @@ impl StackAddressing for AbsoluteStack {
 }
 
 /// Relative addressing into stack (relative to the VM stack pointer).
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct RelativeStack(pub RegisterAndImmediate);
 
@@ -393,7 +400,7 @@ impl StackAddressing for RelativeStack {
 
 /// Same as [`RelativeStack`], but moves the stack pointer on access (decreases it when reading data;
 /// increases when writing data).
-#[derive(Clone)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct AdvanceStackPointer(pub RegisterAndImmediate);
 
@@ -421,6 +428,7 @@ impl StackAddressing for AdvanceStackPointer {
 }
 
 /// Absolute addressing into the code page of the currently executing program.
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct CodePage(pub RegisterAndImmediate);
 
@@ -448,7 +456,7 @@ pub struct Register(u8);
 impl Register {
     /// Creates a register with the specified 0-based index.
     pub const fn new(n: u8) -> Self {
-        assert!(n < 16, "Era VM has 16 registers");
+        assert!(n < 16, "EraVM has 16 registers");
         Self(n)
     }
 
@@ -504,6 +512,7 @@ impl PackedRegisters {
 
 /// All supported addressing modes for source arguments.
 #[enum_dispatch(SourceWriter)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum AnySource {
     Register1,
@@ -516,6 +525,7 @@ pub enum AnySource {
 
 /// Register or immediate addressing modes required by some VM instructions.
 #[enum_dispatch(SourceWriter)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum RegisterOrImmediate {
     Register1,
@@ -540,6 +550,7 @@ impl TryFrom<AnySource> for RegisterOrImmediate {
 
 /// All supported addressing modes for destination arguments.
 #[enum_dispatch(DestinationWriter)]
+#[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub enum AnyDestination {
     Register1,

--- a/crates/vm2/src/callframe.rs
+++ b/crates/vm2/src/callframe.rs
@@ -12,46 +12,36 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct Callframe<T, W> {
-    pub address: H160,
-    pub code_address: H160,
-    pub caller: H160,
-
-    pub exception_handler: u16,
-    pub context_u128: u128,
-    pub is_static: bool,
-    pub is_kernel: bool,
-
+pub(crate) struct Callframe<T, W> {
+    pub(crate) address: H160,
+    pub(crate) code_address: H160,
+    pub(crate) caller: H160,
+    pub(crate) exception_handler: u16,
+    pub(crate) context_u128: u128,
+    pub(crate) is_static: bool,
+    pub(crate) is_kernel: bool,
     pub(crate) stack: Box<Stack>,
-    pub sp: u16,
-
-    pub gas: u32,
-    pub stipend: u32,
-
+    pub(crate) sp: u16,
+    pub(crate) gas: u32,
+    pub(crate) stipend: u32,
     pub(crate) near_calls: Vec<NearCallFrame>,
-
     pub(crate) pc: *const Instruction<T, W>,
     pub(crate) program: Program<T, W>,
-
-    pub heap: HeapId,
-    pub aux_heap: HeapId,
-
+    pub(crate) heap: HeapId,
+    pub(crate) aux_heap: HeapId,
     /// The amount of heap that has been paid for. This should always be greater
     /// or equal to the actual size of the heap in memory.
-    pub heap_size: u32,
-    pub aux_heap_size: u32,
-
+    pub(crate) heap_size: u32,
+    pub(crate) aux_heap_size: u32,
     /// Returning a pointer to the calldata is illegal because it could result in
     /// the caller's heap being accessible both directly and via the fat pointer.
     /// The problem only occurs if the calldata originates from the caller's heap
     /// but this rule is easy to implement.
     pub(crate) calldata_heap: HeapId,
-
     /// Because of the above rule we know that heaps returned to this frame only
     /// exist to allow this frame to read from them. Therefore we can deallocate
     /// all of them upon return, except possibly one that we pass on.
     pub(crate) heaps_i_am_keeping_alive: Vec<HeapId>,
-
     pub(crate) world_before_this_frame: Snapshot,
 }
 

--- a/crates/vm2/src/decode.rs
+++ b/crates/vm2/src/decode.rs
@@ -346,7 +346,7 @@ pub(crate) fn decode<T: Tracer, W: World<T>>(raw: u64, is_bootloader: bool) -> I
                 if let AnySource::AdvanceStackPointer(pop) = src1 {
                     pop
                 } else {
-                    no_sp_movement.clone()
+                    no_sp_movement
                 },
                 if let AnyDestination::AdvanceStackPointer(push) = out {
                     push

--- a/crates/vm2/src/instruction_handlers/precompiles.rs
+++ b/crates/vm2/src/instruction_handlers/precompiles.rs
@@ -41,10 +41,10 @@ fn precompile_call<T: Tracer, W>(
 
         let mut abi = PrecompileCallABI::from_u256(Register1::get(args, &mut vm.state));
         if abi.memory_page_to_read == 0 {
-            abi.memory_page_to_read = vm.state.current_frame.heap.to_u32();
+            abi.memory_page_to_read = vm.state.current_frame.heap.as_u32();
         }
         if abi.memory_page_to_write == 0 {
-            abi.memory_page_to_write = vm.state.current_frame.heap.to_u32();
+            abi.memory_page_to_write = vm.state.current_frame.heap.as_u32();
         }
 
         let query = LogQuery {

--- a/crates/vm2/src/lib.rs
+++ b/crates/vm2/src/lib.rs
@@ -11,12 +11,10 @@ pub(crate) use self::single_instruction_test::{heap, program, stack};
 pub use self::{
     decommit::{address_into_u256, initial_decommit},
     fat_pointer::FatPointer,
-    heap::FIRST_HEAP,
     instruction::{ExecutionEnd, Instruction},
     mode_requirements::ModeRequirements,
     predication::Predicate,
     program::Program,
-    state::State,
     vm::{Settings, VirtualMachine, VmSnapshot as Snapshot},
     world_diff::{Event, L2ToL1Log, WorldDiff},
 };

--- a/crates/vm2/src/program.rs
+++ b/crates/vm2/src/program.rs
@@ -4,7 +4,7 @@ use primitive_types::U256;
 
 use crate::{hash_for_debugging, Instruction};
 
-/// Compiled ZKsync Era VM bytecode.
+/// Compiled EraVM bytecode.
 ///
 /// Cloning this is cheap. It is a handle to memory similar to [`Arc`].
 pub struct Program<T, W> {

--- a/crates/vm2/src/rollback.rs
+++ b/crates/vm2/src/rollback.rs
@@ -8,7 +8,7 @@ pub(crate) trait Rollback {
     fn delete_history(&mut self);
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(crate) struct RollbackableMap<K: Ord, V> {
     map: BTreeMap<K, V>,
     old_entries: Vec<(K, Option<V>)>,
@@ -149,7 +149,7 @@ impl<T> AsRef<[T]> for RollbackableLog<T> {
 }
 
 /// Rollbackable Plain Old Data simply stores copies of itself in snapshots.
-#[derive(Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 pub(crate) struct RollbackablePod<T: Copy>(pub T);
 
 impl<T: Copy> Rollback for RollbackablePod<T> {

--- a/crates/vm2/src/single_instruction_test/callframe.rs
+++ b/crates/vm2/src/single_instruction_test/callframe.rs
@@ -3,10 +3,7 @@ use primitive_types::H160;
 use zkevm_opcode_defs::EVM_SIMULATOR_STIPEND;
 use zksync_vm2_interface::Tracer;
 
-use super::{
-    heap::FIRST_AUX_HEAP,
-    stack::{Stack, StackPool},
-};
+use super::stack::{Stack, StackPool};
 use crate::{
     callframe::Callframe, decommit::is_kernel, predication::Flags, HeapId, Program, World,
     WorldDiff,
@@ -88,8 +85,8 @@ impl<T: Tracer, W> Callframe<T, W> {
             near_calls: vec![],
             pc: std::ptr::null(),
             program: Program::for_decommit(),
-            heap: FIRST_AUX_HEAP,
-            aux_heap: FIRST_AUX_HEAP,
+            heap: HeapId::FIRST_AUX,
+            aux_heap: HeapId::FIRST_AUX,
             heap_size: 0,
             aux_heap_size: 0,
             calldata_heap: HeapId::from_u32_unchecked(1),

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -101,10 +101,6 @@ impl Heaps {
     pub(crate) fn delete_history(&mut self) {
         unimplemented!()
     }
-
-    pub(crate) fn write_byte(&mut self, _: HeapId, _: u32, _: u8) {
-        unimplemented!()
-    }
 }
 
 impl Index<HeapId> for Heaps {

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -57,10 +57,6 @@ pub struct Heaps {
     pub(crate) read: MockRead<HeapId, Heap>,
 }
 
-pub(crate) const CALLDATA_HEAP: HeapId = HeapId::from_u32_unchecked(1);
-pub const FIRST_HEAP: HeapId = HeapId::from_u32_unchecked(2);
-pub(crate) const FIRST_AUX_HEAP: HeapId = HeapId::from_u32_unchecked(3);
-
 impl Heaps {
     pub(crate) fn new(_: &[u8]) -> Self {
         unimplemented!("Should use arbitrary heap, not fresh heap in testing.")

--- a/crates/vm2/src/single_instruction_test/into_zk_evm.rs
+++ b/crates/vm2/src/single_instruction_test/into_zk_evm.rs
@@ -62,7 +62,7 @@ pub fn add_heap_to_zk_evm<T, W>(
             value.reverse();
 
             zk_evm.memory.heap_read = Some(ExpectedHeapValue {
-                heap: heapid.to_u32(),
+                heap: heapid.as_u32(),
                 start_index,
                 value,
             });
@@ -72,7 +72,7 @@ pub fn add_heap_to_zk_evm<T, W>(
             value_u256.to_big_endian(&mut value);
 
             zk_evm.memory.heap_write = Some(ExpectedHeapValue {
-                heap: heapid.to_u32(),
+                heap: heapid.as_u32(),
                 start_index,
                 value,
             });

--- a/crates/vm2/src/single_instruction_test/print_mock_info.rs
+++ b/crates/vm2/src/single_instruction_test/print_mock_info.rs
@@ -1,4 +1,4 @@
-use crate::{callframe::Callframe, State, VirtualMachine};
+use crate::{callframe::Callframe, state::State, VirtualMachine};
 
 impl<T, W> VirtualMachine<T, W> {
     pub fn print_mock_info(&self) {

--- a/crates/vm2/src/single_instruction_test/state_to_zk_evm.rs
+++ b/crates/vm2/src/single_instruction_test/state_to_zk_evm.rs
@@ -8,11 +8,15 @@ use zk_evm::{
 use zkevm_opcode_defs::decoding::EncodingModeProduction;
 use zksync_vm2_interface::Tracer;
 
-use crate::callframe::{Callframe, NearCallFrame};
+use crate::{
+    callframe::{Callframe, NearCallFrame},
+    state::State,
+    Instruction,
+};
 
 pub(crate) fn vm2_state_to_zk_evm_state<T: Tracer, W>(
-    state: &crate::State<T, W>,
-    panic: &crate::Instruction<T, W>,
+    state: &State<T, W>,
+    panic: &Instruction<T, W>,
 ) -> VmLocalState<8, EncodingModeProduction> {
     // zk_evm requires an unused bottom frame
     let mut callframes: Vec<_> = iter::once(CallStackEntry::empty_context())
@@ -67,7 +71,7 @@ fn vm2_frame_to_zk_evm_frames<T, W>(
         this_address: frame.address,
         msg_sender: frame.caller,
         code_address: frame.code_address,
-        base_memory_page: MemoryPage(frame.heap.to_u32() - 2),
+        base_memory_page: MemoryPage(frame.heap.as_u32() - 2),
         code_page: MemoryPage(0), // TODO
         sp: frame.sp,
         pc: 0,

--- a/crates/vm2/src/single_instruction_test/validation.rs
+++ b/crates/vm2/src/single_instruction_test/validation.rs
@@ -1,6 +1,6 @@
 use primitive_types::U256;
 
-use crate::{callframe::Callframe, fat_pointer::FatPointer, State};
+use crate::{callframe::Callframe, fat_pointer::FatPointer, state::State};
 
 pub(crate) fn is_valid_tagged_value((value, is_pointer): (U256, bool)) -> bool {
     if is_pointer {

--- a/crates/vm2/src/single_instruction_test/vm.rs
+++ b/crates/vm2/src/single_instruction_test/vm.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use arbitrary::Arbitrary;
 use primitive_types::U256;
 use zksync_vm2_interface::Tracer;
@@ -43,13 +41,6 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
     /// Returns a raw first instruction in the current call frame.
     pub fn raw_first_instruction(&self) -> u64 {
         self.state.current_frame.program.raw_first_instruction
-    }
-}
-
-impl<T: fmt::Debug, W: fmt::Debug> VirtualMachine<T, W> {
-    /// Returns debuggable representation of the current VM state.
-    pub fn dump_state(&self) -> impl fmt::Debug + '_ {
-        &self.state
     }
 }
 

--- a/crates/vm2/src/stack.rs
+++ b/crates/vm2/src/stack.rs
@@ -105,8 +105,8 @@ impl Clone for Box<Stack> {
     }
 }
 
-#[derive(Default)]
-pub struct StackPool {
+#[derive(Debug, Default)]
+pub(crate) struct StackPool {
     stacks: Vec<Box<Stack>>,
 }
 

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -1,27 +1,28 @@
 use primitive_types::{H160, U256};
+use zksync_vm2_interface::HeapId;
 
 use crate::{
     addressing_modes::Addressable,
     callframe::{Callframe, CallframeSnapshot},
     fat_pointer::FatPointer,
-    heap::{Heaps, CALLDATA_HEAP, FIRST_AUX_HEAP, FIRST_HEAP},
+    heap::Heaps,
     predication::Flags,
     program::Program,
     stack::Stack,
     world_diff::Snapshot,
 };
 
-// TODO: reduce visibility once `multivm` uses `StateInterface` APIs
+/// State of a [`VirtualMachine`](crate::VirtualMachine).
 #[derive(Debug)]
-pub struct State<T, W> {
+pub(crate) struct State<T, W> {
     pub(crate) registers: [U256; 16],
     pub(crate) register_pointer_flags: u16,
     pub(crate) flags: Flags,
-    pub current_frame: Callframe<T, W>,
+    pub(crate) current_frame: Callframe<T, W>,
     /// Contains indices to the far call instructions currently being executed.
     /// They are needed to continue execution from the correct spot upon return.
-    pub previous_frames: Vec<Callframe<T, W>>,
-    pub heaps: Heaps,
+    pub(crate) previous_frames: Vec<Callframe<T, W>>,
+    pub(crate) heaps: Heaps,
     pub(crate) transaction_number: u16,
     pub(crate) context_u128: u128,
 }
@@ -38,7 +39,7 @@ impl<T, W> State<T, W> {
     ) -> Self {
         let mut registers: [U256; 16] = Default::default();
         registers[1] = FatPointer {
-            memory_page: CALLDATA_HEAP,
+            memory_page: HeapId::FIRST_CALLDATA,
             offset: 0,
             start: 0,
             length: calldata.len() as u32,
@@ -55,9 +56,9 @@ impl<T, W> State<T, W> {
                 caller,
                 program,
                 stack,
-                FIRST_HEAP,
-                FIRST_AUX_HEAP,
-                CALLDATA_HEAP,
+                HeapId::FIRST,
+                HeapId::FIRST_AUX,
+                HeapId::FIRST_CALLDATA,
                 gas,
                 0,
                 0,

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -323,6 +323,15 @@ impl<T, W> CallframeInterface for CallframeWrapper<'_, T, W> {
             self.frame.exception_handler
         }
     }
+
+    fn set_exception_handler(&mut self, value: u16) {
+        if let Some(i) = self.near_call {
+            let idx = self.frame.near_calls.len() - i - 1;
+            self.frame.near_calls[idx].exception_handler = value;
+        } else {
+            self.frame.exception_handler = value;
+        }
+    }
 }
 
 impl<T, W> CallframeWrapper<'_, T, W> {

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -73,10 +73,6 @@ impl<T, W> StateInterface for VirtualMachine<T, W> {
         self.state.heaps[heap].read_u256(index)
     }
 
-    fn write_heap_byte(&mut self, heap: HeapId, index: u32, byte: u8) {
-        self.state.heaps.write_byte(heap, index, byte);
-    }
-
     fn write_heap_u256(&mut self, heap: HeapId, index: u32, value: U256) {
         self.state.heaps.write_u256(heap, index, value);
     }

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -69,8 +69,16 @@ impl<T, W> StateInterface for VirtualMachine<T, W> {
         self.state.heaps[heap].read_byte(index)
     }
 
+    fn read_heap_u256(&self, heap: HeapId, index: u32) -> U256 {
+        self.state.heaps[heap].read_u256(index)
+    }
+
     fn write_heap_byte(&mut self, heap: HeapId, index: u32, byte: u8) {
         self.state.heaps.write_byte(heap, index, byte);
+    }
+
+    fn write_heap_u256(&mut self, heap: HeapId, index: u32, value: U256) {
+        self.state.heaps.write_u256(heap, index, value);
     }
 
     fn flags(&self) -> Flags {

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use primitive_types::H160;
 use zksync_vm2_interface::{opcodes::TypeLevelCallingMode, CallingMode, HeapId, Tracer};
 
@@ -72,6 +74,14 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
     /// Provides a reference to the [`World`](crate::World) diff accumulated by VM execution so far.
     pub fn world_diff(&self) -> &WorldDiff {
         &self.world_diff
+    }
+
+    /// Provides a mutable reference to the [`World`](crate::World) diff accumulated by VM execution so far.
+    ///
+    /// It is unsound to mutate `WorldDiff` in the middle of VM execution in the general case; thus, this method should only be used in tests.
+    #[doc(hidden)]
+    pub fn world_diff_mut(&mut self) -> &mut WorldDiff {
+        &mut self.world_diff
     }
 
     pub fn run(&mut self, world: &mut W, tracer: &mut T) -> ExecutionEnd {
@@ -247,6 +257,14 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
     pub(crate) fn start_new_tx(&mut self) {
         self.state.transaction_number = self.state.transaction_number.wrapping_add(1);
         self.world_diff.clear_transient_storage()
+    }
+}
+
+impl<T: fmt::Debug, W: fmt::Debug> VirtualMachine<T, W> {
+    /// Dumps an opaque representation of the current VM state.
+    #[doc(hidden)] // should only be used in tests
+    pub fn dump_state(&self) -> impl PartialEq + fmt::Debug {
+        self.state.clone()
     }
 }
 

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -24,12 +24,10 @@ pub struct Settings {
     pub hook_address: u32,
 }
 
-/// High-performance out-of-circuit ZKsync Era VM.
+/// High-performance out-of-circuit EraVM implementation.
 #[derive(Debug)]
 pub struct VirtualMachine<T, W> {
     pub(crate) world_diff: WorldDiff,
-    /// Storing the state in a separate struct is not just cosmetic.
-    /// The state couldn't be passed to the world if it was inlined.
     pub(crate) state: State<T, W>,
     pub(crate) settings: Settings,
     pub(crate) stack_pool: StackPool,

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -14,7 +14,7 @@ use crate::{
 
 /// Pending modifications to the global state that are executed at the end of a block.
 /// In other words, side effects.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct WorldDiff {
     // These are rolled back on revert or panic (and when the whole VM is rolled back).
     storage_changes: RollbackableMap<(H160, U256), U256>,

--- a/crates/vm2/tests/bytecode_behaviour.rs
+++ b/crates/vm2/tests/bytecode_behaviour.rs
@@ -6,7 +6,7 @@ use zksync_vm2::{
     decode::decode_program, initial_decommit, testworld::TestWorld, ExecutionEnd, Program,
     Settings, VirtualMachine, World,
 };
-use zksync_vm2_interface::Tracer;
+use zksync_vm2_interface::{CallframeInterface, StateInterface, Tracer};
 
 fn program_from_file<T: Tracer, W: World<T>>(filename: &str) -> Program<T, W> {
     let blob = std::fs::read(filename).unwrap();
@@ -50,5 +50,5 @@ fn call_to_invalid_address() {
         vm.run(&mut world, &mut ()),
         ExecutionEnd::Panicked
     ));
-    assert_eq!(vm.state.current_frame.gas, 0);
+    assert_eq!(vm.current_frame().gas(), 0);
 }

--- a/crates/vm2/tests/far_call_decommitment.rs
+++ b/crates/vm2/tests/far_call_decommitment.rs
@@ -32,7 +32,7 @@ fn create_test_world() -> TestWorld<()> {
     let main_program = Program::new(
         vec![
             // 0..=2: Prepare and execute far call
-            Instruction::from_binop::<opcodes::Add>(
+            Instruction::from_add(
                 CodePage(RegisterAndImmediate {
                     immediate: 0,
                     register: r0,
@@ -40,12 +40,11 @@ fn create_test_world() -> TestWorld<()> {
                 .into(),
                 Register2(r0),
                 Register1(r1).into(),
-                (),
                 Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
                 false,
                 false,
             ),
-            Instruction::from_binop::<opcodes::Add>(
+            Instruction::from_add(
                 CodePage(RegisterAndImmediate {
                     immediate: 1,
                     register: r0,
@@ -53,7 +52,6 @@ fn create_test_world() -> TestWorld<()> {
                 .into(),
                 Register2(r0),
                 Register1(r2).into(),
-                (),
                 Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
                 false,
                 false,
@@ -92,11 +90,10 @@ fn create_test_world() -> TestWorld<()> {
 
     let called_program = Program::new(
         vec![
-            Instruction::from_binop::<opcodes::Add>(
+            Instruction::from_add(
                 Register1(r0).into(),
                 Register2(r0),
                 Register1(r0).into(),
-                (),
                 Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
                 false,
                 false,

--- a/crates/vm2/tests/stipend.rs
+++ b/crates/vm2/tests/stipend.rs
@@ -11,7 +11,7 @@ use zksync_vm2::{
     testworld::TestWorld,
     ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
 };
-use zksync_vm2_interface::opcodes::{self, Add};
+use zksync_vm2_interface::opcodes;
 
 const INITIAL_GAS: u32 = 1000;
 
@@ -26,7 +26,7 @@ fn test_scenario(gas_to_pass: u32) -> (ExecutionEnd, u32) {
 
     let main_program = Program::new(
         vec![
-            Instruction::from_binop::<Add>(
+            Instruction::from_add(
                 CodePage(RegisterAndImmediate {
                     immediate: 0,
                     register: r0,
@@ -34,12 +34,11 @@ fn test_scenario(gas_to_pass: u32) -> (ExecutionEnd, u32) {
                 .into(),
                 Register2(r0),
                 Register1(r1).into(),
-                (),
                 Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
                 false,
                 false,
             ),
-            Instruction::from_binop::<Add>(
+            Instruction::from_add(
                 CodePage(RegisterAndImmediate {
                     immediate: 1,
                     register: r0,
@@ -47,7 +46,6 @@ fn test_scenario(gas_to_pass: u32) -> (ExecutionEnd, u32) {
                 .into(),
                 Register2(r0),
                 Register1(r2).into(),
-                (),
                 Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
                 false,
                 false,
@@ -72,11 +70,10 @@ fn test_scenario(gas_to_pass: u32) -> (ExecutionEnd, u32) {
 
     let interpreter = Program::new(
         vec![
-            Instruction::from_binop::<Add>(
+            Instruction::from_add(
                 Register1(r0).into(),
                 Register2(r0),
                 Register1(r0).into(),
-                (),
                 Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
                 false,
                 false,

--- a/crates/vm2/tests/stipend.rs
+++ b/crates/vm2/tests/stipend.rs
@@ -11,7 +11,7 @@ use zksync_vm2::{
     testworld::TestWorld,
     ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
 };
-use zksync_vm2_interface::opcodes;
+use zksync_vm2_interface::{opcodes, CallframeInterface, StateInterface};
 
 const INITIAL_GAS: u32 = 1000;
 
@@ -117,7 +117,8 @@ fn test_scenario(gas_to_pass: u32) -> (ExecutionEnd, u32) {
     );
 
     let result = vm.run(&mut world, &mut ());
-    (result, vm.state.current_frame.gas)
+    let remaining_gas = vm.current_frame().gas();
+    (result, remaining_gas)
 }
 
 #[test]

--- a/tests/afl-fuzz/src/show_testcase.rs
+++ b/tests/afl-fuzz/src/show_testcase.rs
@@ -17,13 +17,13 @@ fn main() {
     let VmAndWorld { mut vm, mut world } =
         arbitrary::Unstructured::new(&bytes).arbitrary().unwrap();
 
-    println!("{:?}", vm.state);
+    println!("{:?}", vm.dump_state());
     assert!(vm.is_in_valid_state());
 
     let mut zk_evm = vm2_to_zk_evm(&vm, world.clone());
 
     let (parsed, _) = EncodingModeProduction::parse_preliminary_variant_and_absolute_number(
-        vm.state.current_frame.raw_first_instruction(),
+        vm.raw_first_instruction(),
     );
     println!("{}", parsed);
     vm.run_single_instruction(&mut world, &mut ());


### PR DESCRIPTION
# What ❔

Continues brushing up the repo.

- Makes VM state types private and somewhat extends `StateInterface` to compensate.
- Adds some doc comments (more to be added separately).

## Why ❔

Minimizes the API surface of the VM crate so that it's easier to maintain.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and `cargo clippy`.