### PR TITLE
feat: expose storage to tracers

### DIFF
--- a/crates/vm2-interface/src/lib.rs
+++ b/crates/vm2-interface/src/lib.rs
@@ -27,12 +27,14 @@
 //! ```
 //! # use zksync_vm2_interface as zksync_vm2_interface_v1;
 //! use zksync_vm2_interface_v1::{
-//!     StateInterface as StateInterfaceV1, Tracer as TracerV1, opcodes::NearCall,
+//!     StateInterface as StateInterfaceV1, GlobalStateInterface as GlobalStateInterfaceV1, Tracer as TracerV1, opcodes::NearCall,
 //! };
 //!
 //! trait StateInterface: StateInterfaceV1 {
 //!     fn get_some_new_field(&self) -> u32;
 //! }
+//!
+//! trait GlobalStateInterface: StateInterface + GlobalStateInterfaceV1 {}
 //!
 //! pub struct NewOpcode;
 //!
@@ -57,27 +59,27 @@
 //! }
 //!
 //! trait Tracer {
-//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, storage: &mut S::StorageInterface) {}
-//!     fn after_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, storage: &mut S::StorageInterface) {}
+//!     fn before_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S) {}
+//!     fn after_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S) {}
 //! }
 //!
 //! impl<T: TracerV1> Tracer for T {
-//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, storage: &mut S::StorageInterface) {
+//!     fn before_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S) {
 //!         match OP::VALUE {
 //!             Opcode::NewOpcode => {}
 //!             // Do this for every old opcode
 //!             Opcode::NearCall => {
-//!                 <Self as TracerV1>::before_instruction::<NearCall, _>(self, state, storage)
+//!                 <Self as TracerV1>::before_instruction::<NearCall, _>(self, state)
 //!             }
 //!         }
 //!     }
-//!     fn after_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, storage: &mut S::StorageInterface) {}
+//!     fn after_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S) {}
 //! }
 //!
 //! // Now you can use the new features by implementing TracerV2
 //! struct MyTracer;
 //! impl Tracer for MyTracer {
-//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, _: &mut S::StorageInterface) {
+//!     fn before_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S) {
 //!         if OP::VALUE == Opcode::NewOpcode {
 //!             state.get_some_new_field();
 //!         }

--- a/crates/vm2-interface/src/lib.rs
+++ b/crates/vm2-interface/src/lib.rs
@@ -57,27 +57,27 @@
 //! }
 //!
 //! trait Tracer {
-//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, _state: &mut S) {}
-//!     fn after_instruction<OP: OpcodeType, S: StateInterface>(&mut self, _state: &mut S) {}
+//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, storage: &mut S::StorageInterface) {}
+//!     fn after_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, storage: &mut S::StorageInterface) {}
 //! }
 //!
 //! impl<T: TracerV1> Tracer for T {
-//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S) {
+//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, storage: &mut S::StorageInterface) {
 //!         match OP::VALUE {
 //!             Opcode::NewOpcode => {}
 //!             // Do this for every old opcode
 //!             Opcode::NearCall => {
-//!                 <Self as TracerV1>::before_instruction::<NearCall, _>(self, state)
+//!                 <Self as TracerV1>::before_instruction::<NearCall, _>(self, state, storage)
 //!             }
 //!         }
 //!     }
-//!     fn after_instruction<OP: OpcodeType, S: StateInterface>(&mut self, _state: &mut S) {}
+//!     fn after_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, storage: &mut S::StorageInterface) {}
 //! }
 //!
 //! // Now you can use the new features by implementing TracerV2
 //! struct MyTracer;
 //! impl Tracer for MyTracer {
-//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S) {
+//!     fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S, _: &mut S::StorageInterface) {
 //!         if OP::VALUE == Opcode::NewOpcode {
 //!             state.get_some_new_field();
 //!         }

--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -2,6 +2,9 @@ use primitive_types::{H160, U256};
 
 /// Public interface of the VM state. Encompasses both read and write methods.
 pub trait StateInterface {
+    /// Storage interface required for operations that read storage.
+    type StorageInterface;
+
     /// Reads a register with the specified zero-based index. Returns a value together with a pointer flag.
     fn read_register(&self, register: u8) -> (U256, bool);
     /// Sets a register with the specified zero-based index
@@ -42,7 +45,12 @@ pub trait StateInterface {
     /// Iterates over storage slots read or written during VM execution.
     fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)>;
     /// Gets value of the specified storage slot.
-    fn get_storage(&mut self, address: H160, slot: U256) -> U256;
+    fn get_storage(
+        &mut self,
+        storage: &mut Self::StorageInterface,
+        address: H160,
+        slot: U256,
+    ) -> U256;
 
     /// Iterates over all transient storage slots set during VM execution.
     fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)>;
