### PR TITLE
ci: fix PR title workflow by removing unnecessary check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 jobs:
-  lint:
+  conventional-pr-title:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -18,15 +18,6 @@ jobs:
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: guibranco/github-status-action-v2@v1.1.13
-        if: always()
-        with:
-          authToken: ${{ secrets.GITHUB_TOKEN }}
-          state: ${{ (steps.lint_pr_title.outputs.error_message != null) && 'error' || 'success' }}
-          context: 'conventional-pr-title'
-          description: PR title ${{ (steps.lint_pr_title.outputs.error_message != null) && 'does not match' || 'matches' }} Conventional Commits spec
-          sha: ${{ github.event.pull_request.head.sha }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
         # When the previous steps fails, the workflow would stop. By adding this

--- a/crates/vm2/src/addressing_modes.rs
+++ b/crates/vm2/src/addressing_modes.rs
@@ -121,7 +121,7 @@ impl Arguments {
             destination_registers: PackedRegisters(0),
             immediate1: 0,
             immediate2: 0,
-            predicate_and_mode_requirements: (predicate as u8) << 2 | mode_requirements.0,
+            predicate_and_mode_requirements: ((predicate as u8) << 2) | mode_requirements.0,
             static_gas_cost: Self::encode_static_gas_cost(gas_cost),
         }
     }

--- a/crates/vm2/src/instruction_handlers/binop.rs
+++ b/crates/vm2/src/instruction_handlers/binop.rs
@@ -127,7 +127,7 @@ impl Binop for RotateLeft {
     #[inline(always)]
     fn perform(a: &U256, b: &U256) -> (U256, (), Flags) {
         let shift = b.low_u32() % 256;
-        let result = *a << shift | *a >> (256 - shift);
+        let result = (*a << shift) | (*a >> (256 - shift));
         (result, (), Flags::new(false, result.is_zero(), false))
     }
     type Out2 = ();
@@ -137,7 +137,7 @@ impl Binop for RotateRight {
     #[inline(always)]
     fn perform(a: &U256, b: &U256) -> (U256, (), Flags) {
         let shift = b.low_u32() % 256;
-        let result = *a >> shift | *a << (256 - shift);
+        let result = (*a >> shift) | (*a << (256 - shift));
         (result, (), Flags::new(false, result.is_zero(), false))
     }
     type Out2 = ();

--- a/crates/vm2/src/precompiles/legacy.rs
+++ b/crates/vm2/src/precompiles/legacy.rs
@@ -160,7 +160,7 @@ mod tests {
         let address_digest = sha3::Keccak256::digest(encoded_key);
         let address_u256 = U256::from_big_endian(&address_digest);
         // Mask out upper bytes of the hash.
-        address_u256 & U256::MAX >> (256 - 160)
+        address_u256 & (U256::MAX >> (256 - 160))
     }
 
     fn test_keccak_precompile(input: &[u8], initial_offset: u32) -> Result<(), TestCaseError> {

--- a/crates/vm2/src/predication.rs
+++ b/crates/vm2/src/predication.rs
@@ -31,7 +31,7 @@ pub enum Predicate {
     /// Execute the associated instruction if either of "less than" or "equal" execution flags are set.
     IfLE = LT_BIT | EQ_BIT,
     /// Execute the associated instruction if the "equal" execution flag is not set.
-    IfNotEQ = EQ_BIT << 4 | ALWAYS_BIT,
+    IfNotEQ = (EQ_BIT << 4) | ALWAYS_BIT,
     /// Execute the associated instruction if either of "less than" or "greater than" execution flags are set.
     IfGTOrLT = GT_BIT | LT_BIT,
 }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -413,7 +413,7 @@ mod tests {
                     .map_or_else(U256::zero, |slot| slot.value);
                 let is_initial = initial_values
                     .get(key)
-                    .map_or(true, |slot| slot.is_write_initial);
+                    .is_none_or(|slot| slot.is_write_initial);
                 (
                     *key,
                     StorageChange {
@@ -443,7 +443,7 @@ mod tests {
                     .unwrap_or_default();
                 let is_initial = initial_values
                     .get(key)
-                    .map_or(true, |slot| slot.is_write_initial);
+                    .is_none_or(|slot| slot.is_write_initial);
                 (
                     *key,
                     StorageChange {


### PR DESCRIPTION
# What ❔

* [x] Fix PR title workflow by removing the unnecessary check
* [x] Fix clippy issues 

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Workflow is not working properly for external collaborators if `github-status-action-v2` is in use, it's unnecessary and should be removed.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and `cargo clippy`.
