### PR TITLE
fix: failing far call tracing

### DIFF
--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -108,7 +108,7 @@ where
 
         // A far call pushes a new frame and returns from it in the next instruction if it panics.
         let (calldata, program, is_evm_interpreter) =
-            failing_part.unwrap_or((U256::zero().into(), Program::new_panicking(), false));
+            failing_part.unwrap_or_else(|| (U256::zero().into(), Program::new_panicking(), false));
 
         let stipend = if is_evm_interpreter {
             EVM_SIMULATOR_STIPEND

--- a/crates/vm2/src/program.rs
+++ b/crates/vm2/src/program.rs
@@ -87,6 +87,10 @@ impl<T: Tracer, W: World<T>> Program<T, W> {
         }
     }
 
+    pub(crate) fn new_panicking() -> Self {
+        Self::from_raw(vec![Instruction::from_spontaneous_panic()], vec![])
+    }
+
     #[doc(hidden)] // should only be used in low-level tests / benchmarks
     pub fn from_raw(instructions: Vec<Instruction<T, W>>, code_page: Vec<U256>) -> Self {
         Self {

--- a/crates/vm2/src/single_instruction_test/program.rs
+++ b/crates/vm2/src/single_instruction_test/program.rs
@@ -82,6 +82,21 @@ impl<T: Tracer, W: World<T>> Program<T, W> {
             code_page: Arc::new([U256::zero(); 1]),
         }
     }
+
+    pub(crate) fn new_panicking() -> Self {
+        Self {
+            raw_first_instruction: 0,
+            first_instruction: MockRead::new(Rc::new([
+                Instruction::from_spontaneous_panic(),
+                Instruction::from_invalid(),
+            ])),
+            other_instruction: MockRead::new(Rc::new(Some([
+                Instruction::from_invalid(),
+                Instruction::from_invalid(),
+            ]))),
+            code_page: Arc::new([U256::zero(); 1]),
+        }
+    }
 }
 
 impl<T, W> PartialEq for Program<T, W> {

--- a/crates/vm2/src/tests/mod.rs
+++ b/crates/vm2/src/tests/mod.rs
@@ -4,3 +4,4 @@ mod bytecode_behaviour;
 mod far_call_decommitment;
 mod panic;
 mod stipend;
+mod trace_failing_far_call;

--- a/crates/vm2/src/tests/trace_failing_far_call.rs
+++ b/crates/vm2/src/tests/trace_failing_far_call.rs
@@ -1,0 +1,85 @@
+use zkevm_opcode_defs::ethereum_types::Address;
+
+use crate::{
+    addressing_modes::{Arguments, Immediate1, Register, Register1, Register2},
+    interface::{
+        opcodes::Normal, CallingMode, GlobalStateInterface, Opcode, OpcodeType, ReturnType,
+        ShouldStop, Tracer,
+    },
+    testonly::{initial_decommit, TestWorld},
+    Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
+};
+
+struct ExpectingTracer {
+    future: Vec<Opcode>,
+    current: Option<Opcode>,
+}
+
+impl ExpectingTracer {
+    fn new(mut opcodes: Vec<Opcode>) -> Self {
+        opcodes.reverse();
+        Self {
+            future: opcodes,
+            current: None,
+        }
+    }
+}
+
+impl Tracer for ExpectingTracer {
+    fn before_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, _: &mut S) {
+        assert!(self.current.is_none(), "expected after_instruction");
+
+        let expected = self.future.pop().expect("expected program end");
+        assert_eq!(OP::VALUE, expected);
+        self.current = Some(expected);
+    }
+    fn after_instruction<OP: OpcodeType, S: GlobalStateInterface>(
+        &mut self,
+        _: &mut S,
+    ) -> ShouldStop {
+        assert_eq!(
+            OP::VALUE,
+            self.current.take().expect("expected before_instruction")
+        );
+        ShouldStop::Continue
+    }
+}
+
+#[test]
+fn trace_failing_far_call() {
+    let instructions = vec![Instruction::from_far_call::<Normal>(
+        Register1(Register::new(0)),
+        Register2(Register::new(1)),
+        Immediate1(1),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 25, ModeRequirements::none()),
+    )];
+
+    let program = Program::from_raw(instructions, vec![]);
+
+    let address = Address::from_low_u64_be(0x_1234_5678_90ab_cdef);
+    let mut world = TestWorld::new(&[(address, program)]);
+    let program = initial_decommit(&mut world, address);
+
+    let mut vm = VirtualMachine::new(
+        address,
+        program,
+        Address::zero(),
+        &[],
+        1000,
+        Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+        },
+    );
+
+    vm.run(
+        &mut world,
+        &mut ExpectingTracer::new(vec![
+            Opcode::FarCall(CallingMode::Normal),
+            Opcode::Ret(ReturnType::Panic),
+        ]),
+    );
+}

--- a/crates/vm2/src/tests/trace_failing_far_call.rs
+++ b/crates/vm2/src/tests/trace_failing_far_call.rs
@@ -93,5 +93,5 @@ fn trace_failing_far_call() {
     ]);
     vm.run(&mut world, &mut tracer);
 
-    assert!(tracer.witnessed_all_opcodes())
+    assert!(tracer.witnessed_all_opcodes());
 }


### PR DESCRIPTION
Fixes tracing so that a failed far call reports a far call and then a panic to tracers instead of reporting the panic in the middle of the far call.