@@ -217,6 +225,8 @@ pub struct DummyState;
 
 #[cfg(test)]
 impl StateInterface for DummyState {
+    type StorageInterface = ();
+
     fn read_register(&self, _: u8) -> (U256, bool) {
         unimplemented!()
     }
@@ -277,7 +287,7 @@ impl StateInterface for DummyState {
         std::iter::empty()
     }
 
-    fn get_storage(&mut self, _: H160, _: U256) -> U256 {
+    fn get_storage(&mut self, _: &mut Self::StorageInterface, _: H160, _: U256) -> U256 {
         unimplemented!()
     }
 

--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -287,7 +287,7 @@ impl StateInterface for DummyState {
         std::iter::empty()
     }
 
-    fn get_storage(&mut self, _: &mut Self::StorageInterface, _: H160, _: U256) -> U256 {
+    fn get_storage(&mut self, (): &mut Self::StorageInterface, _: H160, _: U256) -> U256 {
         unimplemented!()
     }
 

--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -41,6 +41,9 @@ pub trait StateInterface {
 
     /// Iterates over storage slots read or written during VM execution.
     fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)>;
+    /// Gets value of the specified storage slot.
+    fn get_storage(&mut self, address: H160, slot: U256) -> U256;
+
     /// Iterates over all transient storage slots set during VM execution.
     fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)>;
     /// Gets value of the specified transient storage slot.
@@ -272,6 +275,10 @@ impl StateInterface for DummyState {
 
     fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
         std::iter::empty()
+    }
+
+    fn get_storage(&mut self, _: H160, _: U256) -> U256 {
+        unimplemented!()
     }
 
     fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {

--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -2,9 +2,6 @@ use primitive_types::{H160, U256};
 
 /// Public interface of the VM state. Encompasses both read and write methods.
 pub trait StateInterface {
-    /// Storage interface required for operations that read storage.
-    type StorageInterface;
-
     /// Reads a register with the specified zero-based index. Returns a value together with a pointer flag.
     fn read_register(&self, register: u8) -> (U256, bool);
     /// Sets a register with the specified zero-based index
@@ -44,13 +41,6 @@ pub trait StateInterface {
 
     /// Iterates over storage slots read or written during VM execution.
     fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)>;
-    /// Gets value of the specified storage slot.
-    fn get_storage(
-        &mut self,
-        storage: &mut Self::StorageInterface,
-        address: H160,
-        slot: U256,
-    ) -> U256;
 
     /// Iterates over all transient storage slots set during VM execution.
     fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)>;
@@ -68,6 +58,12 @@ pub trait StateInterface {
     fn pubdata(&self) -> i32;
     /// Sets the current amount of published pubdata.
     fn set_pubdata(&mut self, value: i32);
+}
+
+/// State interface with access to global state like storage.
+pub trait GlobalStateInterface: StateInterface {
+    /// Gets value of the specified storage slot.
+    fn get_storage(&mut self, address: H160, slot: U256) -> U256;
 }
 
 /// VM execution flags. See the EraVM reference for more details.
@@ -220,221 +216,227 @@ pub struct L2ToL1Log {
 }
 
 #[cfg(test)]
-#[derive(Debug)]
-pub struct DummyState;
+pub mod tests {
+    use primitive_types::{H160, U256};
 
-#[cfg(test)]
-impl StateInterface for DummyState {
-    type StorageInterface = ();
+    use super::{
+        CallframeInterface, Event, Flags, GlobalStateInterface, HeapId, L2ToL1Log, StateInterface,
+    };
 
-    fn read_register(&self, _: u8) -> (U256, bool) {
-        unimplemented!()
+    #[derive(Debug)]
+    pub struct DummyState;
+
+    impl StateInterface for DummyState {
+        fn read_register(&self, _: u8) -> (U256, bool) {
+            unimplemented!()
+        }
+
+        fn set_register(&mut self, _: u8, _: U256, _: bool) {
+            unimplemented!()
+        }
+
+        fn current_frame(&mut self) -> impl CallframeInterface + '_ {
+            DummyState
+        }
+
+        fn number_of_callframes(&self) -> usize {
+            unimplemented!()
+        }
+
+        fn callframe(&mut self, _: usize) -> impl CallframeInterface + '_ {
+            DummyState
+        }
+
+        fn read_heap_byte(&self, _: HeapId, _: u32) -> u8 {
+            unimplemented!()
+        }
+
+        fn read_heap_u256(&self, _: HeapId, _: u32) -> U256 {
+            unimplemented!()
+        }
+
+        fn write_heap_u256(&mut self, _: HeapId, _: u32, _: U256) {
+            unimplemented!()
+        }
+
+        fn flags(&self) -> Flags {
+            unimplemented!()
+        }
+
+        fn set_flags(&mut self, _: Flags) {
+            unimplemented!()
+        }
+
+        fn transaction_number(&self) -> u16 {
+            unimplemented!()
+        }
+
+        fn set_transaction_number(&mut self, _: u16) {
+            unimplemented!()
+        }
+
+        fn context_u128_register(&self) -> u128 {
+            unimplemented!()
+        }
+
+        fn set_context_u128_register(&mut self, _: u128) {
+            unimplemented!()
+        }
+
+        fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
+            std::iter::empty()
+        }
+
+        fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
+            std::iter::empty()
+        }
+
+        fn get_transient_storage(&self, _: H160, _: U256) -> U256 {
+            unimplemented!()
+        }
+
+        fn write_transient_storage(&mut self, _: H160, _: U256, _: U256) {
+            unimplemented!()
+        }
+
+        fn events(&self) -> impl Iterator<Item = Event> {
+            std::iter::empty()
+        }
+
+        fn l2_to_l1_logs(&self) -> impl Iterator<Item = L2ToL1Log> {
+            std::iter::empty()
+        }
+
+        fn pubdata(&self) -> i32 {
+            unimplemented!()
+        }
+
+        fn set_pubdata(&mut self, _: i32) {
+            unimplemented!()
+        }
     }
 
-    fn set_register(&mut self, _: u8, _: U256, _: bool) {
-        unimplemented!()
+    impl GlobalStateInterface for DummyState {
+        fn get_storage(&mut self, _: H160, _: U256) -> U256 {
+            unimplemented!()
+        }
     }
 
-    fn current_frame(&mut self) -> impl CallframeInterface + '_ {
-        DummyState
-    }
+    impl CallframeInterface for DummyState {
+        fn address(&self) -> H160 {
+            unimplemented!()
+        }
 
-    fn number_of_callframes(&self) -> usize {
-        unimplemented!()
-    }
+        fn set_address(&mut self, _: H160) {
+            unimplemented!()
+        }
 
-    fn callframe(&mut self, _: usize) -> impl CallframeInterface + '_ {
-        DummyState
-    }
+        fn code_address(&self) -> H160 {
+            unimplemented!()
+        }
 
-    fn read_heap_byte(&self, _: HeapId, _: u32) -> u8 {
-        unimplemented!()
-    }
+        fn set_code_address(&mut self, _: H160) {
+            unimplemented!()
+        }
 
-    fn read_heap_u256(&self, _: HeapId, _: u32) -> U256 {
-        unimplemented!()
-    }
+        fn caller(&self) -> H160 {
+            unimplemented!()
+        }
 
-    fn write_heap_u256(&mut self, _: HeapId, _: u32, _: U256) {
-        unimplemented!()
-    }
+        fn set_caller(&mut self, _: H160) {
+            unimplemented!()
+        }
 
-    fn flags(&self) -> Flags {
-        unimplemented!()
-    }
+        fn program_counter(&self) -> Option<u16> {
+            unimplemented!()
+        }
 
-    fn set_flags(&mut self, _: Flags) {
-        unimplemented!()
-    }
+        fn set_program_counter(&mut self, _: u16) {
+            unimplemented!()
+        }
 
-    fn transaction_number(&self) -> u16 {
-        unimplemented!()
-    }
+        fn exception_handler(&self) -> u16 {
+            unimplemented!()
+        }
 
-    fn set_transaction_number(&mut self, _: u16) {
-        unimplemented!()
-    }
+        fn set_exception_handler(&mut self, _: u16) {
+            unimplemented!()
+        }
 
-    fn context_u128_register(&self) -> u128 {
-        unimplemented!()
-    }
+        fn is_static(&self) -> bool {
+            unimplemented!()
+        }
 
-    fn set_context_u128_register(&mut self, _: u128) {
-        unimplemented!()
-    }
+        fn is_kernel(&self) -> bool {
+            unimplemented!()
+        }
 
-    fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
-        std::iter::empty()
-    }
+        fn gas(&self) -> u32 {
+            unimplemented!()
+        }
 
-    fn get_storage(&mut self, (): &mut Self::StorageInterface, _: H160, _: U256) -> U256 {
-        unimplemented!()
-    }
+        fn set_gas(&mut self, _: u32) {
+            unimplemented!()
+        }
 
-    fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
-        std::iter::empty()
-    }
+        fn stipend(&self) -> u32 {
+            unimplemented!()
+        }
 
-    fn get_transient_storage(&self, _: H160, _: U256) -> U256 {
-        unimplemented!()
-    }
+        fn context_u128(&self) -> u128 {
+            unimplemented!()
+        }
 
-    fn write_transient_storage(&mut self, _: H160, _: U256, _: U256) {
-        unimplemented!()
-    }
+        fn set_context_u128(&mut self, _: u128) {
+            unimplemented!()
+        }
 
-    fn events(&self) -> impl Iterator<Item = Event> {
-        std::iter::empty()
-    }
+        fn is_near_call(&self) -> bool {
+            unimplemented!()
+        }
 
-    fn l2_to_l1_logs(&self) -> impl Iterator<Item = L2ToL1Log> {
-        std::iter::empty()
-    }
+        fn read_stack(&self, _: u16) -> (U256, bool) {
+            unimplemented!()
+        }
 
-    fn pubdata(&self) -> i32 {
-        unimplemented!()
-    }
+        fn write_stack(&mut self, _: u16, _: U256, _: bool) {
+            unimplemented!()
+        }
 
-    fn set_pubdata(&mut self, _: i32) {
-        unimplemented!()
-    }
-}
+        fn stack_pointer(&self) -> u16 {
+            unimplemented!()
+        }
 
-#[cfg(test)]
-impl CallframeInterface for DummyState {
-    fn address(&self) -> H160 {
-        unimplemented!()
-    }
+        fn set_stack_pointer(&mut self, _: u16) {
+            unimplemented!()
+        }
 
-    fn set_address(&mut self, _: H160) {
-        unimplemented!()
-    }
+        fn heap(&self) -> HeapId {
+            unimplemented!()
+        }
 
-    fn code_address(&self) -> H160 {
-        unimplemented!()
-    }
+        fn heap_bound(&self) -> u32 {
+            unimplemented!()
+        }
 
-    fn set_code_address(&mut self, _: H160) {
-        unimplemented!()
-    }
+        fn set_heap_bound(&mut self, _: u32) {
+            unimplemented!()
+        }
 
-    fn caller(&self) -> H160 {
-        unimplemented!()
-    }
+        fn aux_heap(&self) -> HeapId {
+            unimplemented!()
+        }
 
-    fn set_caller(&mut self, _: H160) {
-        unimplemented!()
-    }
+        fn aux_heap_bound(&self) -> u32 {
+            unimplemented!()
+        }
 
-    fn program_counter(&self) -> Option<u16> {
-        unimplemented!()
-    }
+        fn set_aux_heap_bound(&mut self, _: u32) {
+            unimplemented!()
+        }
 
-    fn set_program_counter(&mut self, _: u16) {
-        unimplemented!()
-    }
-
-    fn exception_handler(&self) -> u16 {
-        unimplemented!()
-    }
-
-    fn set_exception_handler(&mut self, _: u16) {
-        unimplemented!()
-    }
-
-    fn is_static(&self) -> bool {
-        unimplemented!()
-    }
-
-    fn is_kernel(&self) -> bool {
-        unimplemented!()
-    }
-
-    fn gas(&self) -> u32 {
-        unimplemented!()
-    }
-
-    fn set_gas(&mut self, _: u32) {
-        unimplemented!()
-    }
-
-    fn stipend(&self) -> u32 {
-        unimplemented!()
-    }
-
-    fn context_u128(&self) -> u128 {
-        unimplemented!()
-    }
-
-    fn set_context_u128(&mut self, _: u128) {
-        unimplemented!()
-    }
-
-    fn is_near_call(&self) -> bool {
-        unimplemented!()
-    }
-
-    fn read_stack(&self, _: u16) -> (U256, bool) {
-        unimplemented!()
-    }
-
-    fn write_stack(&mut self, _: u16, _: U256, _: bool) {
-        unimplemented!()
-    }
-
-    fn stack_pointer(&self) -> u16 {
-        unimplemented!()
-    }
-
-    fn set_stack_pointer(&mut self, _: u16) {
-        unimplemented!()
-    }
-
-    fn heap(&self) -> HeapId {
-        unimplemented!()
-    }
-
-    fn heap_bound(&self) -> u32 {
-        unimplemented!()
-    }
-
-    fn set_heap_bound(&mut self, _: u32) {
-        unimplemented!()
-    }
-
-    fn aux_heap(&self) -> HeapId {
-        unimplemented!()
-    }
-
-    fn aux_heap_bound(&self) -> u32 {
-        unimplemented!()
-    }
-
-    fn set_aux_heap_bound(&mut self, _: u32) {
-        unimplemented!()
-    }
-
-    fn read_contract_code(&self, _: u16) -> U256 {
-        unimplemented!()
+        fn read_contract_code(&self, _: u16) -> U256 {
+            unimplemented!()
+        }
     }
 }

--- a/crates/vm2-interface/src/tracer_interface.rs
+++ b/crates/vm2-interface/src/tracer_interface.rs
@@ -257,11 +257,15 @@ pub trait Tracer {
     /// Executes logic before an instruction handler.
     ///
     /// The default implementation does nothing.
-    fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, _state: &mut S) {}
+    fn before_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S) {
+        let _ = state;
+    }
     /// Executes logic after an instruction handler.
     ///
     /// The default implementation does nothing.
-    fn after_instruction<OP: OpcodeType, S: StateInterface>(&mut self, _state: &mut S) {}
+    fn after_instruction<OP: OpcodeType, S: StateInterface>(&mut self, state: &mut S) {
+        let _ = state;
+    }
 
     /// Provides cycle statistics for "complex" instructions from the prover perspective (mostly precompile calls).
     ///

--- a/crates/vm2-interface/src/tracer_interface.rs
+++ b/crates/vm2-interface/src/tracer_interface.rs
@@ -245,7 +245,7 @@ impl<T: opcodes::TypeLevelReturnType> OpcodeType for opcodes::Ret<T> {
 /// struct FarCallCounter(usize);
 ///
 /// impl Tracer for FarCallCounter {
-///     fn before_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S, _: &mut S::StorageInterface) {
+///     fn before_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S) {
 ///         match OP::VALUE {
 ///             Opcode::FarCall(_) => self.0 += 1,
 ///             _ => {}

--- a/crates/vm2/src/callframe.rs
+++ b/crates/vm2/src/callframe.rs
@@ -10,7 +10,7 @@ use crate::{
     program::Program,
     stack::{Stack, StackSnapshot},
     world_diff::Snapshot,
-    Instruction,
+    Instruction, World,
 };
 
 #[derive(Debug)]
@@ -107,7 +107,7 @@ impl<T, W> Callframe<T, W> {
     }
 }
 
-impl<T: Tracer, W> Callframe<T, W> {
+impl<T: Tracer, W: World<T>> Callframe<T, W> {
     pub(crate) fn push_near_call(
         &mut self,
         gas_to_call: u32,

--- a/crates/vm2/src/instruction_handlers/binop.rs
+++ b/crates/vm2/src/instruction_handlers/binop.rs
@@ -28,6 +28,7 @@ fn binop<T, W, Op, In1, Out, const SWAP: bool, const SET_FLAGS: bool>(
 ) -> ExecutionStatus
 where
     T: Tracer,
+    W: World<T>,
     Op: Binop,
     In1: Source,
     Out: Destination,

--- a/crates/vm2/src/instruction_handlers/common.rs
+++ b/crates/vm2/src/instruction_handlers/common.rs
@@ -1,10 +1,7 @@
 use zksync_vm2_interface::{opcodes, OpcodeType, Tracer};
 
 use super::ret::free_panic;
-use crate::{
-    addressing_modes::Arguments, instruction::ExecutionStatus, tracing::VmAndWorld, VirtualMachine,
-    World,
-};
+use crate::{addressing_modes::Arguments, instruction::ExecutionStatus, VirtualMachine, World};
 
 #[inline(always)]
 pub(crate) fn boilerplate<Opcode: OpcodeType, T: Tracer, W: World<T>>(
@@ -56,15 +53,15 @@ pub(crate) fn full_boilerplate<Opcode: OpcodeType, T: Tracer, W: World<T>>(
     }
 
     if args.predicate().satisfied(&vm.state.flags) {
-        tracer.before_instruction::<Opcode, _>(&mut VmAndWorld { vm, world });
+        tracer.before_instruction::<Opcode, _>(vm, world);
         vm.state.current_frame.pc = unsafe { vm.state.current_frame.pc.add(1) };
         let result = business_logic(vm, args, world, tracer);
-        tracer.after_instruction::<Opcode, _>(&mut VmAndWorld { vm, world });
+        tracer.after_instruction::<Opcode, _>(vm, world);
         result
     } else {
-        tracer.before_instruction::<opcodes::Nop, _>(&mut VmAndWorld { vm, world });
+        tracer.before_instruction::<opcodes::Nop, _>(vm, world);
         vm.state.current_frame.pc = unsafe { vm.state.current_frame.pc.add(1) };
-        tracer.after_instruction::<opcodes::Nop, _>(&mut VmAndWorld { vm, world });
+        tracer.after_instruction::<opcodes::Nop, _>(vm, world);
         ExecutionStatus::Running
     }
 }

--- a/crates/vm2/src/instruction_handlers/context.rs
+++ b/crates/vm2/src/instruction_handlers/context.rs
@@ -10,7 +10,7 @@ use crate::{
     addressing_modes::{Arguments, Destination, Register1, Source},
     instruction::ExecutionStatus,
     state::State,
-    Instruction, VirtualMachine,
+    Instruction, VirtualMachine, World,
 };
 
 pub(crate) fn address_into_u256(address: H160) -> U256 {
@@ -19,7 +19,7 @@ pub(crate) fn address_into_u256(address: H160) -> U256 {
     U256::from_big_endian(&buffer)
 }
 
-fn context<T, W, Op>(
+fn context<T, W: World<T>, Op>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -74,7 +74,7 @@ impl ContextOp for SP {
     }
 }
 
-fn context_meta<T: Tracer, W>(
+fn context_meta<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -102,7 +102,7 @@ fn context_meta<T: Tracer, W>(
     })
 }
 
-fn set_context_u128<T: Tracer, W>(
+fn set_context_u128<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -113,7 +113,7 @@ fn set_context_u128<T: Tracer, W>(
     })
 }
 
-fn increment_tx_number<T: Tracer, W>(
+fn increment_tx_number<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -123,7 +123,7 @@ fn increment_tx_number<T: Tracer, W>(
     })
 }
 
-fn aux_mutating<T: Tracer, W>(
+fn aux_mutating<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -134,7 +134,7 @@ fn aux_mutating<T: Tracer, W>(
 }
 
 /// Context-related instructions.
-impl<T: Tracer, W> Instruction<T, W> {
+impl<T: Tracer, W: World<T>> Instruction<T, W> {
     fn from_context<Op: ContextOp>(out: Register1, arguments: Arguments) -> Self {
         Self {
             handler: context::<T, W, Op>,

--- a/crates/vm2/src/instruction_handlers/event.rs
+++ b/crates/vm2/src/instruction_handlers/event.rs
@@ -6,10 +6,10 @@ use super::common::boilerplate_ext;
 use crate::{
     addressing_modes::{Arguments, Immediate1, Register1, Register2, Source},
     instruction::ExecutionStatus,
-    Instruction, VirtualMachine,
+    Instruction, VirtualMachine, World,
 };
 
-fn event<T: Tracer, W>(
+fn event<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -31,7 +31,7 @@ fn event<T: Tracer, W>(
     })
 }
 
-fn l2_to_l1<T: Tracer, W>(
+fn l2_to_l1<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -51,7 +51,7 @@ fn l2_to_l1<T: Tracer, W>(
     })
 }
 
-impl<T: Tracer, W> Instruction<T, W> {
+impl<T: Tracer, W: World<T>> Instruction<T, W> {
     /// Creates an [`Event`](opcodes::Event) instruction with the provided params.
     pub fn from_event(
         key: Register1,

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -34,7 +34,7 @@ use crate::{
 ///
 /// Even though all errors happen before the new stack frame, they cause a panic in the new frame,
 /// not in the caller!
-fn far_call<T, W: World<T>, M, const IS_STATIC: bool, const IS_SHARD: bool>(
+fn far_call<T, W, M, const IS_STATIC: bool, const IS_SHARD: bool>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -34,7 +34,7 @@ use crate::{
 ///
 /// Even though all errors happen before the new stack frame, they cause a panic in the new frame,
 /// not in the caller!
-fn far_call<T, W, M, const IS_STATIC: bool, const IS_SHARD: bool>(
+fn far_call<T, W: World<T>, M, const IS_STATIC: bool, const IS_SHARD: bool>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -109,7 +109,7 @@ where
 
         let Some((calldata, program, is_evm_interpreter)) = failing_part else {
             vm.state.current_frame.gas += new_frame_gas.saturating_sub(RETURN_COST);
-            panic_from_failed_far_call(vm, tracer, exception_handler);
+            panic_from_failed_far_call(vm, world, tracer, exception_handler);
             return;
         };
 

--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -14,7 +14,7 @@ use crate::{
     fat_pointer::FatPointer,
     instruction::ExecutionStatus,
     state::State,
-    ExecutionEnd, Instruction, VirtualMachine,
+    ExecutionEnd, Instruction, VirtualMachine, World,
 };
 
 pub(crate) trait HeapFromState {
@@ -64,7 +64,7 @@ fn bigger_than_last_address(x: U256) -> bool {
     x.0[0] > LAST_ADDRESS.into() || x.0[1] != 0 || x.0[2] != 0 || x.0[3] != 0
 }
 
-fn load<T: Tracer, W, H: HeapFromState, In: Source, const INCREMENT: bool>(
+fn load<T: Tracer, W: World<T>, H: HeapFromState, In: Source, const INCREMENT: bool>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -100,7 +100,7 @@ fn load<T: Tracer, W, H: HeapFromState, In: Source, const INCREMENT: bool>(
     })
 }
 
-fn store<T, W, H, In, const INCREMENT: bool, const HOOKING_ENABLED: bool>(
+fn store<T, W: World<T>, H, In, const INCREMENT: bool, const HOOKING_ENABLED: bool>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -163,7 +163,7 @@ pub(crate) fn grow_heap<T, W, H: HeapFromState>(
     Ok(())
 }
 
-fn load_pointer<T: Tracer, W, const INCREMENT: bool>(
+fn load_pointer<T: Tracer, W: World<T>, const INCREMENT: bool>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -197,7 +197,7 @@ fn load_pointer<T: Tracer, W, const INCREMENT: bool>(
     })
 }
 
-impl<T: Tracer, W> Instruction<T, W> {
+impl<T: Tracer, W: World<T>> Instruction<T, W> {
     /// Creates a [`HeapRead`](opcodes::HeapRead) instruction with the provided params.
     pub fn from_heap_read(
         src: RegisterOrImmediate,

--- a/crates/vm2/src/instruction_handlers/jump.rs
+++ b/crates/vm2/src/instruction_handlers/jump.rs
@@ -10,10 +10,10 @@ use crate::{
         Immediate1, Register1, RelativeStack, Source,
     },
     instruction::{ExecutionStatus, Instruction},
-    VirtualMachine,
+    VirtualMachine, World,
 };
 
-fn jump<T: Tracer, W, In: Source>(
+fn jump<T: Tracer, W: World<T>, In: Source>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -29,7 +29,7 @@ fn jump<T: Tracer, W, In: Source>(
     })
 }
 
-impl<T: Tracer, W> Instruction<T, W> {
+impl<T: Tracer, W: World<T>> Instruction<T, W> {
     /// Creates a [`Jump`](opcodes::Jump) instruction with the provided params.
     pub fn from_jump(source: AnySource, destination: Register1, arguments: Arguments) -> Self {
         Self {

--- a/crates/vm2/src/instruction_handlers/near_call.rs
+++ b/crates/vm2/src/instruction_handlers/near_call.rs
@@ -5,10 +5,10 @@ use crate::{
     addressing_modes::{Arguments, Immediate1, Immediate2, Register1, Source},
     instruction::ExecutionStatus,
     predication::Flags,
-    Instruction, VirtualMachine,
+    Instruction, VirtualMachine, World,
 };
 
-fn near_call<T: Tracer, W>(
+fn near_call<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -35,7 +35,7 @@ fn near_call<T: Tracer, W>(
     })
 }
 
-impl<T: Tracer, W> Instruction<T, W> {
+impl<T: Tracer, W: World<T>> Instruction<T, W> {
     /// Creates a [`NearCall`](opcodes::NearCall) instruction with the provided params.
     pub fn from_near_call(
         gas: Register1,

--- a/crates/vm2/src/instruction_handlers/nop.rs
+++ b/crates/vm2/src/instruction_handlers/nop.rs
@@ -4,10 +4,10 @@ use super::common::boilerplate;
 use crate::{
     addressing_modes::{destination_stack_address, AdvanceStackPointer, Arguments, Source},
     instruction::ExecutionStatus,
-    Instruction, VirtualMachine,
+    Instruction, VirtualMachine, World,
 };
 
-fn nop<T: Tracer, W>(
+fn nop<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -23,7 +23,7 @@ fn nop<T: Tracer, W>(
     })
 }
 
-impl<T: Tracer, W> Instruction<T, W> {
+impl<T: Tracer, W: World<T>> Instruction<T, W> {
     /// Creates a [`Nop`](opcodes::Nop) instruction with the provided params.
     pub fn from_nop(
         pop: AdvanceStackPointer,

--- a/crates/vm2/src/instruction_handlers/pointer.rs
+++ b/crates/vm2/src/instruction_handlers/pointer.rs
@@ -18,10 +18,10 @@ use crate::{
     },
     fat_pointer::FatPointer,
     instruction::ExecutionStatus,
-    Instruction, VirtualMachine,
+    Instruction, VirtualMachine, World,
 };
 
-fn ptr<T: Tracer, W, Op: PtrOp, In1: Source, Out: Destination, const SWAP: bool>(
+fn ptr<T: Tracer, W: World<T>, Op: PtrOp, In1: Source, Out: Destination, const SWAP: bool>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -124,7 +124,7 @@ macro_rules! from_ptr_op {
 }
 
 /// Pointer-related instructions.
-impl<T: Tracer, W> Instruction<T, W> {
+impl<T: Tracer, W: World<T>> Instruction<T, W> {
     from_ptr_op!(from_pointer_add<PointerAdd>);
     from_ptr_op!(from_pointer_sub<PointerSub>);
     from_ptr_op!(from_pointer_pack<PointerPack>);

--- a/crates/vm2/src/instruction_handlers/precompiles.rs
+++ b/crates/vm2/src/instruction_handlers/precompiles.rs
@@ -22,10 +22,10 @@ use crate::{
     addressing_modes::{Arguments, Destination, Register1, Register2, Source},
     heap::Heaps,
     instruction::ExecutionStatus,
-    Instruction, VirtualMachine,
+    Instruction, VirtualMachine, World,
 };
 
-fn precompile_call<T: Tracer, W>(
+fn precompile_call<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -138,7 +138,7 @@ impl Memory for Heaps {
     }
 }
 
-impl<T: Tracer, W> Instruction<T, W> {
+impl<T: Tracer, W: World<T>> Instruction<T, W> {
     /// Creates a [`PrecompileCall`](opcodes::PrecompileCall) instruction with the provided params.
     pub fn from_precompile_call(
         abi: Register1,

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -15,7 +15,6 @@ use crate::{
     instruction::{ExecutionEnd, ExecutionStatus},
     mode_requirements::ModeRequirements,
     predication::Flags,
-    tracing::VmAndWorld,
     Instruction, Predicate, VirtualMachine, World,
 };
 
@@ -144,13 +143,13 @@ pub(crate) fn free_panic<T: Tracer, W: World<T>>(
     world: &mut W,
     tracer: &mut T,
 ) -> ExecutionStatus {
-    tracer.before_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
+    tracer.before_instruction::<opcodes::Ret<Panic>, _>(vm, world);
     // args aren't used for panics unless TO_LABEL
     let result = naked_ret::<T, W, Panic, false>(
         vm,
         &Arguments::new(Predicate::Always, 0, ModeRequirements::none()),
     );
-    tracer.after_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
+    tracer.after_instruction::<opcodes::Ret<Panic>, _>(vm, world);
     result
 }
 
@@ -162,7 +161,7 @@ pub(crate) fn panic_from_failed_far_call<T: Tracer, W: World<T>>(
     tracer: &mut T,
     exception_handler: u16,
 ) {
-    tracer.before_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
+    tracer.before_instruction::<opcodes::Ret<Panic>, _>(vm, world);
 
     // Gas is already subtracted in the far call code.
     // No need to roll back, as no changes are made in this "frame".
@@ -172,7 +171,7 @@ pub(crate) fn panic_from_failed_far_call<T: Tracer, W: World<T>>(
     vm.state.flags = Flags::new(true, false, false);
     vm.state.current_frame.set_pc_from_u16(exception_handler);
 
-    tracer.after_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
+    tracer.after_instruction::<opcodes::Ret<Panic>, _>(vm, world);
 }
 
 fn invalid<T: Tracer, W: World<T>>(

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -15,6 +15,7 @@ use crate::{
     instruction::{ExecutionEnd, ExecutionStatus},
     mode_requirements::ModeRequirements,
     predication::Flags,
+    tracing::VmAndWorld,
     Instruction, Predicate, VirtualMachine, World,
 };
 
@@ -143,13 +144,13 @@ pub(crate) fn free_panic<T: Tracer, W: World<T>>(
     world: &mut W,
     tracer: &mut T,
 ) -> ExecutionStatus {
-    tracer.before_instruction::<opcodes::Ret<Panic>, _>(vm, world);
+    tracer.before_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
     // args aren't used for panics unless TO_LABEL
     let result = naked_ret::<T, W, Panic, false>(
         vm,
         &Arguments::new(Predicate::Always, 0, ModeRequirements::none()),
     );
-    tracer.after_instruction::<opcodes::Ret<Panic>, _>(vm, world);
+    tracer.after_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
     result
 }
 
@@ -161,7 +162,7 @@ pub(crate) fn panic_from_failed_far_call<T: Tracer, W: World<T>>(
     tracer: &mut T,
     exception_handler: u16,
 ) {
-    tracer.before_instruction::<opcodes::Ret<Panic>, _>(vm, world);
+    tracer.before_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
 
     // Gas is already subtracted in the far call code.
     // No need to roll back, as no changes are made in this "frame".
@@ -171,7 +172,7 @@ pub(crate) fn panic_from_failed_far_call<T: Tracer, W: World<T>>(
     vm.state.flags = Flags::new(true, false, false);
     vm.state.current_frame.set_pc_from_u16(exception_handler);
 
-    tracer.after_instruction::<opcodes::Ret<Panic>, _>(vm, world);
+    tracer.after_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
 }
 
 fn invalid<T: Tracer, W: World<T>>(

--- a/crates/vm2/src/instruction_handlers/storage.rs
+++ b/crates/vm2/src/instruction_handlers/storage.rs
@@ -27,7 +27,7 @@ fn sstore<T: Tracer, W: World<T>>(
     })
 }
 
-fn sstore_transient<T: Tracer, W>(
+fn sstore_transient<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,
@@ -60,7 +60,7 @@ fn sload<T: Tracer, W: World<T>>(
     })
 }
 
-fn sload_transient<T: Tracer, W>(
+fn sload_transient<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
     tracer: &mut T,

--- a/crates/vm2/src/single_instruction_test/callframe.rs
+++ b/crates/vm2/src/single_instruction_test/callframe.rs
@@ -65,7 +65,7 @@ impl<'a, T: Tracer, W: World<T>> Arbitrary<'a> for Callframe<T, W> {
     }
 }
 
-impl<T: Tracer, W> Callframe<T, W> {
+impl<T: Tracer, W: World<T>> Callframe<T, W> {
     pub(crate) fn dummy() -> Self {
         Self {
             address: H160::zero(),

--- a/crates/vm2/src/single_instruction_test/print_mock_info.rs
+++ b/crates/vm2/src/single_instruction_test/print_mock_info.rs
@@ -1,8 +1,8 @@
 use zksync_vm2_interface::Tracer;
 
-use crate::{callframe::Callframe, state::State, VirtualMachine};
+use crate::{callframe::Callframe, state::State, VirtualMachine, World};
 
-impl<T: Tracer, W> VirtualMachine<T, W> {
+impl<T: Tracer, W: World<T>> VirtualMachine<T, W> {
     pub fn print_mock_info(&self) {
         self.state.print_mock_info();
         println!("Events: {:?}", self.world_diff.events());
@@ -14,7 +14,7 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
     }
 }
 
-impl<T: Tracer, W> State<T, W> {
+impl<T: Tracer, W: World<T>> State<T, W> {
     pub(crate) fn print_mock_info(&self) {
         if let Some((heap_id, heap)) = self.heaps.read.read_that_happened() {
             println!("Heap: {heap_id:?}");

--- a/crates/vm2/src/single_instruction_test/program.rs
+++ b/crates/vm2/src/single_instruction_test/program.rs
@@ -67,7 +67,7 @@ impl<T, W> Program<T, W> {
     }
 }
 
-impl<T: Tracer, W> Program<T, W> {
+impl<T: Tracer, W: World<T>> Program<T, W> {
     pub fn for_decommit() -> Self {
         Self {
             raw_first_instruction: 0,

--- a/crates/vm2/src/single_instruction_test/state_to_zk_evm.rs
+++ b/crates/vm2/src/single_instruction_test/state_to_zk_evm.rs
@@ -12,9 +12,10 @@ use crate::{
     callframe::{Callframe, NearCallFrame},
     instruction_handlers::spontaneous_panic,
     state::State,
+    World,
 };
 
-pub(crate) fn vm2_state_to_zk_evm_state<T: Tracer, W>(
+pub(crate) fn vm2_state_to_zk_evm_state<T: Tracer, W: World<T>>(
     state: &State<T, W>,
 ) -> VmLocalState<8, EncodingModeProduction> {
     // zk_evm requires an unused bottom frame

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -10,6 +10,7 @@ use crate::{
     program::Program,
     stack::Stack,
     world_diff::Snapshot,
+    World,
 };
 
 /// State of a [`VirtualMachine`](crate::VirtualMachine).
@@ -95,7 +96,7 @@ impl<T, W> State<T, W> {
     }
 }
 
-impl<T: Tracer, W> State<T, W> {
+impl<T: Tracer, W: World<T>> State<T, W> {
     /// Returns the total unspent gas in the VM, including stipends.
     pub(crate) fn total_unspent_gas(&self) -> u32 {
         self.current_frame.gas

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -12,48 +12,44 @@ use crate::{
     VirtualMachine, World,
 };
 
-pub(crate) struct VmAndWorld<'a, T, W> {
-    pub vm: &'a mut VirtualMachine<T, W>,
-    pub world: &'a mut W,
-}
+impl<T: Tracer, W: World<T>> StateInterface for VirtualMachine<T, W> {
+    type StorageInterface = W;
 
-impl<T: Tracer, W: World<T>> StateInterface for VmAndWorld<'_, T, W> {
     fn read_register(&self, register: u8) -> (U256, bool) {
         (
-            self.vm.state.registers[register as usize],
-            self.vm.state.register_pointer_flags & (1 << register) != 0,
+            self.state.registers[register as usize],
+            self.state.register_pointer_flags & (1 << register) != 0,
         )
     }
 
     fn set_register(&mut self, register: u8, value: U256, is_pointer: bool) {
-        self.vm.state.registers[register as usize] = value;
+        self.state.registers[register as usize] = value;
 
-        self.vm.state.register_pointer_flags &= !(1 << register);
-        self.vm.state.register_pointer_flags |= u16::from(is_pointer) << register;
+        self.state.register_pointer_flags &= !(1 << register);
+        self.state.register_pointer_flags |= u16::from(is_pointer) << register;
     }
 
     fn number_of_callframes(&self) -> usize {
-        self.vm
-            .state
+        self.state
             .previous_frames
             .iter()
             .map(|frame| frame.near_calls.len() + 1)
             .sum::<usize>()
-            + self.vm.state.current_frame.near_calls.len()
+            + self.state.current_frame.near_calls.len()
             + 1
     }
 
     fn current_frame(&mut self) -> impl CallframeInterface + '_ {
-        let near_call = self.vm.state.current_frame.near_calls.len().checked_sub(1);
+        let near_call = self.state.current_frame.near_calls.len().checked_sub(1);
         CallframeWrapper {
-            frame: &mut self.vm.state.current_frame,
+            frame: &mut self.state.current_frame,
             near_call,
         }
     }
 
     fn callframe(&mut self, mut n: usize) -> impl CallframeInterface + '_ {
-        for far_frame in std::iter::once(&mut self.vm.state.current_frame)
-            .chain(self.vm.state.previous_frames.iter_mut().rev())
+        for far_frame in std::iter::once(&mut self.state.current_frame)
+            .chain(self.state.previous_frames.iter_mut().rev())
         {
             let near_calls = far_frame.near_calls.len();
             match n.cmp(&near_calls) {
@@ -76,19 +72,19 @@ impl<T: Tracer, W: World<T>> StateInterface for VmAndWorld<'_, T, W> {
     }
 
     fn read_heap_byte(&self, heap: HeapId, index: u32) -> u8 {
-        self.vm.state.heaps[heap].read_byte(index)
+        self.state.heaps[heap].read_byte(index)
     }
 
     fn read_heap_u256(&self, heap: HeapId, index: u32) -> U256 {
-        self.vm.state.heaps[heap].read_u256(index)
+        self.state.heaps[heap].read_u256(index)
     }
 
     fn write_heap_u256(&mut self, heap: HeapId, index: u32, value: U256) {
-        self.vm.state.heaps.write_u256(heap, index, value);
+        self.state.heaps.write_u256(heap, index, value);
     }
 
     fn flags(&self) -> Flags {
-        let flags = &self.vm.state.flags;
+        let flags = &self.state.flags;
         Flags {
             less_than: Predicate::IfLT.satisfied(flags),
             greater: Predicate::IfGT.satisfied(flags),
@@ -97,50 +93,50 @@ impl<T: Tracer, W: World<T>> StateInterface for VmAndWorld<'_, T, W> {
     }
 
     fn set_flags(&mut self, flags: Flags) {
-        self.vm.state.flags = predication::Flags::new(flags.less_than, flags.equal, flags.greater);
+        self.state.flags = predication::Flags::new(flags.less_than, flags.equal, flags.greater);
     }
 
     fn transaction_number(&self) -> u16 {
-        self.vm.state.transaction_number
+        self.state.transaction_number
     }
 
     fn set_transaction_number(&mut self, value: u16) {
-        self.vm.state.transaction_number = value;
+        self.state.transaction_number = value;
     }
 
     fn context_u128_register(&self) -> u128 {
-        self.vm.state.context_u128
+        self.state.context_u128
     }
 
     fn set_context_u128_register(&mut self, value: u128) {
-        self.vm.state.context_u128 = value;
+        self.state.context_u128 = value;
     }
 
     fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
-        self.vm
-            .world_diff
+        self.world_diff
             .get_storage_state()
             .iter()
             .map(|(key, value)| (*key, *value))
     }
 
-    fn get_storage(&mut self, address: H160, slot: U256) -> U256 {
-        self.vm
-            .world_diff
-            .just_read_storage(self.world, address, slot)
+    fn get_storage(
+        &mut self,
+        storage: &mut Self::StorageInterface,
+        address: H160,
+        slot: U256,
+    ) -> U256 {
+        self.world_diff.just_read_storage(storage, address, slot)
     }
 
     fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
-        self.vm
-            .world_diff
+        self.world_diff
             .get_transient_storage_state()
             .iter()
             .map(|(key, value)| (*key, *value))
     }
 
     fn get_transient_storage(&self, address: H160, slot: U256) -> U256 {
-        self.vm
-            .world_diff
+        self.world_diff
             .get_transient_storage_state()
             .get(&(address, slot))
             .copied()
@@ -148,25 +144,24 @@ impl<T: Tracer, W: World<T>> StateInterface for VmAndWorld<'_, T, W> {
     }
 
     fn write_transient_storage(&mut self, address: H160, slot: U256, value: U256) {
-        self.vm
-            .world_diff
+        self.world_diff
             .write_transient_storage(address, slot, value);
     }
 
     fn events(&self) -> impl Iterator<Item = Event> {
-        self.vm.world_diff.events().iter().copied()
+        self.world_diff.events().iter().copied()
     }
 
     fn l2_to_l1_logs(&self) -> impl Iterator<Item = L2ToL1Log> {
-        self.vm.world_diff.l2_to_l1_logs().iter().copied()
+        self.world_diff.l2_to_l1_logs().iter().copied()
     }
 
     fn pubdata(&self) -> i32 {
-        self.vm.world_diff.pubdata()
+        self.world_diff.pubdata()
     }
 
     fn set_pubdata(&mut self, value: i32) {
-        self.vm.world_diff.pubdata.0 = value;
+        self.world_diff.pubdata.0 = value;
     }
 }
 

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -2,7 +2,8 @@ use std::cmp::Ordering;
 
 use primitive_types::{H160, U256};
 use zksync_vm2_interface::{
-    CallframeInterface, Event, Flags, HeapId, L2ToL1Log, StateInterface, Tracer,
+    CallframeInterface, Event, Flags, GlobalStateInterface, HeapId, L2ToL1Log, StateInterface,
+    Tracer,
 };
 
 use crate::{
@@ -13,8 +14,6 @@ use crate::{
 };
 
 impl<T: Tracer, W: World<T>> StateInterface for VirtualMachine<T, W> {
-    type StorageInterface = W;
-
     fn read_register(&self, register: u8) -> (U256, bool) {
         (
             self.state.registers[register as usize],
@@ -117,15 +116,6 @@ impl<T: Tracer, W: World<T>> StateInterface for VirtualMachine<T, W> {
             .get_storage_state()
             .iter()
             .map(|(key, value)| (*key, *value))
-    }
-
-    fn get_storage(
-        &mut self,
-        storage: &mut Self::StorageInterface,
-        address: H160,
-        slot: U256,
-    ) -> U256 {
-        self.world_diff.just_read_storage(storage, address, slot)
     }
 
     fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
@@ -354,6 +344,89 @@ impl<T, W> CallframeWrapper<'_, T, W> {
     fn near_call_on_top_mut(&mut self) -> Option<&mut NearCallFrame> {
         let index = self.near_call.map_or(0, |i| i + 1);
         self.frame.near_calls.get_mut(index)
+    }
+}
+
+pub(crate) struct VmAndWorld<'a, T, W> {
+    pub vm: &'a mut VirtualMachine<T, W>,
+    pub world: &'a mut W,
+}
+
+impl<T: Tracer, W: World<T>> GlobalStateInterface for VmAndWorld<'_, T, W> {
+    fn get_storage(&mut self, address: H160, slot: U256) -> U256 {
+        self.vm
+            .world_diff
+            .just_read_storage(self.world, address, slot)
+    }
+}
+
+// This impl just forwards all calls to the VM part of VmAndWorld
+impl<T: Tracer, W: World<T>> StateInterface for VmAndWorld<'_, T, W> {
+    fn read_register(&self, register: u8) -> (U256, bool) {
+        self.vm.read_register(register)
+    }
+    fn set_register(&mut self, register: u8, value: U256, is_pointer: bool) {
+        self.vm.set_register(register, value, is_pointer);
+    }
+    fn current_frame(&mut self) -> impl CallframeInterface + '_ {
+        self.vm.current_frame()
+    }
+    fn number_of_callframes(&self) -> usize {
+        self.vm.number_of_callframes()
+    }
+    fn callframe(&mut self, n: usize) -> impl CallframeInterface + '_ {
+        self.vm.callframe(n)
+    }
+    fn read_heap_byte(&self, heap: HeapId, offset: u32) -> u8 {
+        self.vm.read_heap_byte(heap, offset)
+    }
+    fn read_heap_u256(&self, heap: HeapId, offset: u32) -> U256 {
+        self.vm.read_heap_u256(heap, offset)
+    }
+    fn write_heap_u256(&mut self, heap: HeapId, offset: u32, value: U256) {
+        self.vm.write_heap_u256(heap, offset, value);
+    }
+    fn flags(&self) -> Flags {
+        self.vm.flags()
+    }
+    fn set_flags(&mut self, flags: Flags) {
+        self.vm.set_flags(flags);
+    }
+    fn transaction_number(&self) -> u16 {
+        self.vm.transaction_number()
+    }
+    fn set_transaction_number(&mut self, value: u16) {
+        self.vm.set_transaction_number(value);
+    }
+    fn context_u128_register(&self) -> u128 {
+        self.vm.context_u128_register()
+    }
+    fn set_context_u128_register(&mut self, value: u128) {
+        self.vm.set_context_u128_register(value);
+    }
+    fn get_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
+        self.vm.get_storage_state()
+    }
+    fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {
+        self.vm.get_transient_storage_state()
+    }
+    fn get_transient_storage(&self, address: H160, slot: U256) -> U256 {
+        self.vm.get_transient_storage(address, slot)
+    }
+    fn write_transient_storage(&mut self, address: H160, slot: U256, value: U256) {
+        self.vm.write_transient_storage(address, slot, value);
+    }
+    fn events(&self) -> impl Iterator<Item = Event> {
+        self.vm.events()
+    }
+    fn l2_to_l1_logs(&self) -> impl Iterator<Item = L2ToL1Log> {
+        self.vm.l2_to_l1_logs()
+    }
+    fn pubdata(&self) -> i32 {
+        self.vm.pubdata()
+    }
+    fn set_pubdata(&mut self, value: i32) {
+        self.vm.set_pubdata(value);
     }
 }
 


### PR DESCRIPTION
Tracers can now read storage slots. This is required for the validation tracer.

## TODO
- [x] check that the extra plumbing does not affect performance