### PR TITLE
feat: Extend functionality & fix regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Nightly Rust necessary for building docs.
-  RUST_NIGHTLY_VERSION: nightly-2025-03-19
+  RUST_NIGHTLY_VERSION: nightly-2026-02-10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Nightly Rust necessary for building docs.
-  RUST_NIGHTLY_VERSION: nightly-2024-08-01
+  RUST_NIGHTLY_VERSION: nightly-2025-03-19
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,7 +27,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
           components: rustfmt, clippy, rust-src
 
       - name: Rust Cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -322,7 +322,7 @@ dependencies = [
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -395,7 +395,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -407,7 +407,7 @@ checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "arbitrary",
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -417,12 +417,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -471,7 +465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -845,7 +839,7 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -883,26 +877,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -912,23 +893,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -945,16 +911,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -1121,7 +1078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1302,28 +1259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,9 +1407,7 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zk_evm"
-version = "0.153.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aab29500e8021fb6fab4b5df7cf1df322d8edd76bc8dfed12ffd1f47988f0d"
+version = "0.153.6"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -1487,9 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "zk_evm_abstractions"
-version = "0.153.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6937012712525098ce376465c33fc0e6b0e833a4b72f0e4b58713944ed3d3eee"
+version = "0.153.6"
 dependencies = [
  "anyhow",
  "num_enum",
@@ -1500,9 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "zkevm_opcode_defs"
-version = "0.153.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca091066c3b64c6d7b6e411fd5a1c81db1f21b0a497c4578e1c55e35ed6f01a"
+version = "0.153.6"
 dependencies = [
  "bitflags",
  "blake2",
@@ -1518,22 +1447,18 @@ dependencies = [
 
 [[package]]
 name = "zksync_ff"
-version = "0.32.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f2aba6f5ee6c4f138eb49d419d2447bb369e7d7a6f256b31ad478795641d0a"
+version = "0.32.7"
 dependencies = [
  "byteorder",
  "hex",
- "rand 0.4.6",
+ "rand",
  "serde",
  "zksync_ff_derive",
 ]
 
 [[package]]
 name = "zksync_ff_derive"
-version = "0.32.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e62c7d995701bfd053958ce2050fced2013ff136bb53d350ffcac6d149a1fd3"
+version = "0.32.7"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -1546,13 +1471,11 @@ dependencies = [
 
 [[package]]
 name = "zksync_pairing"
-version = "0.32.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8348a287108fbb8a1b761ae66f9b344d74df444cb365f8a8259c091be708c5a"
+version = "0.32.7"
 dependencies = [
  "byteorder",
  "cfg-if",
- "rand 0.4.6",
+ "rand",
  "serde",
  "zksync_ff",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "k256"
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sec1"
@@ -1040,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -1407,7 +1407,7 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zk_evm"
-version = "0.153.6"
+version = "0.153.9"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "zk_evm_abstractions"
-version = "0.153.6"
+version = "0.153.9"
 dependencies = [
  "anyhow",
  "num_enum",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "zkevm_opcode_defs"
-version = "0.153.6"
+version = "0.153.9"
 dependencies = [
  "bitflags",
  "blake2",
@@ -1447,18 +1447,23 @@ dependencies = [
 
 [[package]]
 name = "zksync_ff"
-version = "0.32.7"
+version = "0.32.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bc485f5d7a16a83bebde0a083f8d27d94001c58485fbf3b12a21ed9ad3aacc0"
 dependencies = [
  "byteorder",
  "hex",
  "rand",
+ "rand_xorshift",
  "serde",
  "zksync_ff_derive",
 ]
 
 [[package]]
 name = "zksync_ff_derive"
-version = "0.32.7"
+version = "0.32.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ca7e4f9d2756e9b0e3df70a8d18a49412f0706a485eb0bcd903874247a6317"
 dependencies = [
  "num-bigint",
  "num-integer",
@@ -1471,11 +1476,14 @@ dependencies = [
 
 [[package]]
 name = "zksync_pairing"
-version = "0.32.7"
+version = "0.32.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1becfb74e11f67afb73366c2f57412feab53581da029e6107719424b332b8b"
 dependencies = [
  "byteorder",
  "cfg-if",
  "rand",
+ "rand_xorshift",
  "serde",
  "zksync_ff",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,6 +1731,7 @@ dependencies = [
 [[package]]
 name = "zk_evm"
 version = "0.153.9"
+source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -1744,6 +1745,7 @@ dependencies = [
 [[package]]
 name = "zk_evm_abstractions"
 version = "0.153.9"
+source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "airbender-crypto",
  "anyhow",
@@ -1756,6 +1758,7 @@ dependencies = [
 [[package]]
 name = "zkevm_opcode_defs"
 version = "0.153.9"
+source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "bitflags",
  "blake2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "afl"
+version = "0.15.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927cd71710d1a232519e2393470e8f74a178ae59367efe58fa122884bba35ca4"
+dependencies = [
+ "home",
+ "libc",
+ "rustc_version",
+ "xdg",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +456,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,7 +595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -715,6 +733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1011,6 +1038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,7 +1264,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1258,6 +1304,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "seq-macro"
@@ -1388,7 +1440,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1398,7 +1450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1516,12 +1568,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1623,6 +1690,18 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
@@ -1764,6 +1843,18 @@ dependencies = [
  "zk_evm",
  "zk_evm_abstractions",
  "zkevm_opcode_defs",
+ "zksync_vm2_interface",
+]
+
+[[package]]
+name = "zksync_vm2_afl_fuzz"
+version = "0.5.0"
+dependencies = [
+ "afl",
+ "arbitrary",
+ "pretty_assertions",
+ "zkevm_opcode_defs",
+ "zksync_vm2",
  "zksync_vm2_interface",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "airbender-crypto"
+version = "0.1.0"
+source = "git+https://github.com/popzxc/airbender-platform?branch=main#5260a728bd023653dcd7832c3a5fc1fb52f1b0ee"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "blake2",
+ "blake2s_u32",
+ "cfg-if",
+ "common_constants",
+ "const_for",
+ "educe",
+ "itertools 0.14.0",
+ "k256",
+ "num-bigint",
+ "num-traits",
+ "p256",
+ "ripemd",
+ "ruint",
+ "seq-macro",
+ "sha2",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +81,142 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
+ "arrayvec",
+ "digest",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
+ "educe",
+ "fnv",
+ "hashbrown",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive",
+ "ark-std",
+ "arrayvec",
+ "digest",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -102,6 +286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2s_u32"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#769ec2e3937fa591221e8f27dab66273c8ab1ffb"
+dependencies = [
+ "common_constants",
+ "unroll",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +354,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "common_constants"
+version = "0.1.0"
+source = "git+https://github.com/matter-labs/zksync-airbender?branch=dev#769ec2e3937fa591221e8f27dab66273c8ab1ffb"
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +369,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_for"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c50fcfdf972929aff202c16b80086aa3cfc6a3a820af714096c58c7c1d0582"
 
 [[package]]
 name = "const_format"
@@ -309,6 +513,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +548,26 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -474,6 +716,9 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "hex"
@@ -545,6 +790,24 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -739,6 +1002,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -937,6 +1206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1223,21 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+dependencies = [
+ "ruint-macro",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hex"
@@ -1017,6 +1310,12 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -1229,6 +1528,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unroll"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad948c1cb799b1a70f836077721a92a35ac177d4daddf4c20a633786d4cf618"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,6 +1713,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "zk_evm"
@@ -1422,6 +1745,7 @@ dependencies = [
 name = "zk_evm_abstractions"
 version = "0.153.9"
 dependencies = [
+ "airbender-crypto",
  "anyhow",
  "num_enum",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,6 +1667,7 @@ dependencies = [
 [[package]]
 name = "zk_evm"
 version = "0.153.9"
+source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -1680,6 +1681,7 @@ dependencies = [
 [[package]]
 name = "zk_evm_abstractions"
 version = "0.153.9"
+source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "airbender-crypto",
  "anyhow",
@@ -1692,6 +1694,7 @@ dependencies = [
 [[package]]
 name = "zkevm_opcode_defs"
 version = "0.153.9"
+source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "bitflags",
  "blake2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "afl"
-version = "0.15.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a52fe37aa5cbfc75353ee072a0a096036bcb6361ff5f661f7201f3a7f062a2"
-dependencies = [
- "home",
- "libc",
- "rustc_version",
- "xdg",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,12 +444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,15 +715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys",
 ]
 
 [[package]]
@@ -1038,16 +1011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,15 +1209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,12 +1258,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "seq-macro"
@@ -1677,18 +1625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xdg"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
 name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,7 +1667,6 @@ dependencies = [
 [[package]]
 name = "zk_evm"
 version = "0.153.9"
-source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -1745,7 +1680,6 @@ dependencies = [
 [[package]]
 name = "zk_evm_abstractions"
 version = "0.153.9"
-source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "airbender-crypto",
  "anyhow",
@@ -1758,7 +1692,6 @@ dependencies = [
 [[package]]
 name = "zkevm_opcode_defs"
 version = "0.153.9"
-source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#55f7a4cf5f590545edc1c26e31956815a79b037d"
 dependencies = [
  "bitflags",
  "blake2",
@@ -1828,18 +1761,6 @@ dependencies = [
  "zk_evm",
  "zk_evm_abstractions",
  "zkevm_opcode_defs",
- "zksync_vm2_interface",
-]
-
-[[package]]
-name = "zksync_vm2_afl_fuzz"
-version = "0.5.0"
-dependencies = [
- "afl",
- "arbitrary",
- "pretty_assertions",
- "zkevm_opcode_defs",
- "zksync_vm2",
  "zksync_vm2_interface",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "crates/vm2-interface",
     "crates/vm2",
     # Testing crates
-    # "tests/afl-fuzz"
+    "tests/afl-fuzz"
 ]
 resolver = "2"
 
@@ -30,9 +30,9 @@ primitive-types = "0.12.1"
 proptest = "1.4"
 
 # "Internal" dependencies
-zkevm_opcode_defs = { path = "../zksync-protocol/crates/zkevm_opcode_defs" }
-zk_evm_abstractions = { path = "../zksync-protocol/crates/zk_evm_abstractions" }
-zk_evm = { path = "../zksync-protocol/crates/zk_evm" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
+zk_evm_abstractions = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
+zk_evm = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
 
 # Dependencies within the workspace
 zksync_vm2_interface = { version = "=0.5.0", path = "crates/vm2-interface" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = [
     "crates/vm2-interface",
     "crates/vm2",
     # Testing crates
-    "tests/afl-fuzz"
+    # "tests/afl-fuzz"
 ]
 resolver = "2"
 
@@ -30,9 +30,9 @@ primitive-types = "0.12.1"
 proptest = "1.4"
 
 # "Internal" dependencies
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
-zk_evm_abstractions = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
-zk_evm = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
+zkevm_opcode_defs = { path = "../zksync-protocol/crates/zkevm_opcode_defs" }
+zk_evm_abstractions = { path = "../zksync-protocol/crates/zk_evm_abstractions" }
+zk_evm = { path = "../zksync-protocol/crates/zk_evm" }
 
 # Dependencies within the workspace
 zksync_vm2_interface = { version = "=0.5.0", path = "crates/vm2-interface" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ primitive-types = "0.12.1"
 proptest = "1.4"
 
 # "Internal" dependencies
-zkevm_opcode_defs = { version ="0.153.0", path = "../zksync-protocol/crates/zkevm_opcode_defs" }
-zk_evm_abstractions = { version ="0.153.0", path = "../zksync-protocol/crates/zk_evm_abstractions" }
-zk_evm = { version ="0.153.0", path = "../zksync-protocol/crates/zk_evm" }
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
+zk_evm_abstractions = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
+zk_evm = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
 
 # Dependencies within the workspace
 zksync_vm2_interface = { version = "=0.5.0", path = "crates/vm2-interface" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ primitive-types = "0.12.1"
 proptest = "1.4"
 
 # "Internal" dependencies
-zkevm_opcode_defs = "0.153.0"
-zk_evm_abstractions = "0.153.0"
-zk_evm = "0.153.0"
+zkevm_opcode_defs = { version ="0.153.0", path = "../zksync-protocol/crates/zkevm_opcode_defs" }
+zk_evm_abstractions = { version ="0.153.0", path = "../zksync-protocol/crates/zk_evm_abstractions" }
+zk_evm = { version ="0.153.0", path = "../zksync-protocol/crates/zk_evm" }
 
 # Dependencies within the workspace
 zksync_vm2_interface = { version = "=0.5.0", path = "crates/vm2-interface" }

--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -160,11 +160,11 @@ pub struct HeapId(u32);
 
 impl HeapId {
     /// Identifier of the calldata heap used by the first executed program (i.e., the bootloader).
-    pub const FIRST_CALLDATA: Self = Self(1);
+    pub const FIRST_CALLDATA: Self = Self(7);
     /// Identifier of the heap used by the first executed program (i.e., the bootloader).
-    pub const FIRST: Self = Self(2);
+    pub const FIRST: Self = Self(10);
     /// Identifier of the auxiliary heap used by the first executed program (i.e., the bootloader)
-    pub const FIRST_AUX: Self = Self(3);
+    pub const FIRST_AUX: Self = Self(11);
 
     /// Only for dealing with external data structures, never use internally.
     #[doc(hidden)]

--- a/crates/vm2-interface/src/tracer_interface.rs
+++ b/crates/vm2-interface/src/tracer_interface.rs
@@ -34,6 +34,8 @@ macro_rules! forall_simple_opcodes {
         $m!(HeapWrite);
         $m!(AuxHeapRead);
         $m!(AuxHeapWrite);
+        $m!(StaticMemoryRead);
+        $m!(StaticMemoryWrite);
         $m!(PointerRead);
         $m!(PointerAdd);
         $m!(PointerSub);
@@ -165,6 +167,8 @@ pub enum Opcode {
     HeapWrite,
     AuxHeapRead,
     AuxHeapWrite,
+    StaticMemoryRead,
+    StaticMemoryWrite,
     PointerRead,
     PointerAdd,
     PointerSub,

--- a/crates/vm2/Cargo.toml
+++ b/crates/vm2/Cargo.toml
@@ -37,4 +37,4 @@ harness = false
 [features]
 default = []
 airbender-precompile-delegations = ["zk_evm_abstractions/airbender-precompile-delegations"]
-single_instruction_test = ["arbitrary", "primitive-types/arbitrary", "zk_evm", "anyhow"]
+single_instruction_test = ["arbitrary", "primitive-types/arbitrary", "zk_evm", "anyhow"] # TODO UNCOMMENT

--- a/crates/vm2/Cargo.toml
+++ b/crates/vm2/Cargo.toml
@@ -36,4 +36,5 @@ harness = false
 
 [features]
 default = []
+airbender-precompile-delegations = ["zk_evm_abstractions/airbender-precompile-delegations"]
 single_instruction_test = ["arbitrary", "primitive-types/arbitrary", "zk_evm", "anyhow"]

--- a/crates/vm2/benches/nested_near_call.rs
+++ b/crates/vm2/benches/nested_near_call.rs
@@ -1,97 +1,97 @@
-// //! Low-level benchmarks.
+//! Low-level benchmarks.
 
-// use divan::{black_box, Bencher};
-// use zkevm_opcode_defs::ethereum_types::Address;
-// use zksync_vm2::{
-//     addressing_modes::{Arguments, Immediate1, Immediate2, Register, Register1, Register2},
-//     testonly::{initial_decommit, TestWorld},
-//     Instruction, ModeRequirements,
-//     Predicate::Always,
-//     Program, Settings, VirtualMachine,
-// };
+use divan::{black_box, Bencher};
+use zkevm_opcode_defs::ethereum_types::Address;
+use zksync_vm2::{
+    addressing_modes::{Arguments, Immediate1, Immediate2, Register, Register1, Register2},
+    testonly::{initial_decommit, TestWorld},
+    Instruction, ModeRequirements,
+    Predicate::Always,
+    Program, Settings, VirtualMachine,
+};
 
-// #[divan::bench]
-// fn nested_near_call(bencher: Bencher) {
-//     let program = Program::from_raw(
-//         vec![Instruction::from_near_call(
-//             // zero means pass all gas
-//             Register1(Register::new(0)),
-//             Immediate1(0),
-//             Immediate2(0),
-//             Arguments::new(Always, 10, ModeRequirements::none()),
-//         )],
-//         vec![],
-//     );
+#[divan::bench]
+fn nested_near_call(bencher: Bencher) {
+    let program = Program::from_raw(
+        vec![Instruction::from_near_call(
+            // zero means pass all gas
+            Register1(Register::new(0)),
+            Immediate1(0),
+            Immediate2(0),
+            Arguments::new(Always, 10, ModeRequirements::none()),
+        )],
+        vec![],
+    );
 
-//     let address = Address::from_low_u64_be(0x_abe1_23ff);
+    let address = Address::from_low_u64_be(0x_abe1_23ff);
 
-//     bencher.bench(|| {
-//         let mut world = TestWorld::new(&[(address, program.clone())]);
-//         let program = initial_decommit(&mut world, address);
-//         let mut vm = VirtualMachine::new(
-//             address,
-//             program,
-//             Address::zero(),
-//             &[],
-//             10_000_000,
-//             Settings {
-//                 default_aa_code_hash: [0; 32],
-//                 evm_interpreter_code_hash: [0; 32],
-//                 hook_address: 0,
-//             },
-//         );
+    bencher.bench(|| {
+        let mut world = TestWorld::new(&[(address, program.clone())]);
+        let program = initial_decommit(&mut world, address);
+        let mut vm = VirtualMachine::new(
+            address,
+            program,
+            Address::zero(),
+            &[],
+            10_000_000,
+            Settings {
+                default_aa_code_hash: [0; 32],
+                evm_interpreter_code_hash: [0; 32],
+                hook_address: 0,
+            },
+        );
 
-//         vm.run(black_box(&mut world), &mut ());
-//     });
-// }
+        vm.run(black_box(&mut world), &mut ());
+    });
+}
 
-// #[divan::bench]
-// fn nested_near_call_with_storage_write(bencher: Bencher) {
-//     let program = Program::from_raw(
-//         vec![
-//             Instruction::from_ergs_left(
-//                 Register1(Register::new(1)),
-//                 Arguments::new(Always, 5, ModeRequirements::none()),
-//             ),
-//             Instruction::from_storage_write(
-//                 // always use same storage slot to get a warm write discount
-//                 Register1(Register::new(0)),
-//                 Register2(Register::new(1)),
-//                 Arguments::new(Always, 5511, ModeRequirements::none()), // need to use actual cost to not create free gas from refunds
-//             ),
-//             Instruction::from_near_call(
-//                 // zero means pass all gas
-//                 Register1(Register::new(0)),
-//                 Immediate1(0),
-//                 Immediate2(0),
-//                 Arguments::new(Always, 25, ModeRequirements::none()),
-//             ),
-//         ],
-//         vec![],
-//     );
+#[divan::bench]
+fn nested_near_call_with_storage_write(bencher: Bencher) {
+    let program = Program::from_raw(
+        vec![
+            Instruction::from_ergs_left(
+                Register1(Register::new(1)),
+                Arguments::new(Always, 5, ModeRequirements::none()),
+            ),
+            Instruction::from_storage_write(
+                // always use same storage slot to get a warm write discount
+                Register1(Register::new(0)),
+                Register2(Register::new(1)),
+                Arguments::new(Always, 5511, ModeRequirements::none()), // need to use actual cost to not create free gas from refunds
+            ),
+            Instruction::from_near_call(
+                // zero means pass all gas
+                Register1(Register::new(0)),
+                Immediate1(0),
+                Immediate2(0),
+                Arguments::new(Always, 25, ModeRequirements::none()),
+            ),
+        ],
+        vec![],
+    );
 
-//     let address = Address::from_low_u64_be(0x_abe1_23ff);
+    let address = Address::from_low_u64_be(0x_abe1_23ff);
 
-//     bencher.bench(|| {
-//         let mut world = TestWorld::new(&[(address, program.clone())]);
-//         let program = initial_decommit(&mut world, address);
-//         let mut vm = VirtualMachine::new(
-//             address,
-//             program,
-//             Address::zero(),
-//             &[],
-//             80_000_000,
-//             Settings {
-//                 default_aa_code_hash: [0; 32],
-//                 evm_interpreter_code_hash: [0; 32],
-//                 hook_address: 0,
-//             },
-//         );
+    bencher.bench(|| {
+        let mut world = TestWorld::new(&[(address, program.clone())]);
+        let program = initial_decommit(&mut world, address);
+        let mut vm = VirtualMachine::new(
+            address,
+            program,
+            Address::zero(),
+            &[],
+            80_000_000,
+            Settings {
+                default_aa_code_hash: [0; 32],
+                evm_interpreter_code_hash: [0; 32],
+                hook_address: 0,
+            },
+        );
 
-//         vm.run(black_box(&mut world), &mut ());
-//     });
-// }
+        vm.run(black_box(&mut world), &mut ());
+    });
+}
 
 fn main() {
-    // divan::main();
+    divan::main();
 }

--- a/crates/vm2/benches/nested_near_call.rs
+++ b/crates/vm2/benches/nested_near_call.rs
@@ -1,97 +1,97 @@
-//! Low-level benchmarks.
+// //! Low-level benchmarks.
 
-use divan::{black_box, Bencher};
-use zkevm_opcode_defs::ethereum_types::Address;
-use zksync_vm2::{
-    addressing_modes::{Arguments, Immediate1, Immediate2, Register, Register1, Register2},
-    testonly::{initial_decommit, TestWorld},
-    Instruction, ModeRequirements,
-    Predicate::Always,
-    Program, Settings, VirtualMachine,
-};
+// use divan::{black_box, Bencher};
+// use zkevm_opcode_defs::ethereum_types::Address;
+// use zksync_vm2::{
+//     addressing_modes::{Arguments, Immediate1, Immediate2, Register, Register1, Register2},
+//     testonly::{initial_decommit, TestWorld},
+//     Instruction, ModeRequirements,
+//     Predicate::Always,
+//     Program, Settings, VirtualMachine,
+// };
 
-#[divan::bench]
-fn nested_near_call(bencher: Bencher) {
-    let program = Program::from_raw(
-        vec![Instruction::from_near_call(
-            // zero means pass all gas
-            Register1(Register::new(0)),
-            Immediate1(0),
-            Immediate2(0),
-            Arguments::new(Always, 10, ModeRequirements::none()),
-        )],
-        vec![],
-    );
+// #[divan::bench]
+// fn nested_near_call(bencher: Bencher) {
+//     let program = Program::from_raw(
+//         vec![Instruction::from_near_call(
+//             // zero means pass all gas
+//             Register1(Register::new(0)),
+//             Immediate1(0),
+//             Immediate2(0),
+//             Arguments::new(Always, 10, ModeRequirements::none()),
+//         )],
+//         vec![],
+//     );
 
-    let address = Address::from_low_u64_be(0x_abe1_23ff);
+//     let address = Address::from_low_u64_be(0x_abe1_23ff);
 
-    bencher.bench(|| {
-        let mut world = TestWorld::new(&[(address, program.clone())]);
-        let program = initial_decommit(&mut world, address);
-        let mut vm = VirtualMachine::new(
-            address,
-            program,
-            Address::zero(),
-            &[],
-            10_000_000,
-            Settings {
-                default_aa_code_hash: [0; 32],
-                evm_interpreter_code_hash: [0; 32],
-                hook_address: 0,
-            },
-        );
+//     bencher.bench(|| {
+//         let mut world = TestWorld::new(&[(address, program.clone())]);
+//         let program = initial_decommit(&mut world, address);
+//         let mut vm = VirtualMachine::new(
+//             address,
+//             program,
+//             Address::zero(),
+//             &[],
+//             10_000_000,
+//             Settings {
+//                 default_aa_code_hash: [0; 32],
+//                 evm_interpreter_code_hash: [0; 32],
+//                 hook_address: 0,
+//             },
+//         );
 
-        vm.run(black_box(&mut world), &mut ());
-    });
-}
+//         vm.run(black_box(&mut world), &mut ());
+//     });
+// }
 
-#[divan::bench]
-fn nested_near_call_with_storage_write(bencher: Bencher) {
-    let program = Program::from_raw(
-        vec![
-            Instruction::from_ergs_left(
-                Register1(Register::new(1)),
-                Arguments::new(Always, 5, ModeRequirements::none()),
-            ),
-            Instruction::from_storage_write(
-                // always use same storage slot to get a warm write discount
-                Register1(Register::new(0)),
-                Register2(Register::new(1)),
-                Arguments::new(Always, 5511, ModeRequirements::none()), // need to use actual cost to not create free gas from refunds
-            ),
-            Instruction::from_near_call(
-                // zero means pass all gas
-                Register1(Register::new(0)),
-                Immediate1(0),
-                Immediate2(0),
-                Arguments::new(Always, 25, ModeRequirements::none()),
-            ),
-        ],
-        vec![],
-    );
+// #[divan::bench]
+// fn nested_near_call_with_storage_write(bencher: Bencher) {
+//     let program = Program::from_raw(
+//         vec![
+//             Instruction::from_ergs_left(
+//                 Register1(Register::new(1)),
+//                 Arguments::new(Always, 5, ModeRequirements::none()),
+//             ),
+//             Instruction::from_storage_write(
+//                 // always use same storage slot to get a warm write discount
+//                 Register1(Register::new(0)),
+//                 Register2(Register::new(1)),
+//                 Arguments::new(Always, 5511, ModeRequirements::none()), // need to use actual cost to not create free gas from refunds
+//             ),
+//             Instruction::from_near_call(
+//                 // zero means pass all gas
+//                 Register1(Register::new(0)),
+//                 Immediate1(0),
+//                 Immediate2(0),
+//                 Arguments::new(Always, 25, ModeRequirements::none()),
+//             ),
+//         ],
+//         vec![],
+//     );
 
-    let address = Address::from_low_u64_be(0x_abe1_23ff);
+//     let address = Address::from_low_u64_be(0x_abe1_23ff);
 
-    bencher.bench(|| {
-        let mut world = TestWorld::new(&[(address, program.clone())]);
-        let program = initial_decommit(&mut world, address);
-        let mut vm = VirtualMachine::new(
-            address,
-            program,
-            Address::zero(),
-            &[],
-            80_000_000,
-            Settings {
-                default_aa_code_hash: [0; 32],
-                evm_interpreter_code_hash: [0; 32],
-                hook_address: 0,
-            },
-        );
+//     bencher.bench(|| {
+//         let mut world = TestWorld::new(&[(address, program.clone())]);
+//         let program = initial_decommit(&mut world, address);
+//         let mut vm = VirtualMachine::new(
+//             address,
+//             program,
+//             Address::zero(),
+//             &[],
+//             80_000_000,
+//             Settings {
+//                 default_aa_code_hash: [0; 32],
+//                 evm_interpreter_code_hash: [0; 32],
+//                 hook_address: 0,
+//             },
+//         );
 
-        vm.run(black_box(&mut world), &mut ());
-    });
-}
+//         vm.run(black_box(&mut world), &mut ());
+//     });
+// }
 
 fn main() {
-    divan::main();
+    // divan::main();
 }

--- a/crates/vm2/src/callframe.rs
+++ b/crates/vm2/src/callframe.rs
@@ -144,14 +144,17 @@ impl<T: Tracer, W: World<T>> Callframe<T, W> {
     pub(crate) fn get_raw_pc(&self) -> usize {
         // We cannot use `<*const _>::offset_from` because `self.pc` isn't guaranteed to be allocated within `self.program`
         // (invalid instructions and free panics aren't).
+        // We cannot use `isize` either, because it causes troubles when compiled to `RISC-V`, so we are
+        // returning the value that is clearly out of scope.
         let offset_in_bytes = (self.pc as usize)
-            .wrapping_sub(ptr::from_ref(self.program.instruction(0).unwrap()) as usize);
+            .checked_sub(ptr::from_ref(self.program.instruction(0).unwrap()) as usize)
+            .unwrap_or(usize::MAX);
         offset_in_bytes / mem::size_of::<Instruction<T, W>>()
     }
 
     // TODO: can overflow / underflow after an invalid instruction or free panic. Ordinarily, this will lead to VM termination (for an invalid instruction)
     //   or the callframe getting popped (for a panic), but it's still technically possible to invoke this method afterwards in certain cases (e.g., in the bootloader callframe).
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn get_pc_as_u16(&self) -> u16 {
         self.get_raw_pc() as u16
     }

--- a/crates/vm2/src/callframe.rs
+++ b/crates/vm2/src/callframe.rs
@@ -144,9 +144,9 @@ impl<T: Tracer, W: World<T>> Callframe<T, W> {
     pub(crate) fn get_raw_pc(&self) -> usize {
         // We cannot use `<*const _>::offset_from` because `self.pc` isn't guaranteed to be allocated within `self.program`
         // (invalid instructions and free panics aren't).
-        let offset_in_bytes =
-            self.pc as usize - ptr::from_ref(self.program.instruction(0).unwrap()) as usize;
-        offset_in_bytes / mem::size_of::<Instruction<T, W>>() as usize
+        let offset_in_bytes = (self.pc as usize)
+            .wrapping_sub(ptr::from_ref(self.program.instruction(0).unwrap()) as usize);
+        offset_in_bytes / mem::size_of::<Instruction<T, W>>()
     }
 
     // TODO: can overflow / underflow after an invalid instruction or free panic. Ordinarily, this will lead to VM termination (for an invalid instruction)

--- a/crates/vm2/src/callframe.rs
+++ b/crates/vm2/src/callframe.rs
@@ -141,12 +141,12 @@ impl<T: Tracer, W: World<T>> Callframe<T, W> {
 
     /// Gets a raw inferred program counter. This value can be garbage if the frame is on an invalid instruction or free panic.
     #[allow(clippy::cast_possible_wrap)] // false positive: `Instruction` isn't that large
-    pub(crate) fn get_raw_pc(&self) -> isize {
+    pub(crate) fn get_raw_pc(&self) -> usize {
         // We cannot use `<*const _>::offset_from` because `self.pc` isn't guaranteed to be allocated within `self.program`
         // (invalid instructions and free panics aren't).
         let offset_in_bytes =
-            self.pc as isize - ptr::from_ref(self.program.instruction(0).unwrap()) as isize;
-        offset_in_bytes / mem::size_of::<Instruction<T, W>>() as isize
+            self.pc as usize - ptr::from_ref(self.program.instruction(0).unwrap()) as usize;
+        offset_in_bytes / mem::size_of::<Instruction<T, W>>() as usize
     }
 
     // TODO: can overflow / underflow after an invalid instruction or free panic. Ordinarily, this will lead to VM termination (for an invalid instruction)

--- a/crates/vm2/src/decode.rs
+++ b/crates/vm2/src/decode.rs
@@ -18,34 +18,11 @@ use crate::{
     addressing_modes::{
         AbsoluteStack, AdvanceStackPointer, AnyDestination, AnySource, Arguments, CodePage,
         Immediate1, Immediate2, Register, Register1, Register2, RegisterAndImmediate,
-        RelativeStack, SourceWriter,
+        RelativeStack,
     },
-    instruction::{ExecutionEnd, ExecutionStatus},
     mode_requirements::ModeRequirements,
-    Instruction, Predicate, VirtualMachine, World,
+    Instruction, Predicate, World,
 };
-
-fn unimplemented_instruction<T, W>(variant: Opcode) -> Instruction<T, W> {
-    let mut arguments = Arguments::new(Predicate::Always, 0, ModeRequirements::none());
-    let variant_as_number: u16 = unsafe { std::mem::transmute(variant) };
-    Immediate1(variant_as_number).write_source(&mut arguments);
-    Instruction {
-        handler: unimplemented_handler,
-        arguments,
-    }
-}
-
-fn unimplemented_handler<T, W>(
-    vm: &mut VirtualMachine<T, W>,
-    _: &mut W,
-    _: &mut T,
-) -> ExecutionStatus {
-    let variant: Opcode = unsafe {
-        std::mem::transmute(Immediate1::get_u16(&(*vm.state.current_frame.pc).arguments))
-    };
-    eprintln!("Unimplemented instruction: {variant:?}");
-    ExecutionStatus::Stopped(ExecutionEnd::Panicked)
-}
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn decode<T: Tracer, W: World<T>>(raw: u64, is_bootloader: bool) -> Instruction<T, W> {
@@ -313,12 +290,22 @@ pub(crate) fn decode<T: Tracer, W: World<T>>(raw: u64, is_bootloader: bool) -> I
                     increment.then_some(out2),
                     arguments,
                 ),
-                zkevm_opcode_defs::UMAOpcode::StaticMemoryRead => unimplemented_instruction(
-                    Opcode::UMA(zkevm_opcode_defs::UMAOpcode::StaticMemoryRead),
-                ),
-                zkevm_opcode_defs::UMAOpcode::StaticMemoryWrite => unimplemented_instruction(
-                    Opcode::UMA(zkevm_opcode_defs::UMAOpcode::StaticMemoryWrite),
-                ),
+                zkevm_opcode_defs::UMAOpcode::StaticMemoryRead => {
+                    Instruction::from_static_memory_read(
+                        src1.try_into().unwrap(),
+                        out.try_into().unwrap(),
+                        increment.then_some(out2),
+                        arguments,
+                    )
+                }
+                zkevm_opcode_defs::UMAOpcode::StaticMemoryWrite => {
+                    Instruction::from_static_memory_write(
+                        src1.try_into().unwrap(),
+                        src2,
+                        increment.then_some(out.try_into().unwrap()),
+                        arguments,
+                    )
+                }
             }
         }
         Opcode::Invalid(_) => Instruction::from_invalid(),

--- a/crates/vm2/src/decommit.rs
+++ b/crates/vm2/src/decommit.rs
@@ -25,7 +25,8 @@ pub(crate) fn materialize_decommit_page<T: Tracer, W: World<T>>(
         return existing;
     }
 
-    let heap = vm.state.heaps.set_content_at(candidate_page, code);
+    vm.state.heaps.write_bytes(candidate_page, 0, code);
+    let heap = candidate_page;
     vm.world_diff.set_decommit_page(code_hash, heap);
 
     if heap != vm.state.current_frame.heap && heap != vm.state.current_frame.aux_heap {

--- a/crates/vm2/src/decommit.rs
+++ b/crates/vm2/src/decommit.rs
@@ -12,27 +12,31 @@ use crate::{
 
 /// Ensures that a decommit hash has a materialized reusable page and returns it.
 ///
-/// This page is pinned globally in [`WorldDiff`] and additionally kept alive in the
-/// bootloader frame (or current frame if no bootloader frame exists), matching
-/// decommit opcode teardown semantics.
+/// The resulting page is pinned globally in [`WorldDiff`]. If that page is not owned by the
+/// current frame, it is also recorded as kept alive in the bootloader frame (or current frame if
+/// no bootloader frame exists), matching decommit opcode teardown semantics.
 pub(crate) fn materialize_decommit_page<T: Tracer, W: World<T>>(
     vm: &mut VirtualMachine<T, W>,
     code_hash: U256,
     code: &[u8],
+    candidate_page: HeapId,
 ) -> HeapId {
     if let Some(existing) = vm.world_diff.decommit_page(code_hash) {
         return existing;
     }
 
-    let heap = vm.state.heaps.allocate_with_content(code);
+    let heap = vm.state.heaps.set_content_at(candidate_page, code);
     vm.world_diff.set_decommit_page(code_hash, heap);
 
-    let heaps_to_keep_alive = if let Some(bootloader_frame) = vm.state.previous_frames.first_mut() {
-        &mut bootloader_frame.heaps_i_am_keeping_alive
-    } else {
-        &mut vm.state.current_frame.heaps_i_am_keeping_alive
-    };
-    heaps_to_keep_alive.push(heap);
+    if heap != vm.state.current_frame.heap && heap != vm.state.current_frame.aux_heap {
+        let heaps_to_keep_alive =
+            if let Some(bootloader_frame) = vm.state.previous_frames.first_mut() {
+                &mut bootloader_frame.heaps_i_am_keeping_alive
+            } else {
+                &mut vm.state.current_frame.heaps_i_am_keeping_alive
+            };
+        heaps_to_keep_alive.push(heap);
+    }
 
     heap
 }

--- a/crates/vm2/src/decommit.rs
+++ b/crates/vm2/src/decommit.rs
@@ -4,7 +4,11 @@ use zkevm_opcode_defs::{
 };
 use zksync_vm2_interface::{CycleStats, Tracer};
 
-use crate::{program::Program, world_diff::WorldDiff, World};
+use crate::{
+    program::Program,
+    world_diff::{DecommitState, WorldDiff},
+    World,
+};
 
 impl WorldDiff {
     #[allow(clippy::too_many_arguments)]
@@ -77,7 +81,10 @@ impl WorldDiff {
         code_info[1] = 0;
         let code_key: U256 = U256::from_big_endian(&code_info);
 
-        let was_decommitted = self.decommitted_hashes.as_ref().get(&code_key) == Some(&true);
+        let was_decommitted = matches!(
+            self.decommitted_hashes.as_ref().get(&code_key),
+            Some(DecommitState::SucceededNoPage | DecommitState::SucceededWithPage(_))
+        );
         let cost = if was_decommitted {
             0
         } else {
@@ -97,7 +104,14 @@ impl WorldDiff {
         tracer: &mut T,
         code_hash: U256,
     ) -> (Vec<u8>, bool) {
-        let is_new = self.decommitted_hashes.insert(code_hash, true) != Some(true);
+        let is_new = match self.decommitted_hashes.as_ref().get(&code_hash).copied() {
+            None | Some(DecommitState::Unsuccessful) => {
+                self.decommitted_hashes
+                    .insert(code_hash, DecommitState::SucceededNoPage);
+                true
+            }
+            Some(DecommitState::SucceededNoPage | DecommitState::SucceededWithPage(_)) => false,
+        };
         let code = world.decommit_code(code_hash);
         if is_new {
             let code_len = u32::try_from(code.len()).expect("bytecode length overflow");
@@ -117,12 +131,30 @@ impl WorldDiff {
         if decommit.cost > *gas {
             // We intentionally record a decommitment event even if actual decommitment never happens because of an out-of-gas error.
             // This is how the old VM behaves.
-            self.decommitted_hashes.insert(decommit.code_key, false);
+            if !matches!(
+                self.decommitted_hashes.as_ref().get(&decommit.code_key),
+                Some(DecommitState::SucceededNoPage | DecommitState::SucceededWithPage(_))
+            ) {
+                self.decommitted_hashes
+                    .insert(decommit.code_key, DecommitState::Unsuccessful);
+            }
             // Unlike all other gas costs, this one is not paid if low on gas.
             return None;
         }
 
-        let is_new = self.decommitted_hashes.insert(decommit.code_key, true) != Some(true);
+        let is_new = match self
+            .decommitted_hashes
+            .as_ref()
+            .get(&decommit.code_key)
+            .copied()
+        {
+            None | Some(DecommitState::Unsuccessful) => {
+                self.decommitted_hashes
+                    .insert(decommit.code_key, DecommitState::SucceededNoPage);
+                true
+            }
+            Some(DecommitState::SucceededNoPage | DecommitState::SucceededWithPage(_)) => false,
+        };
         *gas -= decommit.cost;
 
         let decommit = world.decommit(decommit.code_key);

--- a/crates/vm2/src/decommit.rs
+++ b/crates/vm2/src/decommit.rs
@@ -2,13 +2,40 @@ use primitive_types::{H160, U256};
 use zkevm_opcode_defs::{
     ethereum_types::Address, system_params::DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW,
 };
-use zksync_vm2_interface::{CycleStats, Tracer};
+use zksync_vm2_interface::{CycleStats, HeapId, Tracer};
 
 use crate::{
     program::Program,
     world_diff::{DecommitState, WorldDiff},
-    World,
+    VirtualMachine, World,
 };
+
+/// Ensures that a decommit hash has a materialized reusable page and returns it.
+///
+/// This page is pinned globally in [`WorldDiff`] and additionally kept alive in the
+/// bootloader frame (or current frame if no bootloader frame exists), matching
+/// decommit opcode teardown semantics.
+pub(crate) fn materialize_decommit_page<T: Tracer, W: World<T>>(
+    vm: &mut VirtualMachine<T, W>,
+    code_hash: U256,
+    code: &[u8],
+) -> HeapId {
+    if let Some(existing) = vm.world_diff.decommit_page(code_hash) {
+        return existing;
+    }
+
+    let heap = vm.state.heaps.allocate_with_content(code);
+    vm.world_diff.set_decommit_page(code_hash, heap);
+
+    let heaps_to_keep_alive = if let Some(bootloader_frame) = vm.state.previous_frames.first_mut() {
+        &mut bootloader_frame.heaps_i_am_keeping_alive
+    } else {
+        &mut vm.state.current_frame.heaps_i_am_keeping_alive
+    };
+    heaps_to_keep_alive.push(heap);
+
+    heap
+}
 
 impl WorldDiff {
     #[allow(clippy::too_many_arguments)]
@@ -81,10 +108,8 @@ impl WorldDiff {
         code_info[1] = 0;
         let code_key: U256 = U256::from_big_endian(&code_info);
 
-        let was_decommitted = matches!(
-            self.decommitted_hashes.as_ref().get(&code_key),
-            Some(DecommitState::SucceededNoPage | DecommitState::SucceededWithPage(_))
-        );
+        let decommit_state = self.decommitted_hashes.as_ref().get(&code_key).copied();
+        let was_decommitted = matches!(decommit_state, Some(DecommitState::Succeeded(_)));
         let cost = if was_decommitted {
             0
         } else {
@@ -92,7 +117,16 @@ impl WorldDiff {
             u32::from(code_length_in_words) * zkevm_opcode_defs::ERGS_PER_CODE_WORD_DECOMMITTMENT
         };
 
-        Some((UnpaidDecommit { cost, code_key }, is_evm))
+        let should_materialize = !was_decommitted;
+
+        Some((
+            UnpaidDecommit {
+                cost,
+                code_key,
+                should_materialize,
+            },
+            is_evm,
+        ))
     }
 
     /// Returns the decommitted contract code and a flag set to `true` if this is a fresh decommit (i.e.,
@@ -105,12 +139,8 @@ impl WorldDiff {
         code_hash: U256,
     ) -> (Vec<u8>, bool) {
         let is_new = match self.decommitted_hashes.as_ref().get(&code_hash).copied() {
-            None | Some(DecommitState::Unsuccessful) => {
-                self.decommitted_hashes
-                    .insert(code_hash, DecommitState::SucceededNoPage);
-                true
-            }
-            Some(DecommitState::SucceededNoPage | DecommitState::SucceededWithPage(_)) => false,
+            None | Some(DecommitState::Unsuccessful) => true,
+            Some(DecommitState::Succeeded(_)) => false,
         };
         let code = world.decommit_code(code_hash);
         if is_new {
@@ -133,7 +163,7 @@ impl WorldDiff {
             // This is how the old VM behaves.
             if !matches!(
                 self.decommitted_hashes.as_ref().get(&decommit.code_key),
-                Some(DecommitState::SucceededNoPage | DecommitState::SucceededWithPage(_))
+                Some(DecommitState::Succeeded(_))
             ) {
                 self.decommitted_hashes
                     .insert(decommit.code_key, DecommitState::Unsuccessful);
@@ -148,12 +178,8 @@ impl WorldDiff {
             .get(&decommit.code_key)
             .copied()
         {
-            None | Some(DecommitState::Unsuccessful) => {
-                self.decommitted_hashes
-                    .insert(decommit.code_key, DecommitState::SucceededNoPage);
-                true
-            }
-            Some(DecommitState::SucceededNoPage | DecommitState::SucceededWithPage(_)) => false,
+            None | Some(DecommitState::Unsuccessful) => true,
+            Some(DecommitState::Succeeded(_)) => false,
         };
         *gas -= decommit.cost;
 
@@ -173,6 +199,18 @@ impl WorldDiff {
 pub(crate) struct UnpaidDecommit {
     cost: u32,
     code_key: U256,
+    /// Indicates whether the decommit page should be materialized after successful payment.
+    should_materialize: bool,
+}
+
+impl UnpaidDecommit {
+    pub(crate) const fn code_key(self) -> U256 {
+        self.code_key
+    }
+
+    pub(crate) const fn should_materialize(self) -> bool {
+        self.should_materialize
+    }
 }
 
 pub(crate) fn u256_into_address(source: U256) -> H160 {

--- a/crates/vm2/src/decommit.rs
+++ b/crates/vm2/src/decommit.rs
@@ -7,6 +7,7 @@ use zksync_vm2_interface::{CycleStats, Tracer};
 use crate::{program::Program, world_diff::WorldDiff, World};
 
 impl WorldDiff {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn decommit<T: Tracer>(
         &mut self,
         world: &mut impl World<T>,

--- a/crates/vm2/src/decommit.rs
+++ b/crates/vm2/src/decommit.rs
@@ -15,6 +15,7 @@ impl WorldDiff {
         default_aa_code_hash: [u8; 32],
         evm_interpreter_code_hash: [u8; 32],
         is_constructor_call: bool,
+        tx_number_in_block: u16,
     ) -> Option<(UnpaidDecommit, bool)> {
         let deployer_system_contract_address =
             Address::from_low_u64_be(DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW.into());
@@ -27,6 +28,7 @@ impl WorldDiff {
                 tracer,
                 deployer_system_contract_address,
                 address,
+                tx_number_in_block,
             );
             let mut code_info_bytes = [0; 32];
             code_info.to_big_endian(&mut code_info_bytes);

--- a/crates/vm2/src/decommit.rs
+++ b/crates/vm2/src/decommit.rs
@@ -159,8 +159,9 @@ impl WorldDiff {
         gas: &mut u32,
     ) -> Option<Program<T, W>> {
         if decommit.cost > *gas {
-            // We intentionally record a decommitment event even if actual decommitment never happens because of an out-of-gas error.
-            // This is how the old VM behaves.
+            // We intentionally keep this hash visible even though decommit did not execute.
+            // Legacy VM includes far-call OOG attempts in "used contracts", and shadow mode
+            // compares that output.
             if !matches!(
                 self.decommitted_hashes.as_ref().get(&decommit.code_key),
                 Some(DecommitState::Succeeded(_))

--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt, mem,
+    fmt,
     ops::{Index, Range},
 };
 
@@ -78,11 +78,6 @@ impl Heap {
         for page in self.pages.into_iter().flatten() {
             pagepool.recycle_page(page);
         }
-    }
-
-    fn replace_contents(&mut self, bytes: &[u8], pagepool: &mut PagePool) {
-        let old = mem::replace(self, Self::from_bytes(bytes, pagepool));
-        old.recycle(pagepool);
     }
 
     pub(crate) fn read_u256(&self, start_address: u32) -> U256 {
@@ -188,6 +183,20 @@ impl Heap {
             for (dst, src) in page.0.iter_mut().zip(bytes_iter) {
                 *dst = src;
             }
+        }
+    }
+
+    fn write_bytes(&mut self, start_address: u32, bytes: &[u8], pagepool: &mut PagePool) {
+        let (mut page_idx, mut offset_in_page) = address_to_page_offset(start_address);
+        let mut remaining = bytes;
+        while !remaining.is_empty() {
+            let bytes_in_page = (HEAP_PAGE_SIZE - offset_in_page).min(remaining.len());
+            let page = self.get_or_insert_page(page_idx, pagepool);
+            page.0[offset_in_page..offset_in_page + bytes_in_page]
+                .copy_from_slice(&remaining[..bytes_in_page]);
+            remaining = &remaining[bytes_in_page..];
+            page_idx += 1;
+            offset_in_page = 0;
         }
     }
 }
@@ -348,28 +357,6 @@ impl Heaps {
         page
     }
 
-    pub(crate) fn set_content_at(&mut self, page: HeapId, memory: &[u8]) -> HeapId {
-        let decoded = DecodedPage::decode(page)
-            .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
-
-        if let DecodedPage::Dynamic { .. } = decoded {
-            let slot = decoded_dynamic_slot_mut(&mut self.dynamic, decoded);
-            let pagepool = &mut self.pagepool;
-            if let Some(heap) = slot.as_mut() {
-                heap.replace_contents(memory, pagepool);
-            } else {
-                *slot = Some(Heap::from_bytes(memory, pagepool));
-            }
-        } else {
-            let (heap, pagepool) = self
-                .try_decoded_page_mut(decoded)
-                .expect("always allocated heap pages must exist");
-            heap.replace_contents(memory, pagepool);
-        }
-
-        page
-    }
-
     #[cfg(test)]
     pub(crate) fn contains(&self, page: HeapId) -> bool {
         DecodedPage::decode(page).is_some_and(|decoded| {
@@ -409,6 +396,21 @@ impl Heaps {
             .try_decoded_page_mut(decoded)
             .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
         heap.write_u256(start_address, value, pagepool);
+    }
+
+    pub(crate) fn write_bytes(&mut self, page: HeapId, start_address: u32, bytes: &[u8]) {
+        let decoded = DecodedPage::decode(page)
+            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
+        if let DecodedPage::Dynamic { .. } = decoded {
+            let slot = decoded_dynamic_slot_mut(&mut self.dynamic, decoded);
+            if slot.is_none() {
+                *slot = Some(Heap::default());
+            }
+        }
+        let (heap, pagepool) = self
+            .try_decoded_page_mut(decoded)
+            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
+        heap.write_bytes(start_address, bytes, pagepool);
     }
 
     pub(crate) fn snapshot(&self) -> (usize, usize) {

--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -4,7 +4,12 @@ use std::{
 };
 
 use primitive_types::U256;
+use zkevm_opcode_defs::{NEW_MEMORY_PAGES_PER_FAR_CALL, STARTING_BASE_PAGE};
 use zksync_vm2_interface::HeapId;
+
+use crate::page_ids::{
+    bootloader_aux_heap_page, bootloader_calldata_page, bootloader_heap_page, static_memory_page,
+};
 
 /// Heap page size in bytes.
 const HEAP_PAGE_SIZE: usize = 1 << 12;
@@ -67,6 +72,17 @@ impl Heap {
             })
             .collect();
         Self { pages }
+    }
+
+    fn recycle(self, pagepool: &mut PagePool) {
+        for page in self.pages.into_iter().flatten() {
+            pagepool.recycle_page(page);
+        }
+    }
+
+    fn replace_contents(&mut self, bytes: &[u8], pagepool: &mut PagePool) {
+        let old = mem::replace(self, Self::from_bytes(bytes, pagepool));
+        old.recycle(pagepool);
     }
 
     pub(crate) fn read_u256(&self, start_address: u32) -> U256 {
@@ -182,9 +198,111 @@ fn address_to_page_offset(address: u32) -> (usize, usize) {
     (offset >> 12, offset & (HEAP_PAGE_SIZE - 1))
 }
 
+// TODO: With all the additions, this file should be split into several under `heap/` folder.
+// For now I'm keeping it here, since the PR diff is already big and splitting would make the
+// diff more obscure.
+#[derive(Debug, Clone, Default, PartialEq)]
+struct DynamicPageGroup {
+    code: Option<Heap>,
+    heap: Option<Heap>,
+    aux: Option<Heap>,
+}
+
+impl DynamicPageGroup {
+    fn is_empty(&self) -> bool {
+        self.code.is_none() && self.heap.is_none() && self.aux.is_none()
+    }
+
+    fn slot(&self, kind: DynamicPageKind) -> Option<&Heap> {
+        match kind {
+            DynamicPageKind::Code => self.code.as_ref(),
+            DynamicPageKind::Heap => self.heap.as_ref(),
+            DynamicPageKind::Aux => self.aux.as_ref(),
+        }
+    }
+
+    fn slot_mut(&mut self, kind: DynamicPageKind) -> &mut Option<Heap> {
+        match kind {
+            DynamicPageKind::Code => &mut self.code,
+            DynamicPageKind::Heap => &mut self.heap,
+            DynamicPageKind::Aux => &mut self.aux,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DynamicPageKind {
+    Code,
+    Heap,
+    Aux,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DecodedPage {
+    Static,
+    BootloaderCalldata,
+    BootloaderHeap,
+    BootloaderAuxHeap,
+    Dynamic { group: usize, kind: DynamicPageKind },
+}
+
+impl DecodedPage {
+    fn decode(page: HeapId) -> Option<Self> {
+        if page == static_memory_page() {
+            return Some(Self::Static);
+        }
+        if page == bootloader_calldata_page() {
+            return Some(Self::BootloaderCalldata);
+        }
+        if page == bootloader_heap_page() {
+            return Some(Self::BootloaderHeap);
+        }
+        if page == bootloader_aux_heap_page() {
+            return Some(Self::BootloaderAuxHeap);
+        }
+
+        let raw = page.as_u32();
+        if raw < STARTING_BASE_PAGE {
+            return None;
+        }
+
+        let rel = raw - STARTING_BASE_PAGE;
+        let group = usize::try_from(rel / NEW_MEMORY_PAGES_PER_FAR_CALL).unwrap();
+        match rel % NEW_MEMORY_PAGES_PER_FAR_CALL {
+            0 => Some(Self::Dynamic {
+                group,
+                kind: DynamicPageKind::Code,
+            }),
+            2 => Some(Self::Dynamic {
+                group,
+                kind: DynamicPageKind::Heap,
+            }),
+            3 => Some(Self::Dynamic {
+                group,
+                kind: DynamicPageKind::Aux,
+            }),
+            _ => None,
+        }
+    }
+
+    const fn is_always_allocated(self) -> bool {
+        matches!(
+            self,
+            Self::Static
+                | Self::BootloaderCalldata
+                | Self::BootloaderHeap
+                | Self::BootloaderAuxHeap
+        )
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct Heaps {
-    heaps: Vec<Heap>,
+    static_memory: Heap,
+    bootloader_calldata: Heap,
+    bootloader_heap: Heap,
+    bootloader_aux_heap: Heap,
+    dynamic: Vec<DynamicPageGroup>,
     pagepool: PagePool,
     bootloader_heap_rollback_info: Vec<(u32, U256)>,
     bootloader_aux_rollback_info: Vec<(u32, U256)>,
@@ -192,56 +310,105 @@ pub(crate) struct Heaps {
 
 impl Heaps {
     pub(crate) fn new(calldata: &[u8]) -> Self {
-        // The first heap can never be used because heap zero
-        // means the current heap in precompile calls
         let mut pagepool = PagePool::default();
+
         Self {
-            heaps: vec![
-                Heap::default(),
-                Heap::from_bytes(calldata, &mut pagepool),
-                Heap::default(),
-                Heap::default(),
-            ],
+            static_memory: Heap::from_bytes(&[], &mut pagepool),
+            bootloader_calldata: Heap::from_bytes(calldata, &mut pagepool),
+            bootloader_heap: Heap::from_bytes(&[], &mut pagepool),
+            bootloader_aux_heap: Heap::from_bytes(&[], &mut pagepool),
+            dynamic: Vec::new(),
             pagepool,
             bootloader_heap_rollback_info: vec![],
             bootloader_aux_rollback_info: vec![],
         }
     }
 
-    pub(crate) fn allocate(&mut self) -> HeapId {
-        self.allocate_inner(&[])
+    pub(crate) fn allocate_at(&mut self, page: HeapId) -> HeapId {
+        self.allocate_with_content_at(page, &[])
     }
 
-    pub(crate) fn allocate_with_content(&mut self, content: &[u8]) -> HeapId {
-        self.allocate_inner(content)
+    pub(crate) fn allocate_with_content_at(&mut self, page: HeapId, memory: &[u8]) -> HeapId {
+        let decoded = DecodedPage::decode(page)
+            .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
+
+        assert!(
+            !decoded.is_always_allocated(),
+            "heap page {} is already allocated",
+            page.as_u32()
+        );
+
+        let slot = decoded_dynamic_slot_mut(&mut self.dynamic, decoded);
+        assert!(
+            slot.is_none(),
+            "heap page {} is already allocated",
+            page.as_u32()
+        );
+        *slot = Some(Heap::from_bytes(memory, &mut self.pagepool));
+        page
     }
 
-    fn allocate_inner(&mut self, memory: &[u8]) -> HeapId {
-        let id = u32::try_from(self.heaps.len()).expect("heap ID overflow");
-        let id = HeapId::from_u32_unchecked(id);
-        self.heaps
-            .push(Heap::from_bytes(memory, &mut self.pagepool));
-        id
-    }
+    pub(crate) fn set_content_at(&mut self, page: HeapId, memory: &[u8]) -> HeapId {
+        let decoded = DecodedPage::decode(page)
+            .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
 
-    pub(crate) fn deallocate(&mut self, heap: HeapId) {
-        let heap = mem::take(&mut self.heaps[heap.as_u32() as usize]);
-        for page in heap.pages.into_iter().flatten() {
-            self.pagepool.recycle_page(page);
+        if let DecodedPage::Dynamic { .. } = decoded {
+            let slot = decoded_dynamic_slot_mut(&mut self.dynamic, decoded);
+            let pagepool = &mut self.pagepool;
+            if let Some(heap) = slot.as_mut() {
+                heap.replace_contents(memory, pagepool);
+            } else {
+                *slot = Some(Heap::from_bytes(memory, pagepool));
+            }
+        } else {
+            let (heap, pagepool) = self
+                .try_decoded_page_mut(decoded)
+                .expect("always allocated heap pages must exist");
+            heap.replace_contents(memory, pagepool);
         }
+
+        page
     }
 
-    pub(crate) fn write_u256(&mut self, heap: HeapId, start_address: u32, value: U256) {
-        if heap == HeapId::FIRST {
-            let prev_value = self[heap].read_u256(start_address);
+    #[cfg(test)]
+    pub(crate) fn contains(&self, page: HeapId) -> bool {
+        DecodedPage::decode(page).is_some_and(|decoded| {
+            decoded.is_always_allocated() || self.try_decoded_page(decoded).is_some()
+        })
+    }
+
+    pub(crate) fn deallocate(&mut self, page: HeapId) {
+        let decoded = DecodedPage::decode(page)
+            .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
+
+        assert!(
+            !decoded.is_always_allocated(),
+            "heap page {} must remain allocated",
+            page.as_u32()
+        );
+
+        let heap = decoded_dynamic_slot_mut(&mut self.dynamic, decoded)
+            .take()
+            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
+        heap.recycle(&mut self.pagepool);
+    }
+
+    pub(crate) fn write_u256(&mut self, page: HeapId, start_address: u32, value: U256) {
+        if page == HeapId::FIRST {
+            let prev_value = self[page].read_u256(start_address);
             self.bootloader_heap_rollback_info
                 .push((start_address, prev_value));
-        } else if heap == HeapId::FIRST_AUX {
-            let prev_value = self[heap].read_u256(start_address);
+        } else if page == HeapId::FIRST_AUX {
+            let prev_value = self[page].read_u256(start_address);
             self.bootloader_aux_rollback_info
                 .push((start_address, prev_value));
         }
-        self.heaps[heap.as_u32() as usize].write_u256(start_address, value, &mut self.pagepool);
+        let decoded = DecodedPage::decode(page)
+            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
+        let (heap, pagepool) = self
+            .try_decoded_page_mut(decoded)
+            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
+        heap.write_u256(start_address, value, pagepool);
     }
 
     pub(crate) fn snapshot(&self) -> (usize, usize) {
@@ -253,19 +420,13 @@ impl Heaps {
 
     pub(crate) fn rollback(&mut self, (heap_snap, aux_snap): (usize, usize)) {
         for (address, value) in self.bootloader_heap_rollback_info.drain(heap_snap..).rev() {
-            self.heaps[HeapId::FIRST.as_u32() as usize].write_u256(
-                address,
-                value,
-                &mut self.pagepool,
-            );
+            self.bootloader_heap
+                .write_u256(address, value, &mut self.pagepool);
         }
 
         for (address, value) in self.bootloader_aux_rollback_info.drain(aux_snap..).rev() {
-            self.heaps[HeapId::FIRST_AUX.as_u32() as usize].write_u256(
-                address,
-                value,
-                &mut self.pagepool,
-            );
+            self.bootloader_aux_heap
+                .write_u256(address, value, &mut self.pagepool);
         }
     }
 
@@ -273,29 +434,106 @@ impl Heaps {
         self.bootloader_heap_rollback_info.clear();
         self.bootloader_aux_rollback_info.clear();
     }
+
+    fn try_decoded_page(&self, page: DecodedPage) -> Option<&Heap> {
+        match page {
+            DecodedPage::Static => Some(&self.static_memory),
+            DecodedPage::BootloaderCalldata => Some(&self.bootloader_calldata),
+            DecodedPage::BootloaderHeap => Some(&self.bootloader_heap),
+            DecodedPage::BootloaderAuxHeap => Some(&self.bootloader_aux_heap),
+            DecodedPage::Dynamic { group, kind } => {
+                self.dynamic.get(group).and_then(|group| group.slot(kind))
+            }
+        }
+    }
+
+    fn decoded_page(&self, page: DecodedPage) -> &Heap {
+        self.try_decoded_page(page)
+            .unwrap_or_else(|| panic!("decoded page {page:?} is not allocated"))
+    }
+
+    fn try_decoded_page_mut(&mut self, page: DecodedPage) -> Option<(&mut Heap, &mut PagePool)> {
+        let Self {
+            static_memory,
+            bootloader_calldata,
+            bootloader_heap,
+            bootloader_aux_heap,
+            dynamic,
+            pagepool,
+            ..
+        } = self;
+
+        let heap = match page {
+            DecodedPage::Static => static_memory,
+            DecodedPage::BootloaderCalldata => bootloader_calldata,
+            DecodedPage::BootloaderHeap => bootloader_heap,
+            DecodedPage::BootloaderAuxHeap => bootloader_aux_heap,
+            DecodedPage::Dynamic { group, kind } => dynamic
+                .get_mut(group)
+                .and_then(|group| group.slot_mut(kind).as_mut())?,
+        };
+        Some((heap, pagepool))
+    }
 }
 
 impl Index<HeapId> for Heaps {
     type Output = Heap;
 
     fn index(&self, index: HeapId) -> &Self::Output {
-        &self.heaps[index.as_u32() as usize]
+        let decoded = DecodedPage::decode(index)
+            .unwrap_or_else(|| panic!("heap page {} is not allocated", index.as_u32()));
+        self.decoded_page(decoded)
     }
 }
 
-// Since we never remove `Heap` entries (even after rollbacks – although we do deallocate heaps in this case),
-// we allow additional empty heaps at the end of `Heaps`.
 impl PartialEq for Heaps {
     fn eq(&self, other: &Self) -> bool {
-        for i in 0..self.heaps.len().max(other.heaps.len()) {
-            if self.heaps.get(i).unwrap_or(&Heap::default())
-                != other.heaps.get(i).unwrap_or(&Heap::default())
-            {
-                return false;
+        if self.static_memory != other.static_memory
+            || self.bootloader_calldata != other.bootloader_calldata
+            || self.bootloader_heap != other.bootloader_heap
+            || self.bootloader_aux_heap != other.bootloader_aux_heap
+        {
+            return false;
+        }
+
+        for idx in 0..self.dynamic.len().max(other.dynamic.len()) {
+            match (self.dynamic.get(idx), other.dynamic.get(idx)) {
+                (Some(this_group), Some(other_group)) => {
+                    if this_group != other_group {
+                        return false;
+                    }
+                }
+                (Some(group), None) | (None, Some(group)) => {
+                    if !group.is_empty() {
+                        return false;
+                    }
+                }
+                (None, None) => {}
             }
         }
         true
     }
+}
+
+fn dynamic_slot_mut(
+    dynamic: &mut Vec<DynamicPageGroup>,
+    group: usize,
+    kind: DynamicPageKind,
+) -> &mut Option<Heap> {
+    if dynamic.len() <= group {
+        dynamic.resize_with(group + 1, DynamicPageGroup::default);
+    }
+    dynamic[group].slot_mut(kind)
+}
+
+fn decoded_dynamic_slot_mut(
+    dynamic: &mut Vec<DynamicPageGroup>,
+    page: DecodedPage,
+) -> &mut Option<Heap> {
+    let DecodedPage::Dynamic { group, kind } = page else {
+        panic!("decoded page {page:?} is not dynamic");
+    };
+    dynamic_slot_mut(dynamic, group, kind)
 }
 
 #[derive(Default, Clone)]
@@ -545,5 +783,18 @@ mod tests {
         assert_eq!(heaps[HeapId::FIRST_AUX].read_u256(0), 42.into());
         assert_eq!(heaps.bootloader_heap_rollback_info.len(), 1);
         assert_eq!(heaps.bootloader_aux_rollback_info.len(), 1);
+    }
+
+    #[test]
+    fn heaps_ignore_trailing_empty_dynamic_groups_in_equality() {
+        let mut with_trailing_group = Heaps::new(&[]);
+        let empty = Heaps::new(&[]);
+        let page = crate::page_ids::heap_page_from_base(crate::page_ids::first_dynamic_base_page());
+
+        with_trailing_group.allocate_at(page);
+        with_trailing_group.deallocate(page);
+
+        assert_eq!(with_trailing_group, empty);
+        assert_eq!(empty, with_trailing_group);
     }
 }

--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -381,15 +381,7 @@ impl Heaps {
     }
 
     pub(crate) fn write_u256(&mut self, page: HeapId, start_address: u32, value: U256) {
-        if page == HeapId::FIRST {
-            let prev_value = self[page].read_u256(start_address);
-            self.bootloader_heap_rollback_info
-                .push((start_address, prev_value));
-        } else if page == HeapId::FIRST_AUX {
-            let prev_value = self[page].read_u256(start_address);
-            self.bootloader_aux_rollback_info
-                .push((start_address, prev_value));
-        }
+        self.record_bootloader_word_rollback(page, start_address);
         let decoded = DecodedPage::decode(page)
             .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
         let (heap, pagepool) = self
@@ -399,6 +391,7 @@ impl Heaps {
     }
 
     pub(crate) fn write_bytes(&mut self, page: HeapId, start_address: u32, bytes: &[u8]) {
+        self.record_bootloader_range_rollback(page, start_address, bytes.len());
         let decoded = DecodedPage::decode(page)
             .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
         if let DecodedPage::Dynamic { .. } = decoded {
@@ -435,6 +428,36 @@ impl Heaps {
     pub(crate) fn delete_history(&mut self) {
         self.bootloader_heap_rollback_info.clear();
         self.bootloader_aux_rollback_info.clear();
+    }
+
+    fn record_bootloader_word_rollback(&mut self, page: HeapId, start_address: u32) {
+        if page == HeapId::FIRST {
+            let prev_value = self[page].read_u256(start_address);
+            self.bootloader_heap_rollback_info
+                .push((start_address, prev_value));
+        } else if page == HeapId::FIRST_AUX {
+            let prev_value = self[page].read_u256(start_address);
+            self.bootloader_aux_rollback_info
+                .push((start_address, prev_value));
+        }
+    }
+
+    fn record_bootloader_range_rollback(&mut self, page: HeapId, start_address: u32, len: usize) {
+        if len == 0 {
+            return;
+        }
+
+        let start = usize::try_from(start_address).expect("heap write address overflow");
+        let end = start.checked_add(len).expect("heap write range overflow");
+        let first_word = start / 32 * 32;
+        let last_word = (end - 1) / 32 * 32;
+
+        for address in (first_word..=last_word).step_by(32) {
+            self.record_bootloader_word_rollback(
+                page,
+                u32::try_from(address).expect("heap write address overflow"),
+            );
+        }
     }
 
     fn try_decoded_page(&self, page: DecodedPage) -> Option<&Heap> {
@@ -785,6 +808,27 @@ mod tests {
         assert_eq!(heaps[HeapId::FIRST_AUX].read_u256(0), 42.into());
         assert_eq!(heaps.bootloader_heap_rollback_info.len(), 1);
         assert_eq!(heaps.bootloader_aux_rollback_info.len(), 1);
+    }
+
+    #[test]
+    fn rolling_back_bootloader_range_writes() {
+        let mut heaps = Heaps::new(&[]);
+        let first_word = repeat_byte(0x11);
+        let second_word = repeat_byte(0x22);
+        heaps.write_u256(HeapId::FIRST, 0, first_word);
+        heaps.write_u256(HeapId::FIRST, 32, second_word);
+
+        let snapshot = heaps.snapshot();
+
+        heaps.write_bytes(HeapId::FIRST, 8, &[0xaa; 40]);
+        assert_ne!(heaps[HeapId::FIRST].read_u256(0), first_word);
+        assert_ne!(heaps[HeapId::FIRST].read_u256(32), second_word);
+
+        heaps.rollback(snapshot);
+
+        assert_eq!(heaps[HeapId::FIRST].read_u256(0), first_word);
+        assert_eq!(heaps[HeapId::FIRST].read_u256(32), second_word);
+        assert_eq!(heaps.bootloader_heap_rollback_info.len(), 2);
     }
 
     #[test]

--- a/crates/vm2/src/instruction_handlers/common.rs
+++ b/crates/vm2/src/instruction_handlers/common.rs
@@ -1,3 +1,4 @@
+use zkevm_opcode_defs::VM_MAX_STACK_DEPTH;
 use zksync_vm2_interface::{opcodes, OpcodeType, Tracer};
 
 use super::ret::free_panic;
@@ -46,12 +47,21 @@ pub(crate) fn full_boilerplate<Opcode: OpcodeType, T: Tracer, W: World<T>>(
 ) -> ExecutionStatus {
     let args = unsafe { &(*vm.state.current_frame.pc).arguments };
 
+    // We are not checking whether the callstack is full here. However,
+    // the callstack depth limit on EraVM is so high that it will not be hit in practice,
+    // so it is fine to not have this check, even though `zk_evm` has it.
+    // Introducing this check would require additional bookkeeping for far/near calls, which
+    // doesn't currently make sense.
+
+    // Make sure that call stack depth is very high, just in case.
+    #[allow(clippy::items_after_statements)] // Invariant for the code below
+    const _: () = assert!(VM_MAX_STACK_DEPTH >= 214_748_444);
+
     if vm.state.use_gas(args.get_static_gas_cost()).is_err()
         || !args.mode_requirements().met(
             vm.state.current_frame.is_kernel,
             vm.state.current_frame.is_static,
         )
-        || vm.state.callstack_is_full()
     {
         return free_panic(vm, world, tracer);
     }

--- a/crates/vm2/src/instruction_handlers/common.rs
+++ b/crates/vm2/src/instruction_handlers/common.rs
@@ -51,6 +51,7 @@ pub(crate) fn full_boilerplate<Opcode: OpcodeType, T: Tracer, W: World<T>>(
             vm.state.current_frame.is_kernel,
             vm.state.current_frame.is_static,
         )
+        || vm.state.callstack_is_full()
     {
         return free_panic(vm, world, tracer);
     }

--- a/crates/vm2/src/instruction_handlers/decommit.rs
+++ b/crates/vm2/src/instruction_handlers/decommit.rs
@@ -38,8 +38,24 @@ fn decommit<T: Tracer, W: World<T>>(
             vm.state.current_frame.gas += extra_cost;
         }
 
-        let heap = vm.state.heaps.allocate_with_content(program.as_ref());
-        vm.state.current_frame.heaps_i_am_keeping_alive.push(heap);
+        let heap = if is_fresh {
+            let heap = vm.state.heaps.allocate_with_content(program.as_ref());
+            vm.world_diff.set_decommit_page(code_hash, heap);
+            heap
+        } else {
+            vm.world_diff
+                .decommit_page(code_hash)
+                .expect("decommit page must exist for non-fresh hash")
+        };
+
+        if !vm
+            .state
+            .current_frame
+            .heaps_i_am_keeping_alive
+            .contains(&heap)
+        {
+            vm.state.current_frame.heaps_i_am_keeping_alive.push(heap);
+        }
 
         let value = FatPointer {
             offset: 0,

--- a/crates/vm2/src/instruction_handlers/decommit.rs
+++ b/crates/vm2/src/instruction_handlers/decommit.rs
@@ -48,13 +48,16 @@ fn decommit<T: Tracer, W: World<T>>(
                 .expect("decommit page must exist for non-fresh hash")
         };
 
-        if !vm
-            .state
-            .current_frame
-            .heaps_i_am_keeping_alive
-            .contains(&heap)
-        {
-            vm.state.current_frame.heaps_i_am_keeping_alive.push(heap);
+        // Decommit page mapping lives for the whole VM run, so nested-frame decommits
+        // must pin pages in the bootloader frame rather than in the current frame.
+        let heaps_to_keep_alive =
+            if let Some(bootloader_frame) = vm.state.previous_frames.first_mut() {
+                &mut bootloader_frame.heaps_i_am_keeping_alive
+            } else {
+                &mut vm.state.current_frame.heaps_i_am_keeping_alive
+            };
+        if !heaps_to_keep_alive.contains(&heap) {
+            heaps_to_keep_alive.push(heap);
         }
 
         let value = FatPointer {

--- a/crates/vm2/src/instruction_handlers/decommit.rs
+++ b/crates/vm2/src/instruction_handlers/decommit.rs
@@ -39,7 +39,7 @@ fn decommit<T: Tracer, W: World<T>>(
             vm.state.current_frame.gas += extra_cost;
         }
 
-        let heap = materialize_decommit_page(vm, code_hash, &code);
+        let heap = materialize_decommit_page(vm, code_hash, &code, vm.state.current_frame.heap);
 
         let value = FatPointer {
             offset: 0,

--- a/crates/vm2/src/instruction_handlers/decommit.rs
+++ b/crates/vm2/src/instruction_handlers/decommit.rs
@@ -5,6 +5,7 @@ use zksync_vm2_interface::{opcodes, Tracer};
 use super::common::boilerplate_ext;
 use crate::{
     addressing_modes::{Arguments, Destination, Register1, Register2, Source},
+    decommit::materialize_decommit_page,
     fat_pointer::FatPointer,
     instruction::ExecutionStatus,
     Instruction, VirtualMachine, World,
@@ -33,40 +34,12 @@ fn decommit<T: Tracer, W: World<T>>(
             return;
         }
 
-        let (program, is_fresh) = vm.world_diff.decommit_opcode(world, tracer, code_hash);
+        let (code, is_fresh) = vm.world_diff.decommit_opcode(world, tracer, code_hash);
         if !is_fresh {
             vm.state.current_frame.gas += extra_cost;
         }
 
-        // We only need to mutate keep-alive state when this opcode allocates a new heap.
-        let (heap, should_record_keep_alive) = if is_fresh {
-            let heap = vm.state.heaps.allocate_with_content(program.as_ref());
-            vm.world_diff.set_decommit_page(code_hash, heap);
-            (heap, true)
-        } else {
-            // `pay_for_decommit` can mark the hash as decommitted without assigning a memory page.
-            // In that case, the first `Decommit` opcode materializes the page lazily and starts
-            // tracking it for frame teardown semantics.
-            if let Some(heap) = vm.world_diff.decommit_page(code_hash) {
-                (heap, false)
-            } else {
-                let heap = vm.state.heaps.allocate_with_content(program.as_ref());
-                vm.world_diff.set_decommit_page(code_hash, heap);
-                (heap, true)
-            }
-        };
-
-        // Decommit page mapping lives for the whole VM run, so nested-frame decommits
-        // must pin pages in the bootloader frame rather than in the current frame.
-        let heaps_to_keep_alive =
-            if let Some(bootloader_frame) = vm.state.previous_frames.first_mut() {
-                &mut bootloader_frame.heaps_i_am_keeping_alive
-            } else {
-                &mut vm.state.current_frame.heaps_i_am_keeping_alive
-            };
-        if should_record_keep_alive {
-            heaps_to_keep_alive.push(heap);
-        }
+        let heap = materialize_decommit_page(vm, code_hash, &code);
 
         let value = FatPointer {
             offset: 0,

--- a/crates/vm2/src/instruction_handlers/decommit.rs
+++ b/crates/vm2/src/instruction_handlers/decommit.rs
@@ -43,9 +43,16 @@ fn decommit<T: Tracer, W: World<T>>(
             vm.world_diff.set_decommit_page(code_hash, heap);
             heap
         } else {
-            vm.world_diff
-                .decommit_page(code_hash)
-                .expect("decommit page must exist for non-fresh hash")
+            // `pay_for_decommit` marks hashes as decommitted without assigning a decommit page.
+            // If `Decommit` is the first opcode path that needs a memory page for this hash,
+            // materialize the page lazily instead of panicking the host process.
+            if let Some(heap) = vm.world_diff.decommit_page(code_hash) {
+                heap
+            } else {
+                let heap = vm.state.heaps.allocate_with_content(program.as_ref());
+                vm.world_diff.set_decommit_page(code_hash, heap);
+                heap
+            }
         };
 
         // Decommit page mapping lives for the whole VM run, so nested-frame decommits

--- a/crates/vm2/src/instruction_handlers/decommit.rs
+++ b/crates/vm2/src/instruction_handlers/decommit.rs
@@ -38,20 +38,21 @@ fn decommit<T: Tracer, W: World<T>>(
             vm.state.current_frame.gas += extra_cost;
         }
 
-        let heap = if is_fresh {
+        // We only need to mutate keep-alive state when this opcode allocates a new heap.
+        let (heap, should_record_keep_alive) = if is_fresh {
             let heap = vm.state.heaps.allocate_with_content(program.as_ref());
             vm.world_diff.set_decommit_page(code_hash, heap);
-            heap
+            (heap, true)
         } else {
-            // `pay_for_decommit` marks hashes as decommitted without assigning a decommit page.
-            // If `Decommit` is the first opcode path that needs a memory page for this hash,
-            // materialize the page lazily instead of panicking the host process.
+            // `pay_for_decommit` can mark the hash as decommitted without assigning a memory page.
+            // In that case, the first `Decommit` opcode materializes the page lazily and starts
+            // tracking it for frame teardown semantics.
             if let Some(heap) = vm.world_diff.decommit_page(code_hash) {
-                heap
+                (heap, false)
             } else {
                 let heap = vm.state.heaps.allocate_with_content(program.as_ref());
                 vm.world_diff.set_decommit_page(code_hash, heap);
-                heap
+                (heap, true)
             }
         };
 
@@ -63,7 +64,7 @@ fn decommit<T: Tracer, W: World<T>>(
             } else {
                 &mut vm.state.current_frame.heaps_i_am_keeping_alive
             };
-        if !heaps_to_keep_alive.contains(&heap) {
+        if should_record_keep_alive {
             heaps_to_keep_alive.push(heap);
         }
 

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     addressing_modes::{Arguments, Immediate1, Register1, Register2, Source},
-    decommit::{is_kernel, u256_into_address},
+    decommit::{is_kernel, materialize_decommit_page, u256_into_address},
     fat_pointer::FatPointer,
     instruction::ExecutionStatus,
     predication::Flags,
@@ -99,12 +99,23 @@ where
             }
             let calldata = maybe_calldata?;
             let (unpaid_decommit, is_evm) = decommit_result?;
+            let code_hash = unpaid_decommit.code_key();
+            let should_materialize = unpaid_decommit.should_materialize();
             let program = vm.world_diff.pay_for_decommit(
                 world,
                 tracer,
                 unpaid_decommit,
                 &mut vm.state.current_frame.gas,
             )?;
+
+            if should_materialize {
+                // TODO: The interfaces that `World` provide exposes either a parsed program OR bytes,
+                // so converting back to bytes here feels like a more reasonable choice; though probably
+                // a more optimal approach is possible if we rework interfaces either for the `World` or
+                // for heap instantiation.
+                let code = program_to_bytes(&program);
+                materialize_decommit_page(vm, code_hash, &code);
+            }
 
             Some((calldata, program, is_evm))
         })();
@@ -176,6 +187,16 @@ fn get_far_call_arguments(abi: U256) -> FarCallABI {
         is_constructor_call: constructor_call_byte != 0,
         is_system_call: system_call_byte != 0,
     }
+}
+
+fn program_to_bytes<T, W>(program: &Program<T, W>) -> Vec<u8> {
+    let mut result = Vec::with_capacity(program.code_page().len() * 32);
+    for word in program.code_page().iter() {
+        let mut bytes = [0u8; 32];
+        word.to_big_endian(&mut bytes);
+        result.extend_from_slice(&bytes);
+    }
+    result
 }
 
 /// Forms a new fat pointer or narrows an existing one, as dictated by the ABI.

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -67,6 +67,7 @@ where
                 vm.settings.default_aa_code_hash,
                 vm.settings.evm_interpreter_code_hash,
                 abi.is_constructor_call,
+                vm.state.transaction_number,
             );
 
             // calldata has to be constructed even if we already know we will panic because

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -60,21 +60,29 @@ where
             };
 
         let fallible_part = (|| {
-            let decommit_result = vm.world_diff.decommit(
-                world,
-                tracer,
-                destination_address,
-                vm.settings.default_aa_code_hash,
-                vm.settings.evm_interpreter_code_hash,
-                abi.is_constructor_call,
-                vm.state.transaction_number,
-            );
+            let shard_call_failed = IS_SHARD && abi.shard_id != 0;
 
-            // calldata has to be constructed even if we already know we will panic because
-            // overflowing start + length makes the heap resize even when already panicking.
-            let already_failed = decommit_result.is_none() || IS_SHARD && abi.shard_id != 0;
+            let (maybe_calldata, decommit_result) = if shard_call_failed {
+                // calldata has to be constructed even if we already know we will panic because
+                // overflowing start + length makes the heap resize even when already panicking.
+                (get_calldata(raw_abi, raw_abi_is_pointer, vm, true), None)
+            } else {
+                let decommit_result = vm.world_diff.decommit(
+                    world,
+                    tracer,
+                    destination_address,
+                    vm.settings.default_aa_code_hash,
+                    vm.settings.evm_interpreter_code_hash,
+                    abi.is_constructor_call,
+                    vm.state.transaction_number,
+                );
 
-            let maybe_calldata = get_calldata(raw_abi, raw_abi_is_pointer, vm, already_failed);
+                // calldata has to be constructed even if we already know we will panic because
+                // overflowing start + length makes the heap resize even when already panicking.
+                let already_failed = decommit_result.is_none();
+                let maybe_calldata = get_calldata(raw_abi, raw_abi_is_pointer, vm, already_failed);
+                (maybe_calldata, decommit_result)
+            };
 
             // mandated gas is passed even if it means transferring more than the 63/64 rule allows
             if let Some(gas_left) = vm.state.current_frame.gas.checked_sub(mandated_gas) {
@@ -86,7 +94,7 @@ where
                 return None;
             }
 
-            if IS_SHARD && abi.shard_id != 0 {
+            if shard_call_failed {
                 return None;
             }
             let calldata = maybe_calldata?;

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -16,6 +16,7 @@ use crate::{
     decommit::{is_kernel, materialize_decommit_page, u256_into_address},
     fat_pointer::FatPointer,
     instruction::ExecutionStatus,
+    page_ids::code_page_from_base,
     predication::Flags,
     Instruction, Program, VirtualMachine, World,
 };
@@ -58,6 +59,7 @@ where
             } else {
                 0
             };
+        let new_base_page = vm.state.next_base_page();
 
         let fallible_part = (|| {
             let shard_call_failed = IS_SHARD && abi.shard_id != 0;
@@ -114,7 +116,7 @@ where
                 // a more optimal approach is possible if we rework interfaces either for the `World` or
                 // for heap instantiation.
                 let code = program_to_bytes(&program);
-                materialize_decommit_page(vm, code_hash, &code);
+                materialize_decommit_page(vm, code_hash, &code, code_page_from_base(new_base_page));
             }
 
             Some((calldata, program, is_evm))

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -191,6 +191,7 @@ fn get_far_call_arguments(abi: U256) -> FarCallABI {
 
 fn program_to_bytes<T, W>(program: &Program<T, W>) -> Vec<u8> {
     let mut result = Vec::with_capacity(program.code_page().len() * 32);
+    #[allow(clippy::explicit_iter_loop)] // `.iter()` is required in this case
     for word in program.code_page().iter() {
         let mut bytes = [0u8; 32];
         word.to_big_endian(&mut bytes);

--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -201,7 +201,7 @@ fn load_static<T: Tracer, W: World<T>, In: Source, const INCREMENT: bool>(
     world: &mut W,
     tracer: &mut T,
 ) -> ExecutionStatus {
-    boilerplate::<opcodes::HeapRead, _, _>(vm, world, tracer, |vm, args| {
+    boilerplate::<opcodes::StaticMemoryRead, _, _>(vm, world, tracer, |vm, args| {
         // Static memory uses a plain 32-bit offset in src0, same as heap UMA ops.
         // Pointer-typed values are still accepted as raw words and then validated by range check.
         let (pointer, _) = In::get_with_pointer_flag(args, &mut vm.state);
@@ -230,7 +230,7 @@ where
     T: Tracer,
     In: Source,
 {
-    boilerplate::<opcodes::HeapWrite, _, _>(vm, world, tracer, |vm, args| {
+    boilerplate::<opcodes::StaticMemoryWrite, _, _>(vm, world, tracer, |vm, args| {
         // Static memory uses a plain 32-bit offset in src0, same as heap UMA ops.
         // Pointer-typed values are still accepted as raw words and then validated by range check.
         let (pointer, _) = In::get_with_pointer_flag(args, &mut vm.state);

--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -17,7 +17,7 @@ use crate::{
     ExecutionEnd, Instruction, VirtualMachine, World,
 };
 
-/// Dedicated heap slot used to model zk_evm static memory.
+/// Dedicated heap slot used to model `zk_evm` static memory.
 ///
 /// `heap_id == 0` is otherwise unused by vm2 heap instructions and thus can safely back
 /// static memory without interfering with regular heap / calldata pages.

--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -13,15 +13,13 @@ use crate::{
     },
     fat_pointer::FatPointer,
     instruction::ExecutionStatus,
+    page_ids::static_memory_page,
     state::State,
     ExecutionEnd, Instruction, VirtualMachine, World,
 };
 
-/// Dedicated heap slot used to model `zk_evm` static memory.
-///
-/// `heap_id == 0` is otherwise unused by vm2 heap instructions and thus can safely back
-/// static memory without interfering with regular heap / calldata pages.
-const STATIC_MEMORY_HEAP: HeapId = HeapId::from_u32_unchecked(0);
+/// Dedicated heap page used to model `zk_evm` static memory.
+const STATIC_MEMORY_HEAP: HeapId = static_memory_page();
 
 pub(crate) trait HeapFromState {
     type Read: OpcodeType;

--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -17,6 +17,12 @@ use crate::{
     ExecutionEnd, Instruction, VirtualMachine, World,
 };
 
+/// Dedicated heap slot used to model zk_evm static memory.
+///
+/// `heap_id == 0` is otherwise unused by vm2 heap instructions and thus can safely back
+/// static memory without interfering with regular heap / calldata pages.
+const STATIC_MEMORY_HEAP: HeapId = HeapId::from_u32_unchecked(0);
+
 pub(crate) trait HeapFromState {
     type Read: OpcodeType;
     type Write: OpcodeType;
@@ -190,6 +196,62 @@ fn load_pointer<T: Tracer, W: World<T>, const INCREMENT: bool>(
     })
 }
 
+fn load_static<T: Tracer, W: World<T>, In: Source, const INCREMENT: bool>(
+    vm: &mut VirtualMachine<T, W>,
+    world: &mut W,
+    tracer: &mut T,
+) -> ExecutionStatus {
+    boilerplate::<opcodes::HeapRead, _, _>(vm, world, tracer, |vm, args| {
+        // Static memory uses a plain 32-bit offset in src0, same as heap UMA ops.
+        // Pointer-typed values are still accepted as raw words and then validated by range check.
+        let (pointer, _) = In::get_with_pointer_flag(args, &mut vm.state);
+
+        if bigger_than_last_address(pointer) {
+            vm.state.current_frame.pc = spontaneous_panic();
+            return;
+        }
+
+        let address = pointer.low_u32();
+        let value = vm.state.heaps[STATIC_MEMORY_HEAP].read_u256(address);
+        Register1::set(args, &mut vm.state, value);
+
+        if INCREMENT {
+            Register2::set(args, &mut vm.state, pointer + 32);
+        }
+    })
+}
+
+fn store_static<T, W: World<T>, In, const INCREMENT: bool>(
+    vm: &mut VirtualMachine<T, W>,
+    world: &mut W,
+    tracer: &mut T,
+) -> ExecutionStatus
+where
+    T: Tracer,
+    In: Source,
+{
+    boilerplate::<opcodes::HeapWrite, _, _>(vm, world, tracer, |vm, args| {
+        // Static memory uses a plain 32-bit offset in src0, same as heap UMA ops.
+        // Pointer-typed values are still accepted as raw words and then validated by range check.
+        let (pointer, _) = In::get_with_pointer_flag(args, &mut vm.state);
+
+        if bigger_than_last_address(pointer) {
+            vm.state.current_frame.pc = spontaneous_panic();
+            return;
+        }
+
+        let address = pointer.low_u32();
+        let value = Register2::get(args, &mut vm.state);
+        vm.state
+            .heaps
+            .write_u256(STATIC_MEMORY_HEAP, address, value);
+
+        if INCREMENT {
+            Register1::set(args, &mut vm.state, pointer + 32);
+        }
+    })
+}
+
 impl<T: Tracer, W: World<T>> Instruction<T, W> {
     /// Creates a [`HeapRead`](opcodes::HeapRead) instruction with the provided params.
     pub fn from_heap_read(
@@ -209,6 +271,26 @@ impl<T: Tracer, W: World<T>> Instruction<T, W> {
         arguments: Arguments,
     ) -> Self {
         Self::from_read::<AuxHeap>(src, out, incremented_out, arguments)
+    }
+
+    /// Creates a static memory read instruction.
+    pub fn from_static_memory_read(
+        src: RegisterOrImmediate,
+        out: Register1,
+        incremented_out: Option<Register2>,
+        arguments: Arguments,
+    ) -> Self {
+        let mut arguments = arguments.write_source(&src).write_destination(&out);
+
+        let increment = incremented_out.is_some();
+        if let Some(out2) = incremented_out {
+            out2.write_destination(&mut arguments);
+        }
+
+        Self {
+            handler: monomorphize!(load_static [T W] match_reg_imm src match_boolean increment),
+            arguments,
+        }
     }
 
     fn from_read<H: HeapFromState>(
@@ -249,6 +331,23 @@ impl<T: Tracer, W: World<T>> Instruction<T, W> {
         arguments: Arguments,
     ) -> Self {
         Self::from_write::<AuxHeap>(src1, src2, incremented_out, arguments, false)
+    }
+
+    /// Creates a static memory write instruction.
+    pub fn from_static_memory_write(
+        src1: RegisterOrImmediate,
+        src2: Register2,
+        incremented_out: Option<Register1>,
+        arguments: Arguments,
+    ) -> Self {
+        let increment = incremented_out.is_some();
+        Self {
+            handler: monomorphize!(store_static [T W] match_reg_imm src1 match_boolean increment),
+            arguments: arguments
+                .write_source(&src1)
+                .write_source(&src2)
+                .write_destination(&incremented_out),
+        }
     }
 
     fn from_write<H: HeapFromState>(

--- a/crates/vm2/src/instruction_handlers/near_call.rs
+++ b/crates/vm2/src/instruction_handlers/near_call.rs
@@ -28,6 +28,7 @@ fn near_call<T: Tracer, W: World<T>>(
             error_handler,
             vm.world_diff.snapshot(),
         );
+        vm.state.increment_callstack_depth();
 
         vm.state.flags = Flags::new(false, false, false);
 

--- a/crates/vm2/src/instruction_handlers/near_call.rs
+++ b/crates/vm2/src/instruction_handlers/near_call.rs
@@ -28,7 +28,6 @@ fn near_call<T: Tracer, W: World<T>>(
             error_handler,
             vm.world_diff.snapshot(),
         );
-        vm.state.increment_callstack_depth();
 
         vm.state.flags = Flags::new(false, false, false);
 

--- a/crates/vm2/src/instruction_handlers/precompiles.rs
+++ b/crates/vm2/src/instruction_handlers/precompiles.rs
@@ -88,6 +88,10 @@ fn precompile_call<T: Tracer, W: World<T>>(
             }
 
             let mut abi = PrecompileCallAbi::from_u256(Register1::get(args, &mut vm.state));
+            // `zk_evm` uses `memory_page == 0` in precompile ABI as a sentinel meaning
+            // "use the current heap". vm2 also uses heap id `0` to model static memory,
+            // so we must preserve this remapping here to keep precompile accesses isolated
+            // from static UMA memory.
             if abi.memory_page_to_read.as_u32() == 0 {
                 abi.memory_page_to_read = vm.state.current_frame.heap;
             }

--- a/crates/vm2/src/instruction_handlers/precompiles.rs
+++ b/crates/vm2/src/instruction_handlers/precompiles.rs
@@ -89,9 +89,7 @@ fn precompile_call<T: Tracer, W: World<T>>(
 
             let mut abi = PrecompileCallAbi::from_u256(Register1::get(args, &mut vm.state));
             // `zk_evm` uses `memory_page == 0` in precompile ABI as a sentinel meaning
-            // "use the current heap". vm2 also uses heap id `0` to model static memory,
-            // so we must preserve this remapping here to keep precompile accesses isolated
-            // from static UMA memory.
+            // "use the current heap", so remap it before heap lookup.
             if abi.memory_page_to_read.as_u32() == 0 {
                 abi.memory_page_to_read = vm.state.current_frame.heap;
             }

--- a/crates/vm2/src/instruction_handlers/precompiles.rs
+++ b/crates/vm2/src/instruction_handlers/precompiles.rs
@@ -1,7 +1,7 @@
 use primitive_types::U256;
 use zksync_vm2_interface::{opcodes, HeapId, Tracer};
 
-use super::{common::boilerplate_ext, ret::spontaneous_panic};
+use super::common::boilerplate_ext;
 use crate::{
     addressing_modes::{Arguments, Destination, Register1, Register2, Source},
     instruction::ExecutionStatus,
@@ -78,7 +78,7 @@ fn precompile_call<T: Tracer, W: World<T>>(
             // This is safe because system contracts are trusted
             let aux_data = PrecompileAuxData::from_u256(Register2::get(args, &mut vm.state));
             let Ok(()) = vm.state.use_gas(aux_data.extra_ergs_cost) else {
-                vm.state.current_frame.pc = spontaneous_panic();
+                Register1::set(args, &mut vm.state, U256::zero());
                 return;
             };
 

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -114,6 +114,7 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
     };
 
     if return_type.is_failure() {
+        vm.world_diff.append_rollback_logs(&snapshot);
         vm.world_diff.rollback(snapshot);
     }
 

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -14,6 +14,7 @@ use crate::{
     callframe::FrameRemnant,
     instruction::{ExecutionEnd, ExecutionStatus},
     mode_requirements::ModeRequirements,
+    page_ids::base_page_from_heap,
     predication::Flags,
     tracing::VmAndWorld,
     Instruction, Predicate, VirtualMachine, World,
@@ -51,7 +52,7 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
                     // Non-kernel returndata forwarding must be unidirectional: callers may pass
                     // pointers down the stack, but callees must not forward pointers to older pages.
                     // This mirrors zk_evm's restriction based on base memory page checks.
-                    pointer.memory_page.as_u32() >= vm.state.current_frame.heap.as_u32()
+                    pointer.memory_page.as_u32() >= base_page_from_heap(vm.state.current_frame.heap)
                         && pointer.memory_page != vm.state.current_frame.calldata_heap
                 }
             });

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -45,8 +45,15 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
         } else {
             let (raw_abi, is_pointer) = Register1::get_with_pointer_flag(args, &mut vm.state);
             let result = get_calldata(raw_abi, is_pointer, vm, false).filter(|pointer| {
-                vm.state.current_frame.is_kernel
-                    || pointer.memory_page != vm.state.current_frame.calldata_heap
+                if vm.state.current_frame.is_kernel {
+                    true
+                } else {
+                    // Non-kernel returndata forwarding must be unidirectional: callers may pass
+                    // pointers down the stack, but callees must not forward pointers to older pages.
+                    // This mirrors zk_evm's restriction based on base memory page checks.
+                    pointer.memory_page.as_u32() >= vm.state.current_frame.heap.as_u32()
+                        && pointer.memory_page != vm.state.current_frame.calldata_heap
+                }
             });
 
             if result.is_none() {

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -31,8 +31,6 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
         snapshot,
     }) = vm.state.current_frame.pop_near_call()
     {
-        vm.state.decrement_callstack_depth();
-
         if TO_LABEL {
             let pc = Immediate1::get_u16(args);
             vm.state.current_frame.set_pc_from_u16(pc);

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -31,6 +31,8 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
         snapshot,
     }) = vm.state.current_frame.pop_near_call()
     {
+        vm.state.decrement_callstack_depth();
+
         if TO_LABEL {
             let pc = Immediate1::get_u16(args);
             vm.state.current_frame.set_pc_from_u16(pc);

--- a/crates/vm2/src/instruction_handlers/storage.rs
+++ b/crates/vm2/src/instruction_handlers/storage.rs
@@ -18,9 +18,14 @@ fn sstore<T: Tracer, W: World<T>>(
         let key = Register1::get(args, &mut vm.state);
         let value = Register2::get(args, &mut vm.state);
 
-        let refund =
-            vm.world_diff
-                .write_storage(world, tracer, vm.state.current_frame.address, key, value);
+        let refund = vm.world_diff.write_storage(
+            world,
+            tracer,
+            vm.state.current_frame.address,
+            key,
+            value,
+            vm.state.transaction_number,
+        );
 
         assert!(refund <= SSTORE_COST);
         vm.state.current_frame.gas += refund;
@@ -49,9 +54,13 @@ fn sload<T: Tracer, W: World<T>>(
     boilerplate_ext::<opcodes::StorageRead, _, _>(vm, world, tracer, |vm, args, world, tracer| {
         let key = Register1::get(args, &mut vm.state);
 
-        let (value, refund) =
-            vm.world_diff
-                .read_storage(world, tracer, vm.state.current_frame.address, key);
+        let (value, refund) = vm.world_diff.read_storage(
+            world,
+            tracer,
+            vm.state.current_frame.address,
+            key,
+            vm.state.transaction_number,
+        );
 
         assert!(refund <= SLOAD_COST);
         vm.state.current_frame.gas += refund;

--- a/crates/vm2/src/lib.rs
+++ b/crates/vm2/src/lib.rs
@@ -34,6 +34,7 @@ mod heap;
 mod instruction;
 mod instruction_handlers;
 mod mode_requirements;
+mod page_ids;
 pub mod precompiles;
 mod predication;
 #[cfg(not(feature = "single_instruction_test"))]

--- a/crates/vm2/src/page_ids.rs
+++ b/crates/vm2/src/page_ids.rs
@@ -1,0 +1,45 @@
+use zkevm_opcode_defs::{
+    BOOTLOADER_AUX_HEAP_PAGE, BOOTLOADER_CALLDATA_PAGE, BOOTLOADER_HEAP_PAGE,
+    NEW_MEMORY_PAGES_PER_FAR_CALL, STARTING_BASE_PAGE, STATIC_MEMORY_PAGE,
+};
+use zksync_vm2_interface::HeapId;
+
+pub(crate) const fn static_memory_page() -> HeapId {
+    HeapId::from_u32_unchecked(STATIC_MEMORY_PAGE)
+}
+
+pub(crate) const fn bootloader_calldata_page() -> HeapId {
+    HeapId::from_u32_unchecked(BOOTLOADER_CALLDATA_PAGE)
+}
+
+pub(crate) const fn bootloader_heap_page() -> HeapId {
+    HeapId::from_u32_unchecked(BOOTLOADER_HEAP_PAGE)
+}
+
+pub(crate) const fn bootloader_aux_heap_page() -> HeapId {
+    HeapId::from_u32_unchecked(BOOTLOADER_AUX_HEAP_PAGE)
+}
+
+pub(crate) const fn heap_page_from_base(base_page: u32) -> HeapId {
+    HeapId::from_u32_unchecked(base_page + 2)
+}
+
+pub(crate) const fn aux_heap_page_from_base(base_page: u32) -> HeapId {
+    HeapId::from_u32_unchecked(base_page + 3)
+}
+
+pub(crate) const fn code_page_from_base(base_page: u32) -> HeapId {
+    HeapId::from_u32_unchecked(base_page)
+}
+
+pub(crate) const fn base_page_from_heap(heap: HeapId) -> u32 {
+    heap.as_u32() - 2
+}
+
+pub(crate) const fn first_dynamic_base_page() -> u32 {
+    STARTING_BASE_PAGE
+}
+
+pub(crate) const fn next_page_group(page: u32) -> u32 {
+    page + NEW_MEMORY_PAGES_PER_FAR_CALL
+}

--- a/crates/vm2/src/page_ids.rs
+++ b/crates/vm2/src/page_ids.rs
@@ -8,14 +8,17 @@ pub(crate) const fn static_memory_page() -> HeapId {
     HeapId::from_u32_unchecked(STATIC_MEMORY_PAGE)
 }
 
+#[cfg_attr(feature = "single_instruction_test", allow(dead_code))]
 pub(crate) const fn bootloader_calldata_page() -> HeapId {
     HeapId::from_u32_unchecked(BOOTLOADER_CALLDATA_PAGE)
 }
 
+#[cfg_attr(feature = "single_instruction_test", allow(dead_code))]
 pub(crate) const fn bootloader_heap_page() -> HeapId {
     HeapId::from_u32_unchecked(BOOTLOADER_HEAP_PAGE)
 }
 
+#[cfg_attr(feature = "single_instruction_test", allow(dead_code))]
 pub(crate) const fn bootloader_aux_heap_page() -> HeapId {
     HeapId::from_u32_unchecked(BOOTLOADER_AUX_HEAP_PAGE)
 }

--- a/crates/vm2/src/single_instruction_test/callframe.rs
+++ b/crates/vm2/src/single_instruction_test/callframe.rs
@@ -82,7 +82,7 @@ impl<T: Tracer, W: World<T>> Callframe<T, W> {
             aux_heap: HeapId::FIRST_AUX,
             heap_size: 0,
             aux_heap_size: 0,
-            calldata_heap: HeapId::from_u32_unchecked(1),
+            calldata_heap: HeapId::FIRST_CALLDATA,
             heaps_i_am_keeping_alive: vec![],
             world_before_this_frame: WorldDiff::default().snapshot(),
         }

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -19,6 +19,13 @@ impl Heap {
         self.write = Some((start_address, value));
     }
 
+    fn write_bytes(&mut self, start_address: u32, bytes: &[u8]) {
+        let mut word = [0_u8; 32];
+        let copied = bytes.len().min(word.len());
+        word[..copied].copy_from_slice(&bytes[..copied]);
+        self.write_u256(start_address, U256::from_big_endian(&word));
+    }
+
     pub(crate) fn read_byte(&self, _: u32) -> u8 {
         unimplemented!()
     }
@@ -68,12 +75,21 @@ impl Heaps {
         self.heap_id
     }
 
+    pub(crate) fn allocate_at(&mut self, page: HeapId) -> HeapId {
+        page
+    }
+
     pub(crate) fn allocate_with_content(&mut self, content: &[u8]) -> HeapId {
         let id = self.allocate();
         self.read
             .get_mut(id)
             .write_u256(0, U256::from_big_endian(content));
         id
+    }
+
+    pub(crate) fn allocate_with_content_at(&mut self, page: HeapId, content: &[u8]) -> HeapId {
+        self.read.get_mut(page).write_bytes(0, content);
+        page
     }
 
     pub(crate) fn deallocate(&mut self, _: HeapId) {}
@@ -90,6 +106,10 @@ impl Heaps {
 
     pub fn write_u256(&mut self, heap: HeapId, start_address: u32, value: U256) {
         self.read.get_mut(heap).write_u256(start_address, value);
+    }
+
+    pub(crate) fn write_bytes(&mut self, heap: HeapId, start_address: u32, bytes: &[u8]) {
+        self.read.get_mut(heap).write_bytes(start_address, bytes);
     }
 
     pub(crate) fn snapshot(&self) -> (usize, usize) {

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -61,6 +61,7 @@ impl<'a> Arbitrary<'a> for Heap {
 
 #[derive(Debug, Clone)]
 pub struct Heaps {
+    #[allow(dead_code)] // For API compatibility with real implementation.
     heap_id: HeapId,
     pub(crate) read: MockRead<HeapId, Heap>,
 }
@@ -71,6 +72,7 @@ impl Heaps {
         unimplemented!("Should use arbitrary heap, not fresh heap in testing.")
     }
 
+    #[allow(dead_code)] // For API compatibility with real implementation.
     pub(crate) fn allocate(&mut self) -> HeapId {
         self.heap_id
     }
@@ -79,6 +81,7 @@ impl Heaps {
         page
     }
 
+    #[allow(dead_code)] // For API compatibility with real implementation.
     pub(crate) fn allocate_with_content(&mut self, content: &[u8]) -> HeapId {
         let id = self.allocate();
         self.read
@@ -87,6 +90,7 @@ impl Heaps {
         id
     }
 
+    #[allow(dead_code)] // For API compatibility with real implementation.
     pub(crate) fn allocate_with_content_at(&mut self, page: HeapId, content: &[u8]) -> HeapId {
         self.read.get_mut(page).write_bytes(0, content);
         page

--- a/crates/vm2/src/single_instruction_test/vm.rs
+++ b/crates/vm2/src/single_instruction_test/vm.rs
@@ -4,8 +4,8 @@ use zksync_vm2_interface::{HeapId, Tracer};
 
 use super::{heap::Heaps, stack::StackPool};
 use crate::{
-    callframe::Callframe, fat_pointer::FatPointer, state::State, Settings, VirtualMachine, World,
-    WorldDiff,
+    callframe::Callframe, fat_pointer::FatPointer, page_ids::first_dynamic_base_page, state::State,
+    Settings, VirtualMachine, World, WorldDiff,
 };
 
 impl<T: Tracer, W> VirtualMachine<T, W> {
@@ -75,6 +75,7 @@ impl<'a, T: Tracer, W: World<T>> Arbitrary<'a> for VirtualMachine<T, W> {
                 heaps,
                 transaction_number: u.arbitrary()?,
                 context_u128: u.arbitrary()?,
+                next_base_page: first_dynamic_base_page(),
             },
             settings: u.arbitrary()?,
             world_diff: WorldDiff::default(),

--- a/crates/vm2/src/single_instruction_test/vm.rs
+++ b/crates/vm2/src/single_instruction_test/vm.rs
@@ -62,6 +62,7 @@ impl<'a, T: Tracer, W: World<T>> Arbitrary<'a> for VirtualMachine<T, W> {
         }
 
         let heaps = Heaps::from_id(current_frame.heap, u)?;
+        let callstack_depth = current_frame.near_calls.len() + 2;
 
         Ok(Self {
             state: State {
@@ -72,6 +73,7 @@ impl<'a, T: Tracer, W: World<T>> Arbitrary<'a> for VirtualMachine<T, W> {
                 // Exiting the final frame is different in vm2 on purpose,
                 // so always generate two frames to avoid that.
                 previous_frames: vec![Callframe::dummy()],
+                callstack_depth,
                 heaps,
                 transaction_number: u.arbitrary()?,
                 context_u128: u.arbitrary()?,

--- a/crates/vm2/src/single_instruction_test/vm.rs
+++ b/crates/vm2/src/single_instruction_test/vm.rs
@@ -62,7 +62,6 @@ impl<'a, T: Tracer, W: World<T>> Arbitrary<'a> for VirtualMachine<T, W> {
         }
 
         let heaps = Heaps::from_id(current_frame.heap, u)?;
-        let callstack_depth = current_frame.near_calls.len() + 2;
 
         Ok(Self {
             state: State {
@@ -73,7 +72,6 @@ impl<'a, T: Tracer, W: World<T>> Arbitrary<'a> for VirtualMachine<T, W> {
                 // Exiting the final frame is different in vm2 on purpose,
                 // so always generate two frames to avoid that.
                 previous_frames: vec![Callframe::dummy()],
-                callstack_depth,
                 heaps,
                 transaction_number: u.arbitrary()?,
                 context_u128: u.arbitrary()?,

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -24,11 +24,6 @@ pub(crate) struct State<T, W> {
     /// Contains indices to the far call instructions currently being executed.
     /// They are needed to continue execution from the correct spot upon return.
     pub(crate) previous_frames: Vec<Callframe<T, W>>,
-    /// Cached callstack depth across far and near frames.
-    ///
-    /// This value is updated on each push/pop so that callstack saturation checks in
-    /// instruction boilerplate stay O(1) on the hot path.
-    pub(crate) callstack_depth: usize,
     pub(crate) heaps: Heaps,
     pub(crate) transaction_number: u16,
     pub(crate) context_u128: u128,
@@ -75,9 +70,6 @@ impl<T, W> State<T, W> {
             ),
             previous_frames: vec![],
 
-            // A fresh VM starts with a single far frame and no near calls.
-            callstack_depth: 1,
-
             heaps: Heaps::new(calldata),
 
             transaction_number: 0,
@@ -104,24 +96,12 @@ impl<T, W> State<T, W> {
         self.current_frame.context_u128
     }
 
-    #[inline(always)]
-    pub(crate) fn increment_callstack_depth(&mut self) {
-        self.callstack_depth = self
-            .callstack_depth
-            .checked_add(1)
-            .expect("callstack depth overflow");
-    }
-
-    #[inline(always)]
-    pub(crate) fn decrement_callstack_depth(&mut self) {
-        self.callstack_depth = self
-            .callstack_depth
-            .checked_sub(1)
-            .expect("callstack depth underflow");
-    }
-
     pub(crate) fn callstack_is_full(&self) -> bool {
-        self.callstack_depth >= VM_MAX_STACK_DEPTH as usize
+        // TODO: This is not precise, since we should account for the depth of near calls
+        // in each of previous frames. This is unlikely to be hit in practice, so it is
+        // probably fine to keep it as is for now.
+        self.previous_frames.len() + self.current_frame.near_calls.len()
+            >= VM_MAX_STACK_DEPTH as usize
     }
 }
 
@@ -145,7 +125,6 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             bootloader_heap_snapshot: self.heaps.snapshot(),
             transaction_number: self.transaction_number,
             context_u128: self.context_u128,
-            callstack_depth: self.callstack_depth,
         }
     }
 
@@ -162,7 +141,6 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             bootloader_heap_snapshot,
             transaction_number,
             context_u128,
-            callstack_depth,
         } = snapshot;
 
         for heap in self.current_frame.rollback(bootloader_frame) {
@@ -176,7 +154,6 @@ impl<T: Tracer, W: World<T>> State<T, W> {
         self.flags = flags;
         self.transaction_number = transaction_number;
         self.context_u128 = context_u128;
-        self.callstack_depth = callstack_depth;
     }
 
     pub(crate) fn delete_history(&mut self) {
@@ -192,7 +169,6 @@ impl<T, W> Clone for State<T, W> {
             flags: self.flags.clone(),
             current_frame: self.current_frame.clone(),
             previous_frames: self.previous_frames.clone(),
-            callstack_depth: self.callstack_depth,
             heaps: self.heaps.clone(),
             transaction_number: self.transaction_number,
             context_u128: self.context_u128,
@@ -211,7 +187,6 @@ impl<T, W> PartialEq for State<T, W> {
             && self.context_u128 == other.context_u128
             && self.current_frame == other.current_frame
             && self.previous_frames == other.previous_frames
-            && self.callstack_depth == other.callstack_depth
             && self.heaps == other.heaps
     }
 }
@@ -267,5 +242,4 @@ pub(crate) struct StateSnapshot {
     bootloader_heap_snapshot: (usize, usize),
     transaction_number: u16,
     context_u128: u128,
-    callstack_depth: usize,
 }

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -95,14 +95,6 @@ impl<T, W> State<T, W> {
     pub(crate) fn get_context_u128(&self) -> u128 {
         self.current_frame.context_u128
     }
-
-    pub(crate) fn callstack_is_full(&self) -> bool {
-        // TODO: This is not precise, since we should account for the depth of near calls
-        // in each of previous frames. This is unlikely to be hit in practice, so it is
-        // probably fine to keep it as is for now.
-        self.previous_frames.len() + self.current_frame.near_calls.len()
-            >= VM_MAX_STACK_DEPTH as usize
-    }
 }
 
 impl<T: Tracer, W: World<T>> State<T, W> {

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -1,5 +1,4 @@
 use primitive_types::{H160, U256};
-use zkevm_opcode_defs::system_params::VM_MAX_STACK_DEPTH;
 use zksync_vm2_interface::{HeapId, Tracer};
 
 use crate::{

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -97,8 +97,14 @@ impl<T, W> State<T, W> {
     }
 
     pub(crate) fn callstack_is_full(&self) -> bool {
-        self.previous_frames.len() + self.current_frame.near_calls.len()
-            >= VM_MAX_STACK_DEPTH as usize
+        let previous_depth = self
+            .previous_frames
+            .iter()
+            .map(|frame| frame.near_calls.len() + 1)
+            .sum::<usize>();
+        let current_depth = self.current_frame.near_calls.len() + 1;
+
+        previous_depth + current_depth >= VM_MAX_STACK_DEPTH as usize
     }
 }
 

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -24,6 +24,11 @@ pub(crate) struct State<T, W> {
     /// Contains indices to the far call instructions currently being executed.
     /// They are needed to continue execution from the correct spot upon return.
     pub(crate) previous_frames: Vec<Callframe<T, W>>,
+    /// Cached callstack depth across far and near frames.
+    ///
+    /// This value is updated on each push/pop so that callstack saturation checks in
+    /// instruction boilerplate stay O(1) on the hot path.
+    pub(crate) callstack_depth: usize,
     pub(crate) heaps: Heaps,
     pub(crate) transaction_number: u16,
     pub(crate) context_u128: u128,
@@ -70,6 +75,9 @@ impl<T, W> State<T, W> {
             ),
             previous_frames: vec![],
 
+            // A fresh VM starts with a single far frame and no near calls.
+            callstack_depth: 1,
+
             heaps: Heaps::new(calldata),
 
             transaction_number: 0,
@@ -96,15 +104,24 @@ impl<T, W> State<T, W> {
         self.current_frame.context_u128
     }
 
-    pub(crate) fn callstack_is_full(&self) -> bool {
-        let previous_depth = self
-            .previous_frames
-            .iter()
-            .map(|frame| frame.near_calls.len() + 1)
-            .sum::<usize>();
-        let current_depth = self.current_frame.near_calls.len() + 1;
+    #[inline(always)]
+    pub(crate) fn increment_callstack_depth(&mut self) {
+        self.callstack_depth = self
+            .callstack_depth
+            .checked_add(1)
+            .expect("callstack depth overflow");
+    }
 
-        previous_depth + current_depth >= VM_MAX_STACK_DEPTH as usize
+    #[inline(always)]
+    pub(crate) fn decrement_callstack_depth(&mut self) {
+        self.callstack_depth = self
+            .callstack_depth
+            .checked_sub(1)
+            .expect("callstack depth underflow");
+    }
+
+    pub(crate) fn callstack_is_full(&self) -> bool {
+        self.callstack_depth >= VM_MAX_STACK_DEPTH as usize
     }
 }
 
@@ -128,6 +145,7 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             bootloader_heap_snapshot: self.heaps.snapshot(),
             transaction_number: self.transaction_number,
             context_u128: self.context_u128,
+            callstack_depth: self.callstack_depth,
         }
     }
 
@@ -144,6 +162,7 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             bootloader_heap_snapshot,
             transaction_number,
             context_u128,
+            callstack_depth,
         } = snapshot;
 
         for heap in self.current_frame.rollback(bootloader_frame) {
@@ -157,6 +176,7 @@ impl<T: Tracer, W: World<T>> State<T, W> {
         self.flags = flags;
         self.transaction_number = transaction_number;
         self.context_u128 = context_u128;
+        self.callstack_depth = callstack_depth;
     }
 
     pub(crate) fn delete_history(&mut self) {
@@ -172,6 +192,7 @@ impl<T, W> Clone for State<T, W> {
             flags: self.flags.clone(),
             current_frame: self.current_frame.clone(),
             previous_frames: self.previous_frames.clone(),
+            callstack_depth: self.callstack_depth,
             heaps: self.heaps.clone(),
             transaction_number: self.transaction_number,
             context_u128: self.context_u128,
@@ -190,6 +211,7 @@ impl<T, W> PartialEq for State<T, W> {
             && self.context_u128 == other.context_u128
             && self.current_frame == other.current_frame
             && self.previous_frames == other.previous_frames
+            && self.callstack_depth == other.callstack_depth
             && self.heaps == other.heaps
     }
 }
@@ -245,4 +267,5 @@ pub(crate) struct StateSnapshot {
     bootloader_heap_snapshot: (usize, usize),
     transaction_number: u16,
     context_u128: u128,
+    callstack_depth: usize,
 }

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -1,4 +1,5 @@
 use primitive_types::{H160, U256};
+use zkevm_opcode_defs::system_params::VM_MAX_STACK_DEPTH;
 use zksync_vm2_interface::{HeapId, Tracer};
 
 use crate::{
@@ -93,6 +94,11 @@ impl<T, W> State<T, W> {
 
     pub(crate) fn get_context_u128(&self) -> u128 {
         self.current_frame.context_u128
+    }
+
+    pub(crate) fn callstack_is_full(&self) -> bool {
+        self.previous_frames.len() + self.current_frame.near_calls.len()
+            >= VM_MAX_STACK_DEPTH as usize
     }
 }
 

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -125,7 +125,11 @@ impl<T: Tracer, W: World<T>> State<T, W> {
         }
     }
 
-    pub(crate) fn rollback(&mut self, snapshot: StateSnapshot) {
+    pub(crate) fn rollback(
+        &mut self,
+        snapshot: StateSnapshot,
+        mut is_heap_pinned: impl FnMut(HeapId) -> bool,
+    ) {
         let StateSnapshot {
             registers,
             register_pointer_flags,
@@ -137,7 +141,9 @@ impl<T: Tracer, W: World<T>> State<T, W> {
         } = snapshot;
 
         for heap in self.current_frame.rollback(bootloader_frame) {
-            self.heaps.deallocate(heap);
+            if !is_heap_pinned(heap) {
+                self.heaps.deallocate(heap);
+            }
         }
         self.heaps.rollback(bootloader_heap_snapshot);
         self.registers = registers;

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -6,6 +6,7 @@ use crate::{
     callframe::{Callframe, CallframeSnapshot},
     fat_pointer::FatPointer,
     heap::Heaps,
+    page_ids::{first_dynamic_base_page, next_page_group},
     predication::Flags,
     program::Program,
     stack::Stack,
@@ -26,6 +27,7 @@ pub(crate) struct State<T, W> {
     pub(crate) heaps: Heaps,
     pub(crate) transaction_number: u16,
     pub(crate) context_u128: u128,
+    pub(crate) next_base_page: u32,
 }
 
 impl<T, W> State<T, W> {
@@ -73,6 +75,7 @@ impl<T, W> State<T, W> {
 
             transaction_number: 0,
             context_u128: 0,
+            next_base_page: first_dynamic_base_page(),
         }
     }
 
@@ -93,6 +96,20 @@ impl<T, W> State<T, W> {
 
     pub(crate) fn get_context_u128(&self) -> u128 {
         self.current_frame.context_u128
+    }
+
+    pub(crate) const fn next_base_page(&self) -> u32 {
+        self.next_base_page
+    }
+
+    /// Reserves the next far-call page group and returns its base page.
+    ///
+    /// The returned base page is used to derive the pages owned by a new frame,
+    /// such as its heap and aux heap.
+    pub(crate) fn allocate_base_page(&mut self) -> u32 {
+        let base_page = self.next_base_page;
+        self.next_base_page = next_page_group(self.next_base_page);
+        base_page
     }
 }
 
@@ -116,6 +133,7 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             bootloader_heap_snapshot: self.heaps.snapshot(),
             transaction_number: self.transaction_number,
             context_u128: self.context_u128,
+            next_base_page: self.next_base_page,
         }
     }
 
@@ -132,6 +150,7 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             bootloader_heap_snapshot,
             transaction_number,
             context_u128,
+            next_base_page,
         } = snapshot;
 
         for heap in self.current_frame.rollback(bootloader_frame) {
@@ -145,6 +164,7 @@ impl<T: Tracer, W: World<T>> State<T, W> {
         self.flags = flags;
         self.transaction_number = transaction_number;
         self.context_u128 = context_u128;
+        self.next_base_page = next_base_page;
     }
 
     pub(crate) fn delete_history(&mut self) {
@@ -163,6 +183,7 @@ impl<T, W> Clone for State<T, W> {
             heaps: self.heaps.clone(),
             transaction_number: self.transaction_number,
             context_u128: self.context_u128,
+            next_base_page: self.next_base_page,
         }
     }
 }
@@ -176,6 +197,7 @@ impl<T, W> PartialEq for State<T, W> {
             && self.flags == other.flags
             && self.transaction_number == other.transaction_number
             && self.context_u128 == other.context_u128
+            && self.next_base_page == other.next_base_page
             && self.current_frame == other.current_frame
             && self.previous_frames == other.previous_frames
             && self.heaps == other.heaps
@@ -233,4 +255,5 @@ pub(crate) struct StateSnapshot {
     bootloader_heap_snapshot: (usize, usize),
     transaction_number: u16,
     context_u128: u128,
+    next_base_page: u32,
 }

--- a/crates/vm2/src/tests/bytecode_behaviour.rs
+++ b/crates/vm2/src/tests/bytecode_behaviour.rs
@@ -2,8 +2,9 @@ use zkevm_opcode_defs::ethereum_types::Address;
 use zksync_vm2_interface::{CallframeInterface, StateInterface};
 
 use crate::{
+    addressing_modes::{Arguments, Register, Register1},
     testonly::{initial_decommit, TestWorld},
-    ExecutionEnd, Program, Settings, VirtualMachine,
+    ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
 };
 
 #[test]
@@ -34,4 +35,46 @@ fn call_to_invalid_address() {
         ExecutionEnd::Panicked
     ));
     assert_eq!(vm.current_frame().gas(), 0);
+}
+
+#[test]
+fn storage_log_uses_vm_transaction_number() {
+    let storage_read = Instruction::from_storage_read(
+        Register1(Register::new(0)),
+        Register1(Register::new(2)),
+        Arguments::new(Predicate::Always, 0, ModeRequirements::none()),
+    );
+    let ret = Instruction::from_ret(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 0, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![storage_read, ret], vec![]);
+
+    let address = Address::from_low_u64_be(0x_2234_5678_90ab_cdef);
+    let mut world = TestWorld::new(&[(address, program)]);
+    let program = initial_decommit(&mut world, address);
+
+    let mut vm = VirtualMachine::new(
+        address,
+        program,
+        Address::zero(),
+        &[],
+        100,
+        Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+        },
+    );
+    vm.state.transaction_number = 7;
+
+    assert_eq!(
+        vm.run(&mut world, &mut ()),
+        ExecutionEnd::ProgramFinished(vec![])
+    );
+
+    let storage_logs = vm.world_diff().storage_log_queries();
+    assert_eq!(storage_logs.len(), 1);
+    assert_eq!(storage_logs[0].tx_number_in_block, 7);
 }

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -4,12 +4,15 @@ use zkevm_opcode_defs::{
     Condition, DecodedOpcode, ImmMemHandlerFlags, Opcode, Operand, RegOrImmFlags, UMAOpcode,
     OPCODES_TABLE, UMA_INCREMENT_FLAG_IDX,
 };
-use zksync_vm2_interface::{opcodes, Tracer};
+use zksync_vm2_interface::{opcodes, HeapId, Tracer};
 
 use crate::{
     addressing_modes::{Arguments, Immediate1, Register, Register1, Register2},
     decode::decode,
     fat_pointer::FatPointer,
+    page_ids::{
+        aux_heap_page_from_base, first_dynamic_base_page, heap_page_from_base, next_page_group,
+    },
     precompiles::{PrecompileMemoryReader, PrecompileOutput, Precompiles},
     testonly::TestWorld,
     ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, StorageInterface,
@@ -43,12 +46,93 @@ fn execute_one_instruction<T: Tracer, W: World<T>>(
     }
 }
 
+fn allocate_standalone_heap<T: Tracer, W: World<T>>(
+    vm: &mut VirtualMachine<T, W>,
+    memory: &[u8],
+) -> HeapId {
+    let mut page = vm.state.next_base_page();
+    loop {
+        let heap = HeapId::from_u32_unchecked(page);
+        if !vm.state.heaps.contains(heap) {
+            vm.state.heaps.allocate_with_content_at(heap, memory);
+            return heap;
+        }
+        page = next_page_group(page);
+    }
+}
+
 fn ret_instruction<T: Tracer, W: World<T>>() -> Instruction<T, W> {
     Instruction::from_ret(
         Register1(Register::new(0)),
         None,
         Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
     )
+}
+
+#[test]
+fn bootloader_calldata_pointer_should_use_reference_page_id() {
+    let program: Program<(), TestWorld<()>> =
+        Program::from_raw(vec![ret_instruction::<(), TestWorld<()>>()], vec![]);
+    let vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[1, 2, 3, 4],
+        1_000_000,
+        default_settings(),
+    );
+
+    let calldata = FatPointer::from(vm.state.registers[1]);
+    assert_eq!(
+        calldata.memory_page,
+        zksync_vm2_interface::HeapId::FIRST_CALLDATA
+    );
+    assert_eq!(calldata.length, 4);
+}
+
+#[test]
+fn far_call_calldata_pointer_should_use_caller_heap_reference_page() {
+    let called_address = Address::from_low_u64_be(2);
+    let called_program = Program::from_raw(vec![ret_instruction()], vec![]);
+    let mut world = TestWorld::new(&[(called_address, called_program)]);
+    let called_address_as_u256 = U256::from(called_address.to_low_u64_be());
+
+    let far_call = Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(1),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![far_call, ret_instruction()], vec![]);
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let mut far_call_abi = U256::zero();
+    far_call_abi.0[3] = 10_000;
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = far_call_abi;
+    vm.state.registers[2] = called_address_as_u256;
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+
+    let calldata = FatPointer::from(vm.state.registers[1]);
+    assert_eq!(calldata.memory_page, zksync_vm2_interface::HeapId::FIRST);
+    assert_eq!(
+        vm.state.current_frame.heap,
+        heap_page_from_base(first_dynamic_base_page())
+    );
+    assert_eq!(
+        vm.state.current_frame.aux_heap,
+        aux_heap_page_from_base(first_dynamic_base_page())
+    );
 }
 
 fn static_uma_instruction<T: Tracer, W: World<T>>(opcode: UMAOpcode) -> Instruction<T, W> {
@@ -534,6 +618,48 @@ fn non_kernel_returndata_forward_to_older_page_should_panic() {
 }
 
 #[test]
+fn fresh_decommit_should_use_current_heap_page() {
+    let contract = (
+        non_kernel_address(),
+        Program::from_raw(vec![ret_instruction()], vec![]),
+    );
+    let mut world = TestWorld::new(&[contract]);
+    let code_hash = *world
+        .address_to_hash
+        .values()
+        .next()
+        .expect("test contract hash must exist");
+
+    let decommit = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(3)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![decommit], vec![]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+    vm.state.registers[1] = code_hash;
+    vm.state.registers[2] = U256::zero();
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    let pointer = FatPointer::from(vm.state.registers[3]);
+
+    assert_eq!(pointer.memory_page, vm.state.current_frame.heap);
+    assert_eq!(
+        vm.world_diff.decommit_page(code_hash),
+        Some(pointer.memory_page)
+    );
+}
+
+#[test]
 fn nonfresh_decommit_should_reuse_existing_memory_page() {
     // zk_evm reuses the same memory page for repeated decommit of the same code hash.
     let contract = (
@@ -574,6 +700,7 @@ fn nonfresh_decommit_should_reuse_existing_memory_page() {
 
     execute_one_instruction(&mut vm, &mut world, &mut ());
     let first = FatPointer::from(vm.state.registers[3]);
+    assert_eq!(first.memory_page, vm.state.current_frame.heap);
 
     execute_one_instruction(&mut vm, &mut world, &mut ());
     let second = FatPointer::from(vm.state.registers[4]);
@@ -727,13 +854,16 @@ fn nonfresh_decommit_should_keep_page_alive_after_nested_frame_returns() {
 
     execute_one_instruction(&mut vm, &mut world, &mut ());
     let first = FatPointer::from(vm.state.registers[3]);
+    let nested_heap = vm.state.current_frame.heap;
     assert_eq!(vm.state.heaps[first.memory_page].read_u256(0), code_word);
+    assert_eq!(first.memory_page, nested_heap);
 
     vm.pop_frame(None)
         .expect("nested frame must be present for pop");
 
     execute_one_instruction(&mut vm, &mut world, &mut ());
     let second = FatPointer::from(vm.state.registers[4]);
+    let bootloader_heap = vm.state.current_frame.heap;
 
     let keep_alive_occurrences = vm
         .state
@@ -744,10 +874,12 @@ fn nonfresh_decommit_should_keep_page_alive_after_nested_frame_returns() {
         .count();
 
     assert_eq!(first.memory_page, second.memory_page);
+    assert_ne!(second.memory_page, bootloader_heap);
     assert_eq!(vm.state.heaps[second.memory_page].read_u256(0), code_word);
+    assert!(vm.world_diff.is_decommit_page_pinned(second.memory_page));
     assert_eq!(
-        keep_alive_occurrences, 1,
-        "Nested and parent decommits should not duplicate keep-alive entries"
+        keep_alive_occurrences, 0,
+        "Pinned decommit pages owned by the current frame should not need a keep-alive entry"
     );
 }
 
@@ -780,8 +912,8 @@ fn decommit_page_in_keep_alive_list_should_not_be_deallocated_on_pop() {
     let code_word = U256::from(0xabcdu64);
     let mut code_bytes = [0_u8; 32];
     code_word.to_big_endian(&mut code_bytes);
-    let decommit_heap = vm.state.heaps.allocate_with_content(&code_bytes);
-    let kept_heap = vm.state.heaps.allocate_with_content(&[0x11; 32]);
+    let decommit_heap = allocate_standalone_heap(&mut vm, &code_bytes);
+    let kept_heap = allocate_standalone_heap(&mut vm, &[0x11; 32]);
 
     vm.world_diff
         .set_decommit_page(U256::from(0x1234_u64), decommit_heap);
@@ -812,7 +944,7 @@ fn rollback_should_preserve_pre_snapshot_decommit_page() {
     let code_word = U256::from(0xdead_beef_u64);
     let mut code_bytes = [0_u8; 32];
     code_word.to_big_endian(&mut code_bytes);
-    let decommit_heap = vm.state.heaps.allocate_with_content(&code_bytes);
+    let decommit_heap = allocate_standalone_heap(&mut vm, &code_bytes);
     vm.world_diff
         .set_decommit_page(U256::from(0xfeed_u64), decommit_heap);
 

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -83,8 +83,8 @@ fn static_uma_instruction<T: Tracer, W: World<T>>(opcode: UMAOpcode) -> Instruct
 
 #[test]
 fn static_memory_read_should_not_panic_in_kernel_mode() {
-    // In zk_evm this opcode is executable in kernel mode. We lock this behavior as a regression
-    // test before implementing StaticMemoryRead in vm2.
+    // In zk_evm this opcode is executable in kernel mode. This regression test locks that
+    // behavior in vm2.
     let program = Program::from_raw(
         vec![
             static_uma_instruction(UMAOpcode::StaticMemoryRead),
@@ -111,8 +111,8 @@ fn static_memory_read_should_not_panic_in_kernel_mode() {
 
 #[test]
 fn static_memory_write_should_not_panic_in_kernel_mode() {
-    // In zk_evm this opcode is executable in kernel mode. We lock this behavior as a regression
-    // test before implementing StaticMemoryWrite in vm2.
+    // In zk_evm this opcode is executable in kernel mode. This regression test locks that
+    // behavior in vm2.
     let program = Program::from_raw(
         vec![
             static_uma_instruction(UMAOpcode::StaticMemoryWrite),

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -429,7 +429,14 @@ fn precompile_extra_ergs_oog_should_not_panic() {
 }
 
 #[test]
+#[ignore = "extreme callstack saturation case; memory-heavy and long-running; run on demand"]
 fn callstack_saturation_should_count_near_calls_in_previous_far_frames() {
+    // This test checks the extreme case of callstack saturation, which is highly unlikely
+    // to be hit in practice. It is memory-heavy and long-running.
+    // Consider running it only when debugging an active VM issue and you suspect
+    // callstack processing behavior.
+    // Run on demand with:
+    // cargo test -p zksync_vm2 callstack_saturation_should_count_near_calls_in_previous_far_frames -- --ignored --nocapture
     let program: Program<(), TestWorld<()>> =
         Program::from_raw(vec![ret_instruction::<(), TestWorld<()>>()], vec![]);
 
@@ -443,13 +450,15 @@ fn callstack_saturation_should_count_near_calls_in_previous_far_frames() {
     );
 
     // Fill the current far frame with local near calls and then move it to `previous_frames`
-    // via a far-frame push. This reproduces mixed far+near depth where vm2 undercounts.
+    // via a far-frame push. This reproduces mixed far+near depth that previously undercounted.
     let snapshot = vm.world_diff.snapshot();
     vm.state
         .current_frame
         .push_near_call(vm.state.current_frame.gas, 0, snapshot);
     let template_near_call = vm.state.current_frame.near_calls[0].clone();
     vm.state.current_frame.near_calls = vec![template_near_call; VM_MAX_STACK_DEPTH as usize - 1];
+    // Keep the cached depth in sync with the direct near call vector mutation above.
+    vm.state.callstack_depth = VM_MAX_STACK_DEPTH as usize;
 
     let calldata_heap = vm.state.current_frame.calldata_heap;
     vm.push_frame::<opcodes::Normal>(
@@ -470,11 +479,14 @@ fn callstack_saturation_should_count_near_calls_in_previous_far_frames() {
 }
 
 #[test]
-#[ignore = "long-running; run on demand"]
+#[ignore = "extreme callstack saturation case; memory-heavy and long-running; run on demand"]
 fn callstack_saturation_should_mask_near_call_to_panic() {
+    // This test checks the extreme case of callstack saturation, which is highly unlikely
+    // to be hit in practice. It is memory-heavy and long-running.
+    // Consider running it only when debugging an active VM issue and you suspect
+    // callstack processing behavior.
     // In zk_evm, callstack-full is checked before opcode execution and masked into panic.
-    // vm2 currently executes NearCall directly even when the callstack is saturated.
-    // This test is long-running because it must fill the callstack up to VM_MAX_STACK_DEPTH.
+    // vm2 should preserve this behavior.
     // Run on demand with:
     // cargo test -p zksync_vm2 callstack_saturation_should_mask_near_call_to_panic -- --ignored --nocapture
     let near_call = Instruction::from_near_call(
@@ -500,6 +512,7 @@ fn callstack_saturation_should_mask_near_call_to_panic() {
         vm.state
             .current_frame
             .push_near_call(vm.state.current_frame.gas, 0, snapshot.clone());
+        vm.state.increment_callstack_depth();
     }
 
     execute_one_instruction(&mut vm, &mut world, &mut ());

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -1,14 +1,15 @@
 use primitive_types::{H160, U256};
 use zkevm_opcode_defs::{
-    decoding::EncodingModeProduction, ethereum_types::Address, Condition, DecodedOpcode,
-    ImmMemHandlerFlags, Opcode, Operand, RegOrImmFlags, UMAOpcode, OPCODES_TABLE,
-    UMA_INCREMENT_FLAG_IDX,
+    decoding::EncodingModeProduction, ethereum_types::Address, system_params::VM_MAX_STACK_DEPTH,
+    Condition, DecodedOpcode, ImmMemHandlerFlags, Opcode, Operand, RegOrImmFlags, UMAOpcode,
+    OPCODES_TABLE, UMA_INCREMENT_FLAG_IDX,
 };
 use zksync_vm2_interface::{opcodes, Tracer};
 
 use crate::{
     addressing_modes::{Arguments, Immediate1, Register, Register1, Register2},
     decode::decode,
+    fat_pointer::FatPointer,
     testonly::TestWorld,
     ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, StorageInterface,
     StorageSlot, VirtualMachine, World,
@@ -25,6 +26,20 @@ fn default_settings() -> Settings {
 fn kernel_address() -> Address {
     // First 18 bytes are zero, so this address executes in kernel mode.
     Address::from_low_u64_be(1)
+}
+
+fn non_kernel_address() -> Address {
+    Address::repeat_byte(1)
+}
+
+fn execute_one_instruction<T: Tracer, W: World<T>>(
+    vm: &mut VirtualMachine<T, W>,
+    world: &mut W,
+    tracer: &mut T,
+) {
+    unsafe {
+        let _ = ((*vm.state.current_frame.pc).handler)(vm, world, tracer);
+    }
 }
 
 fn ret_instruction<T: Tracer, W: World<T>>() -> Instruction<T, W> {
@@ -230,4 +245,154 @@ fn precompile_extra_ergs_oog_should_not_panic() {
         vm.run(&mut world, &mut ()),
         ExecutionEnd::ProgramFinished(vec![])
     );
+}
+
+#[test]
+#[ignore = "long-running; run on demand"]
+fn callstack_saturation_should_mask_near_call_to_panic() {
+    // In zk_evm, callstack-full is checked before opcode execution and masked into panic.
+    // vm2 currently executes NearCall directly even when the callstack is saturated.
+    // This test is long-running because it must fill the callstack up to VM_MAX_STACK_DEPTH.
+    // Run on demand with:
+    // cargo test -p zksync_vm2 callstack_saturation_should_mask_near_call_to_panic -- --ignored --nocapture
+    let near_call = Instruction::from_near_call(
+        Register1(Register::new(1)),
+        Immediate1(0),
+        crate::addressing_modes::Immediate2(0),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![near_call], vec![]);
+    let mut world = TestWorld::new(&[]);
+    let mut vm = VirtualMachine::new(
+        non_kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    vm.state.registers[1] = U256::zero();
+    let snapshot = vm.world_diff.snapshot();
+    for _ in 0..VM_MAX_STACK_DEPTH {
+        vm.state
+            .current_frame
+            .push_near_call(vm.state.current_frame.gas, 0, snapshot.clone());
+    }
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+
+    assert_eq!(
+        vm.state.current_frame.near_calls.len(),
+        VM_MAX_STACK_DEPTH as usize - 1
+    );
+}
+
+#[test]
+fn non_kernel_returndata_forward_to_older_page_should_panic() {
+    // zk_evm rejects non-kernel returndata forwarding to an older memory page.
+    // vm2 only blocks forwarding to the current calldata page.
+    let caller_program = Program::from_raw(
+        vec![Instruction::from_ret(
+            Register1(Register::new(1)),
+            None,
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        )],
+        vec![],
+    );
+    let mut world = TestWorld::new(&[]);
+    let mut vm = VirtualMachine::new(
+        non_kernel_address(),
+        caller_program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let caller_heap = vm.state.current_frame.heap;
+    let caller_aux_heap = vm.state.current_frame.aux_heap;
+    let callee_program = Program::from_raw(
+        vec![Instruction::from_ret(
+            Register1(Register::new(1)),
+            None,
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        )],
+        vec![],
+    );
+    vm.push_frame::<opcodes::Normal>(
+        non_kernel_address(),
+        callee_program,
+        200_000,
+        0,
+        false,
+        false,
+        caller_heap,
+        vm.world_diff.snapshot(),
+    );
+
+    let mut return_abi = FatPointer {
+        offset: 0,
+        memory_page: caller_aux_heap,
+        start: 0,
+        length: 0,
+    }
+    .into_u256();
+    // ForwardFatPointer mode in ABI.
+    return_abi.0[3] = 1_u64 << 32;
+    vm.state.registers[1] = return_abi;
+    vm.state.register_pointer_flags = 1 << 1;
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+
+    assert_eq!(vm.state.registers[1], U256::zero());
+}
+
+#[test]
+fn nonfresh_decommit_should_reuse_existing_memory_page() {
+    // zk_evm reuses the same memory page for repeated decommit of the same code hash.
+    // vm2 currently allocates a fresh page every time.
+    let contract = (
+        non_kernel_address(),
+        Program::from_raw(vec![ret_instruction()], vec![]),
+    );
+    let mut world = TestWorld::new(&[contract]);
+    let code_hash = *world
+        .address_to_hash
+        .values()
+        .next()
+        .expect("test contract hash must exist");
+
+    let decommit_first = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(3)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let decommit_second = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(4)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![decommit_first, decommit_second], vec![]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+    vm.state.registers[1] = code_hash;
+    vm.state.registers[2] = U256::zero();
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    let first = FatPointer::from(vm.state.registers[3]);
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    let second = FatPointer::from(vm.state.registers[4]);
+
+    assert_eq!(first.memory_page, second.memory_page);
 }

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -430,56 +430,6 @@ fn precompile_extra_ergs_oog_should_not_panic() {
 
 #[test]
 #[ignore = "extreme callstack saturation case; memory-heavy and long-running; run on demand"]
-fn callstack_saturation_should_count_near_calls_in_previous_far_frames() {
-    // This test checks the extreme case of callstack saturation, which is highly unlikely
-    // to be hit in practice. It is memory-heavy and long-running.
-    // Consider running it only when debugging an active VM issue and you suspect
-    // callstack processing behavior.
-    // Run on demand with:
-    // cargo test -p zksync_vm2 callstack_saturation_should_count_near_calls_in_previous_far_frames -- --ignored --nocapture
-    let program: Program<(), TestWorld<()>> =
-        Program::from_raw(vec![ret_instruction::<(), TestWorld<()>>()], vec![]);
-
-    let mut vm = VirtualMachine::new(
-        non_kernel_address(),
-        program.clone(),
-        Address::zero(),
-        &[],
-        1_000_000,
-        default_settings(),
-    );
-
-    // Fill the current far frame with local near calls and then move it to `previous_frames`
-    // via a far-frame push. This reproduces mixed far+near depth that previously undercounted.
-    let snapshot = vm.world_diff.snapshot();
-    vm.state
-        .current_frame
-        .push_near_call(vm.state.current_frame.gas, 0, snapshot);
-    let template_near_call = vm.state.current_frame.near_calls[0].clone();
-    vm.state.current_frame.near_calls = vec![template_near_call; VM_MAX_STACK_DEPTH as usize - 1];
-    // Keep the cached depth in sync with the direct near call vector mutation above.
-    vm.state.callstack_depth = VM_MAX_STACK_DEPTH as usize;
-
-    let calldata_heap = vm.state.current_frame.calldata_heap;
-    vm.push_frame::<opcodes::Normal>(
-        non_kernel_address(),
-        program,
-        200_000,
-        0,
-        false,
-        false,
-        calldata_heap,
-        vm.world_diff.snapshot(),
-    );
-
-    assert!(
-        vm.state.callstack_is_full(),
-        "callstack saturation should include near calls from previous far frames"
-    );
-}
-
-#[test]
-#[ignore = "extreme callstack saturation case; memory-heavy and long-running; run on demand"]
 fn callstack_saturation_should_mask_near_call_to_panic() {
     // This test checks the extreme case of callstack saturation, which is highly unlikely
     // to be hit in practice. It is memory-heavy and long-running.
@@ -512,7 +462,6 @@ fn callstack_saturation_should_mask_near_call_to_panic() {
         vm.state
             .current_frame
             .push_near_call(vm.state.current_frame.gas, 0, snapshot.clone());
-        vm.state.increment_callstack_depth();
     }
 
     execute_one_instruction(&mut vm, &mut world, &mut ());

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -351,7 +351,6 @@ fn non_kernel_returndata_forward_to_older_page_should_panic() {
 #[test]
 fn nonfresh_decommit_should_reuse_existing_memory_page() {
     // zk_evm reuses the same memory page for repeated decommit of the same code hash.
-    // vm2 currently allocates a fresh page every time.
     let contract = (
         non_kernel_address(),
         Program::from_raw(vec![ret_instruction()], vec![]),
@@ -395,4 +394,147 @@ fn nonfresh_decommit_should_reuse_existing_memory_page() {
     let second = FatPointer::from(vm.state.registers[4]);
 
     assert_eq!(first.memory_page, second.memory_page);
+}
+
+#[test]
+fn nonfresh_decommit_should_keep_page_alive_after_nested_frame_returns() {
+    // Reusing decommit pages is correct only if the page survives nested frame teardown.
+    let code_word = U256::from(0xdead_beef_u64);
+    let contract = (
+        non_kernel_address(),
+        Program::from_raw(vec![ret_instruction()], vec![code_word]),
+    );
+    let mut world = TestWorld::new(&[contract]);
+    let code_hash = *world
+        .address_to_hash
+        .values()
+        .next()
+        .expect("test contract hash must exist");
+
+    let nested_decommit = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(3)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let nested_program = Program::from_raw(vec![nested_decommit], vec![]);
+    let bootloader_decommit = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(4)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let bootloader_program = Program::from_raw(vec![bootloader_decommit], vec![]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        bootloader_program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+    vm.state.registers[1] = code_hash;
+    vm.state.registers[2] = U256::zero();
+
+    let calldata_heap = vm.state.current_frame.calldata_heap;
+    let world_before_nested = vm.world_diff.snapshot();
+    vm.push_frame::<opcodes::Normal>(
+        kernel_address(),
+        nested_program,
+        200_000,
+        0,
+        false,
+        false,
+        calldata_heap,
+        world_before_nested,
+    );
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    let first = FatPointer::from(vm.state.registers[3]);
+    assert_eq!(vm.state.heaps[first.memory_page].read_u256(0), code_word);
+
+    vm.pop_frame(None)
+        .expect("nested frame must be present for pop");
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    let second = FatPointer::from(vm.state.registers[4]);
+
+    assert_eq!(first.memory_page, second.memory_page);
+    assert_eq!(vm.state.heaps[second.memory_page].read_u256(0), code_word);
+}
+
+#[test]
+fn decommit_page_in_keep_alive_list_should_not_be_deallocated_on_pop() {
+    let program: Program<(), TestWorld<()>> =
+        Program::from_raw(vec![ret_instruction::<(), TestWorld<()>>()], vec![]);
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program.clone(),
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let calldata_heap = vm.state.current_frame.calldata_heap;
+    let world_before_nested = vm.world_diff.snapshot();
+    vm.push_frame::<opcodes::Normal>(
+        kernel_address(),
+        program,
+        200_000,
+        0,
+        false,
+        false,
+        calldata_heap,
+        world_before_nested,
+    );
+
+    let code_word = U256::from(0xabcdu64);
+    let mut code_bytes = [0_u8; 32];
+    code_word.to_big_endian(&mut code_bytes);
+    let decommit_heap = vm.state.heaps.allocate_with_content(&code_bytes);
+    let kept_heap = vm.state.heaps.allocate_with_content(&[0x11; 32]);
+
+    vm.world_diff
+        .set_decommit_page(U256::from(0x1234_u64), decommit_heap);
+    vm.state
+        .current_frame
+        .heaps_i_am_keeping_alive
+        .extend([decommit_heap, kept_heap]);
+
+    vm.pop_frame(Some(kept_heap))
+        .expect("nested frame must be present for pop");
+
+    assert_eq!(vm.state.heaps[decommit_heap].read_u256(0), code_word);
+}
+
+#[test]
+fn rollback_should_preserve_pre_snapshot_decommit_page() {
+    let program: Program<(), TestWorld<()>> =
+        Program::from_raw(vec![ret_instruction::<(), TestWorld<()>>()], vec![]);
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let code_word = U256::from(0xdead_beef_u64);
+    let mut code_bytes = [0_u8; 32];
+    code_word.to_big_endian(&mut code_bytes);
+    let decommit_heap = vm.state.heaps.allocate_with_content(&code_bytes);
+    vm.world_diff
+        .set_decommit_page(U256::from(0xfeed_u64), decommit_heap);
+
+    vm.make_snapshot();
+    vm.state
+        .current_frame
+        .heaps_i_am_keeping_alive
+        .push(decommit_heap);
+    vm.rollback();
+
+    assert_eq!(vm.state.heaps[decommit_heap].read_u256(0), code_word);
 }

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -583,9 +583,8 @@ fn nonfresh_decommit_should_reuse_existing_memory_page() {
 
 #[test]
 fn decommit_after_far_call_decommit_should_not_panic() {
-    // `pay_for_decommit` marks the hash as decommitted but does not assign a Decommit page.
-    // The first follow-up `Decommit` must materialize a page lazily, while repeated `Decommit`
-    // should reuse that page without creating duplicate keep-alive entries.
+    // Far-call decommit must eagerly materialize a reusable decommit page.
+    // Follow-up `Decommit` calls should return that same page without duplicate keep-alive entries.
     let called_address = Address::from_low_u64_be(2);
     let called_program = Program::from_raw(vec![ret_instruction()], vec![]);
     let mut world = TestWorld::new(&[(called_address, called_program)]);
@@ -638,6 +637,11 @@ fn decommit_after_far_call_decommit_should_not_panic() {
     execute_one_instruction(&mut vm, &mut world, &mut ());
     execute_one_instruction(&mut vm, &mut world, &mut ());
 
+    assert!(
+        vm.world_diff.decommit_page(code_hash).is_some(),
+        "Far-call decommit should materialize a reusable page"
+    );
+
     vm.state.registers[1] = code_hash;
     vm.state.registers[2] = U256::zero();
     vm.state.register_pointer_flags &= !(1 << 1);
@@ -658,7 +662,7 @@ fn decommit_after_far_call_decommit_should_not_panic() {
 
     assert!(
         vm.world_diff.decommit_page(code_hash).is_some(),
-        "Decommit opcode should materialize a reusable page for non-fresh hashes"
+        "Non-fresh decommit should keep using a materialized reusable page"
     );
     assert_eq!(first.memory_page, second.memory_page);
     assert_eq!(

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -710,7 +710,7 @@ fn nonfresh_decommit_should_reuse_existing_memory_page() {
 
 #[test]
 fn fresh_decommit_should_preserve_existing_heap_bytes_after_code() {
-    let code_word = U256::from(0x363d3d37363d34f0_u64);
+    let code_word = U256::from(0x363d_3d37_363d_34f0_u64);
     let contract = (
         non_kernel_address(),
         Program::from_raw(vec![ret_instruction()], vec![code_word]),

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -1039,3 +1039,47 @@ fn rollback_should_preserve_pre_snapshot_decommit_page() {
 
     assert_eq!(vm.state.heaps[decommit_heap].read_u256(0), code_word);
 }
+
+#[test]
+fn rollback_should_restore_bootloader_heap_after_fresh_decommit() {
+    let code_word = U256::from(0xdead_beef_u64);
+    let contract = (
+        non_kernel_address(),
+        Program::from_raw(vec![ret_instruction()], vec![code_word]),
+    );
+    let mut world = TestWorld::new(&[contract]);
+    let code_hash = *world
+        .address_to_hash
+        .values()
+        .next()
+        .expect("test contract hash must exist");
+
+    let decommit = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(3)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let bootloader_program = Program::from_raw(vec![decommit], vec![]);
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        bootloader_program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let bootloader_heap = vm.state.current_frame.heap;
+    let sentinel = U256::from(0x1234_5678_u64);
+    vm.state.heaps.write_u256(bootloader_heap, 0, sentinel);
+    vm.state.registers[1] = code_hash;
+    vm.state.registers[2] = U256::zero();
+
+    vm.make_snapshot();
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    assert_eq!(vm.state.heaps[bootloader_heap].read_u256(0), code_word);
+
+    vm.rollback();
+    assert_eq!(vm.state.heaps[bootloader_heap].read_u256(0), sentinel);
+}

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -1,0 +1,233 @@
+use primitive_types::{H160, U256};
+use zkevm_opcode_defs::{
+    decoding::EncodingModeProduction, ethereum_types::Address, Condition, DecodedOpcode,
+    ImmMemHandlerFlags, Opcode, Operand, RegOrImmFlags, UMAOpcode, OPCODES_TABLE,
+    UMA_INCREMENT_FLAG_IDX,
+};
+use zksync_vm2_interface::{opcodes, Tracer};
+
+use crate::{
+    addressing_modes::{Arguments, Immediate1, Register, Register1, Register2},
+    decode::decode,
+    testonly::TestWorld,
+    ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, StorageInterface,
+    StorageSlot, VirtualMachine, World,
+};
+
+fn default_settings() -> Settings {
+    Settings {
+        default_aa_code_hash: [0; 32],
+        evm_interpreter_code_hash: [0; 32],
+        hook_address: 0,
+    }
+}
+
+fn kernel_address() -> Address {
+    // First 18 bytes are zero, so this address executes in kernel mode.
+    Address::from_low_u64_be(1)
+}
+
+fn ret_instruction<T: Tracer, W: World<T>>() -> Instruction<T, W> {
+    Instruction::from_ret(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    )
+}
+
+fn static_uma_instruction<T: Tracer, W: World<T>>(opcode: UMAOpcode) -> Instruction<T, W> {
+    let variant = OPCODES_TABLE
+        .iter()
+        .copied()
+        .find(|variant| {
+            variant.opcode == Opcode::UMA(opcode)
+                && variant.src0_operand_type == Operand::RegOrImm(RegOrImmFlags::UseRegOnly)
+                && matches!(
+                    variant.dst0_operand_type,
+                    Operand::RegOnly | Operand::Full(ImmMemHandlerFlags::UseRegOnly)
+                )
+                && !variant.flags[UMA_INCREMENT_FLAG_IDX]
+        })
+        .expect("Static UMA Register-only variant must exist");
+
+    let encoded = DecodedOpcode::<8, EncodingModeProduction> {
+        variant,
+        condition: Condition::Always,
+        src0_reg_idx: 0,
+        src1_reg_idx: 0,
+        dst0_reg_idx: 1,
+        dst1_reg_idx: 0,
+        imm_0: 0,
+        imm_1: 0,
+    }
+    .serialize_as_integer();
+
+    decode(encoded, false)
+}
+
+#[test]
+fn static_memory_read_should_not_panic_in_kernel_mode() {
+    // In zk_evm this opcode is executable in kernel mode. We lock this behavior as a regression
+    // test before implementing StaticMemoryRead in vm2.
+    let program = Program::from_raw(
+        vec![
+            static_uma_instruction(UMAOpcode::StaticMemoryRead),
+            ret_instruction(),
+        ],
+        vec![],
+    );
+    let mut world = TestWorld::new(&[]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    assert_eq!(
+        vm.run(&mut world, &mut ()),
+        ExecutionEnd::ProgramFinished(vec![])
+    );
+}
+
+#[test]
+fn static_memory_write_should_not_panic_in_kernel_mode() {
+    // In zk_evm this opcode is executable in kernel mode. We lock this behavior as a regression
+    // test before implementing StaticMemoryWrite in vm2.
+    let program = Program::from_raw(
+        vec![
+            static_uma_instruction(UMAOpcode::StaticMemoryWrite),
+            ret_instruction(),
+        ],
+        vec![],
+    );
+    let mut world = TestWorld::new(&[]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    assert_eq!(
+        vm.run(&mut world, &mut ()),
+        ExecutionEnd::ProgramFinished(vec![])
+    );
+}
+
+#[derive(Debug, Default)]
+struct CountingWorld {
+    storage_reads: usize,
+}
+
+impl StorageInterface for CountingWorld {
+    fn read_storage(&mut self, _: H160, _: U256) -> StorageSlot {
+        self.storage_reads += 1;
+        StorageSlot::EMPTY
+    }
+
+    fn cost_of_writing_storage(&mut self, _: StorageSlot, _: U256) -> u32 {
+        0
+    }
+
+    fn is_free_storage_slot(&self, _: &H160, _: &U256) -> bool {
+        false
+    }
+}
+
+impl<T: Tracer> World<T> for CountingWorld {
+    fn decommit(&mut self, _: U256) -> Program<T, Self> {
+        Program::new_panicking()
+    }
+
+    fn decommit_code(&mut self, _: U256) -> Vec<u8> {
+        vec![]
+    }
+}
+
+#[test]
+fn shard_far_call_should_not_touch_storage_on_nonzero_shard() {
+    // In zk_evm, non-zero shard calls fail before deployer storage lookups.
+    let far_call = Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(1),
+        false,
+        true,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![far_call, ret_instruction()], vec![]);
+
+    let mut world = CountingWorld::default();
+    let mut vm = VirtualMachine::new(
+        Address::from_low_u64_be(0x100),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    // Use a plain ABI value (not a pointer), but make shard_id non-zero.
+    vm.state.register_pointer_flags &= !(1 << 1);
+    let mut abi = U256::zero();
+    abi.0[3] = 1_u64 << 40;
+    vm.state.registers[1] = abi;
+    vm.state.registers[2] = U256::from(0x1234_u64);
+
+    let _ = vm.run(&mut world, &mut ());
+
+    assert_eq!(world.storage_reads, 0);
+}
+
+#[test]
+fn precompile_extra_ergs_oog_should_not_panic() {
+    // In zk_evm, PrecompileCall with insufficient extra ergs writes zero to dst and continues.
+    // We intentionally follow the precompile call with two 0-cost instructions to verify that
+    // execution continues to the next opcode instead of turning the current opcode into panic.
+    let precompile_call = Instruction::from_precompile_call(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(3)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let add_zero_cost = Instruction::from_add(
+        Register1(Register::new(0)).into(),
+        Register2(Register::new(0)),
+        Register1(Register::new(0)).into(),
+        Arguments::new(Predicate::Always, 0, ModeRequirements::none()),
+        false,
+        false,
+    );
+    let ret_zero_cost = Instruction::from_ret(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 0, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![precompile_call, add_zero_cost, ret_zero_cost], vec![]);
+    let mut world = TestWorld::new(&[]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = U256::zero();
+    vm.state.registers[2] = U256::from(u32::MAX);
+
+    assert_eq!(
+        vm.run(&mut world, &mut ()),
+        ExecutionEnd::ProgramFinished(vec![])
+    );
+}

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -10,6 +10,7 @@ use crate::{
     addressing_modes::{Arguments, Immediate1, Register, Register1, Register2},
     decode::decode,
     fat_pointer::FatPointer,
+    precompiles::{PrecompileMemoryReader, PrecompileOutput, Precompiles},
     testonly::TestWorld,
     ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, StorageInterface,
     StorageSlot, VirtualMachine, World,
@@ -136,6 +137,186 @@ fn static_memory_write_should_not_panic_in_kernel_mode() {
     );
 }
 
+#[test]
+fn static_memory_should_be_isolated_from_regular_heap() {
+    let static_write = Instruction::from_static_memory_write(
+        Register1(Register::new(1)).into(),
+        Register2(Register::new(2)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let heap_read = Instruction::from_heap_read(
+        Register1(Register::new(1)).into(),
+        Register1(Register::new(3)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let static_read = Instruction::from_static_memory_read(
+        Register1(Register::new(1)).into(),
+        Register1(Register::new(4)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(
+        vec![static_write, heap_read, static_read, ret_instruction()],
+        vec![],
+    );
+    let mut world = TestWorld::new(&[]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let static_value = U256::from(0x11_u64);
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = U256::zero();
+    vm.state.registers[2] = static_value;
+
+    assert_eq!(
+        vm.run(&mut world, &mut ()),
+        ExecutionEnd::ProgramFinished(vec![])
+    );
+    assert_eq!(vm.state.registers[3], U256::zero());
+    assert_eq!(vm.state.registers[4], static_value);
+}
+
+#[derive(Debug, Default)]
+struct IncrementingPrecompiles;
+
+impl Precompiles for IncrementingPrecompiles {
+    fn call_precompile(
+        &self,
+        _: u16,
+        mut memory: PrecompileMemoryReader<'_>,
+        _: u64,
+    ) -> PrecompileOutput {
+        let mut input_word = [0_u8; 32];
+        for byte in &mut input_word {
+            *byte = memory.next().unwrap_or_default();
+        }
+        (U256::from_big_endian(&input_word) + U256::one()).into()
+    }
+}
+
+#[derive(Debug, Default)]
+struct PrecompileSentinelWorld {
+    precompiles: IncrementingPrecompiles,
+}
+
+impl StorageInterface for PrecompileSentinelWorld {
+    fn read_storage(&mut self, _: H160, _: U256) -> StorageSlot {
+        StorageSlot::EMPTY
+    }
+
+    fn cost_of_writing_storage(&mut self, _: StorageSlot, _: U256) -> u32 {
+        0
+    }
+
+    fn is_free_storage_slot(&self, _: &H160, _: &U256) -> bool {
+        false
+    }
+}
+
+impl<T: Tracer> World<T> for PrecompileSentinelWorld {
+    fn decommit(&mut self, _: U256) -> Program<T, Self> {
+        Program::new_panicking()
+    }
+
+    fn decommit_code(&mut self, _: U256) -> Vec<u8> {
+        vec![]
+    }
+
+    fn precompiles(&self) -> &impl Precompiles {
+        &self.precompiles
+    }
+}
+
+#[test]
+fn precompile_zero_memory_page_should_use_current_heap_instead_of_static_memory() {
+    let static_write = Instruction::from_static_memory_write(
+        Register1(Register::new(1)).into(),
+        Register2(Register::new(2)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let heap_write = Instruction::from_heap_write(
+        Register1(Register::new(1)).into(),
+        Register2(Register::new(3)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        false,
+    );
+    let precompile_call = Instruction::from_precompile_call(
+        Register1(Register::new(4)),
+        Register2(Register::new(5)),
+        Register1(Register::new(6)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let heap_read_after = Instruction::from_heap_read(
+        Register1(Register::new(1)).into(),
+        Register1(Register::new(7)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let static_read_after = Instruction::from_static_memory_read(
+        Register1(Register::new(1)).into(),
+        Register1(Register::new(8)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(
+        vec![
+            static_write,
+            heap_write,
+            precompile_call,
+            heap_read_after,
+            static_read_after,
+            ret_instruction(),
+        ],
+        vec![],
+    );
+    let mut world = PrecompileSentinelWorld::default();
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let static_value = U256::from(0x11_u64);
+    let heap_value = U256::from(0x22_u64);
+    let expected_heap_after_precompile = heap_value + U256::one();
+
+    // ABI: read 32 bytes from offset 0, write 1 word at offset 0, with page ids left at zero.
+    // Page zero is the sentinel path under test.
+    let mut precompile_abi = U256::zero();
+    precompile_abi.0[0] = 32_u64 << 32;
+    precompile_abi.0[1] = 1_u64 << 32;
+
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = U256::zero();
+    vm.state.registers[2] = static_value;
+    vm.state.registers[3] = heap_value;
+    vm.state.registers[4] = precompile_abi;
+    vm.state.registers[5] = U256::zero();
+
+    assert_eq!(
+        vm.run(&mut world, &mut ()),
+        ExecutionEnd::ProgramFinished(vec![])
+    );
+    assert_eq!(vm.state.registers[6], U256::one());
+    assert_eq!(vm.state.registers[7], expected_heap_after_precompile);
+    assert_eq!(vm.state.registers[8], static_value);
+}
+
 #[derive(Debug, Default)]
 struct CountingWorld {
     storage_reads: usize,
@@ -244,6 +425,47 @@ fn precompile_extra_ergs_oog_should_not_panic() {
     assert_eq!(
         vm.run(&mut world, &mut ()),
         ExecutionEnd::ProgramFinished(vec![])
+    );
+}
+
+#[test]
+fn callstack_saturation_should_count_near_calls_in_previous_far_frames() {
+    let program: Program<(), TestWorld<()>> =
+        Program::from_raw(vec![ret_instruction::<(), TestWorld<()>>()], vec![]);
+
+    let mut vm = VirtualMachine::new(
+        non_kernel_address(),
+        program.clone(),
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    // Fill the current far frame with local near calls and then move it to `previous_frames`
+    // via a far-frame push. This reproduces mixed far+near depth where vm2 undercounts.
+    let snapshot = vm.world_diff.snapshot();
+    vm.state
+        .current_frame
+        .push_near_call(vm.state.current_frame.gas, 0, snapshot);
+    let template_near_call = vm.state.current_frame.near_calls[0].clone();
+    vm.state.current_frame.near_calls = vec![template_near_call; VM_MAX_STACK_DEPTH as usize - 1];
+
+    let calldata_heap = vm.state.current_frame.calldata_heap;
+    vm.push_frame::<opcodes::Normal>(
+        non_kernel_address(),
+        program,
+        200_000,
+        0,
+        false,
+        false,
+        calldata_heap,
+        vm.world_diff.snapshot(),
+    );
+
+    assert!(
+        vm.state.callstack_is_full(),
+        "callstack saturation should include near calls from previous far frames"
     );
 }
 
@@ -394,6 +616,66 @@ fn nonfresh_decommit_should_reuse_existing_memory_page() {
     let second = FatPointer::from(vm.state.registers[4]);
 
     assert_eq!(first.memory_page, second.memory_page);
+}
+
+#[test]
+fn decommit_after_far_call_decommit_should_not_panic() {
+    // `pay_for_decommit` marks the hash as decommitted but does not assign a Decommit page.
+    // A follow-up Decommit opcode on the same hash should stay inside VM semantics instead of
+    // panicking the host process.
+    let called_address = Address::from_low_u64_be(2);
+    let called_program = Program::from_raw(vec![ret_instruction()], vec![]);
+    let mut world = TestWorld::new(&[(called_address, called_program)]);
+    let called_address_as_u256 = U256::from(called_address.to_low_u64_be());
+    let code_hash = *world
+        .address_to_hash
+        .get(&called_address_as_u256)
+        .expect("test contract hash must exist");
+
+    let far_call = Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(1),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    );
+    let decommit = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(3)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![far_call, decommit, ret_instruction()], vec![]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let mut far_call_abi = U256::zero();
+    far_call_abi.0[3] = 10_000;
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = far_call_abi;
+    vm.state.registers[2] = called_address_as_u256;
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+
+    vm.state.registers[1] = code_hash;
+    vm.state.registers[2] = U256::zero();
+    vm.state.register_pointer_flags &= !(1 << 1);
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+
+    assert!(
+        vm.world_diff.decommit_page(code_hash).is_some(),
+        "Decommit opcode should materialize a reusable page for non-fresh hashes"
+    );
 }
 
 #[test]

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -709,6 +709,88 @@ fn nonfresh_decommit_should_reuse_existing_memory_page() {
 }
 
 #[test]
+fn fresh_decommit_should_preserve_existing_heap_bytes_after_code() {
+    let code_word = U256::from(0x363d3d37363d34f0_u64);
+    let contract = (
+        non_kernel_address(),
+        Program::from_raw(vec![ret_instruction()], vec![code_word]),
+    );
+    let mut world = TestWorld::new(&[contract]);
+    let code_hash = *world
+        .address_to_hash
+        .values()
+        .next()
+        .expect("test contract hash must exist");
+
+    let decommit = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(3)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![decommit], vec![]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+    vm.state.registers[1] = code_hash;
+    vm.state.registers[2] = U256::zero();
+
+    let preserved = [0xda, 0x0a, 0x64, 0x56];
+    let preserved_word = U256::from_big_endian(&[
+        preserved[0],
+        preserved[1],
+        preserved[2],
+        preserved[3],
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]);
+    let current_heap = vm.state.current_frame.heap;
+    vm.state.heaps.write_u256(current_heap, 32, preserved_word);
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    let pointer = FatPointer::from(vm.state.registers[3]);
+
+    assert_eq!(pointer.memory_page, current_heap);
+    assert_eq!(vm.state.heaps[current_heap].read_u256(0), code_word);
+    assert_eq!(
+        vm.state.heaps[current_heap].read_range_big_endian(32..36),
+        preserved
+    );
+}
+
+#[test]
 fn decommit_after_far_call_decommit_should_not_panic() {
     // Far-call decommit must eagerly materialize a reusable decommit page.
     // Follow-up `Decommit` calls should return that same page without duplicate keep-alive entries.

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -473,6 +473,7 @@ fn callstack_saturation_should_mask_near_call_to_panic() {
 }
 
 #[test]
+#[allow(clippy::similar_names)] // `caller` / `callee` is standard notation
 fn non_kernel_returndata_forward_to_older_page_should_panic() {
     // zk_evm rejects non-kernel returndata forwarding to an older memory page.
     // vm2 only blocks forwarding to the current calldata page.

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -584,8 +584,8 @@ fn nonfresh_decommit_should_reuse_existing_memory_page() {
 #[test]
 fn decommit_after_far_call_decommit_should_not_panic() {
     // `pay_for_decommit` marks the hash as decommitted but does not assign a Decommit page.
-    // A follow-up Decommit opcode on the same hash should stay inside VM semantics instead of
-    // panicking the host process.
+    // The first follow-up `Decommit` must materialize a page lazily, while repeated `Decommit`
+    // should reuse that page without creating duplicate keep-alive entries.
     let called_address = Address::from_low_u64_be(2);
     let called_program = Program::from_raw(vec![ret_instruction()], vec![]);
     let mut world = TestWorld::new(&[(called_address, called_program)]);
@@ -603,13 +603,22 @@ fn decommit_after_far_call_decommit_should_not_panic() {
         false,
         Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
     );
-    let decommit = Instruction::from_decommit(
+    let decommit_first = Instruction::from_decommit(
         Register1(Register::new(1)),
         Register2(Register::new(2)),
         Register1(Register::new(3)),
         Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
     );
-    let program = Program::from_raw(vec![far_call, decommit, ret_instruction()], vec![]);
+    let decommit_second = Instruction::from_decommit(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Register1(Register::new(4)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(
+        vec![far_call, decommit_first, decommit_second, ret_instruction()],
+        vec![],
+    );
 
     let mut vm = VirtualMachine::new(
         kernel_address(),
@@ -634,10 +643,27 @@ fn decommit_after_far_call_decommit_should_not_panic() {
     vm.state.register_pointer_flags &= !(1 << 1);
 
     execute_one_instruction(&mut vm, &mut world, &mut ());
+    let first = FatPointer::from(vm.state.registers[3]);
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    let second = FatPointer::from(vm.state.registers[4]);
+
+    let keep_alive_occurrences = vm
+        .state
+        .current_frame
+        .heaps_i_am_keeping_alive
+        .iter()
+        .filter(|&&heap| heap == first.memory_page)
+        .count();
 
     assert!(
         vm.world_diff.decommit_page(code_hash).is_some(),
         "Decommit opcode should materialize a reusable page for non-fresh hashes"
+    );
+    assert_eq!(first.memory_page, second.memory_page);
+    assert_eq!(
+        keep_alive_occurrences, 1,
+        "Reused decommit pages should be recorded in keep-alive once"
     );
 }
 
@@ -705,8 +731,20 @@ fn nonfresh_decommit_should_keep_page_alive_after_nested_frame_returns() {
     execute_one_instruction(&mut vm, &mut world, &mut ());
     let second = FatPointer::from(vm.state.registers[4]);
 
+    let keep_alive_occurrences = vm
+        .state
+        .current_frame
+        .heaps_i_am_keeping_alive
+        .iter()
+        .filter(|&&heap| heap == second.memory_page)
+        .count();
+
     assert_eq!(first.memory_page, second.memory_page);
     assert_eq!(vm.state.heaps[second.memory_page].read_u256(0), code_word);
+    assert_eq!(
+        keep_alive_occurrences, 1,
+        "Nested and parent decommits should not duplicate keep-alive entries"
+    );
 }
 
 #[test]

--- a/crates/vm2/src/tests/mod.rs
+++ b/crates/vm2/src/tests/mod.rs
@@ -1,6 +1,7 @@
 //! Low-level VM tests.
 
 mod bytecode_behaviour;
+mod divergence_regressions;
 mod far_call_decommitment;
 mod panic;
 mod trace_failing_far_call;

--- a/crates/vm2/src/tests/trace_failing_far_call.rs
+++ b/crates/vm2/src/tests/trace_failing_far_call.rs
@@ -95,3 +95,54 @@ fn trace_failing_far_call() {
 
     assert!(tracer.witnessed_all_opcodes());
 }
+
+#[test]
+fn trace_static_memory_opcodes() {
+    let instructions = vec![
+        Instruction::from_static_memory_write(
+            Register1(Register::new(1)).into(),
+            Register2(Register::new(2)),
+            None,
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        ),
+        Instruction::from_static_memory_read(
+            Register1(Register::new(1)).into(),
+            Register1(Register::new(3)),
+            None,
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        ),
+        Instruction::from_ret(
+            Register1(Register::new(0)),
+            None,
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        ),
+    ];
+    let program = Program::from_raw(instructions, vec![]);
+
+    let mut world = TestWorld::new(&[]);
+    let mut vm = VirtualMachine::new(
+        Address::from_low_u64_be(1),
+        program,
+        Address::zero(),
+        &[],
+        1000,
+        Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+        },
+    );
+
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = 0.into();
+    vm.state.registers[2] = 0xdead_u32.into();
+
+    let mut tracer = ExpectingTracer::new(vec![
+        Opcode::StaticMemoryWrite,
+        Opcode::StaticMemoryRead,
+        Opcode::Ret(ReturnType::Normal),
+    ]);
+    vm.run(&mut world, &mut tracer);
+
+    assert!(tracer.witnessed_all_opcodes());
+}

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -284,20 +284,14 @@ impl<T: Tracer, W: World<T>> CallframeInterface for CallframeWrapper<'_, T, W> {
         }
     }
 
-    // we don't expect the VM to run on 16-bit machines, and sign loss / wrap is checked
-    #[allow(
-        clippy::cast_sign_loss,
-        clippy::cast_possible_truncation,
-        clippy::cast_possible_wrap
-    )]
+    // we don't expect the VM to run on 16-bit machines, and truncation is checked
+    #[allow(clippy::cast_possible_truncation)]
     fn program_counter(&self) -> Option<u16> {
         if let Some(call) = self.near_call_on_top() {
             Some(call.previous_frame_pc)
         } else {
             let offset = self.frame.get_raw_pc();
-            if offset < 0
-                || offset > u16::MAX as usize
-                || self.frame.program.instruction(offset as u16).is_none()
+            if offset > u16::MAX as usize || self.frame.program.instruction(offset as u16).is_none()
             {
                 None
             } else {

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -296,7 +296,7 @@ impl<T: Tracer, W: World<T>> CallframeInterface for CallframeWrapper<'_, T, W> {
         } else {
             let offset = self.frame.get_raw_pc();
             if offset < 0
-                || offset > u16::MAX as isize
+                || offset > u16::MAX as usize
                 || self.frame.program.instruction(offset as u16).is_none()
             {
                 None
@@ -499,5 +499,40 @@ mod test {
             assert_eq!(vm.callframe(fwd).exception_handler(), rev);
             assert_eq!(vm.callframe(fwd).gas(), rev.into());
         }
+    }
+
+    #[test]
+    fn program_counter_does_not_panic_for_pointer_before_program() {
+        let program = Program::from_raw(vec![Instruction::from_invalid()], vec![]);
+
+        let address = Address::from_low_u64_be(0x_1234_5678_90ab_cdef);
+        let mut world = TestWorld::<()>::new(&[(address, program)]);
+        let program = initial_decommit(&mut world, address);
+
+        let mut vm = VirtualMachine::new(
+            address,
+            program,
+            Address::zero(),
+            &[],
+            1000,
+            crate::Settings {
+                default_aa_code_hash: [0; 32],
+                evm_interpreter_code_hash: [0; 32],
+                hook_address: 0,
+            },
+        );
+
+        let first_instruction = vm.state.current_frame.pc;
+        vm.state.current_frame.pc = first_instruction.wrapping_sub(1);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            vm.current_frame().program_counter()
+        }));
+
+        assert!(
+            result.is_ok(),
+            "program_counter should not panic on invalid pc"
+        );
+        assert_eq!(result.unwrap(), None);
     }
 }

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -478,6 +478,7 @@ mod test {
             vm.state
                 .current_frame
                 .push_near_call(count_u32, *counter, vm.world_diff.snapshot());
+            vm.state.increment_callstack_depth();
             assert_eq!(vm.current_frame().gas(), (*counter).into());
             *counter += 1;
         };

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -496,7 +496,7 @@ mod test {
     }
 
     #[test]
-    fn program_counter_does_not_panic_for_pointer_before_program() {
+    fn program_counter_with_pointer_before_program() {
         let program = Program::from_raw(vec![Instruction::from_invalid()], vec![]);
 
         let address = Address::from_low_u64_be(0x_1234_5678_90ab_cdef);
@@ -519,14 +519,7 @@ mod test {
         let first_instruction = vm.state.current_frame.pc;
         vm.state.current_frame.pc = first_instruction.wrapping_sub(1);
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            vm.current_frame().program_counter()
-        }));
-
-        assert!(
-            result.is_ok(),
-            "program_counter should not panic on invalid pc"
-        );
-        assert_eq!(result.unwrap(), None);
+        let result = vm.current_frame().program_counter();
+        assert_eq!(result, None);
     }
 }

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -478,7 +478,6 @@ mod test {
             vm.state
                 .current_frame
                 .push_near_call(count_u32, *counter, vm.world_diff.snapshot());
-            vm.state.increment_callstack_depth();
             assert_eq!(vm.current_frame().gas(), (*counter).into());
             *counter += 1;
         };

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -161,7 +161,9 @@ impl<T: Tracer, W: World<T>> VirtualMachine<T, W> {
             .take()
             .expect("`rollback()` called without a snapshot");
         self.world_diff.external_rollback(snapshot.world_snapshot);
-        self.state.rollback(snapshot.state_snapshot);
+        self.state.rollback(snapshot.state_snapshot, |heap| {
+            self.world_diff.is_decommit_page_pinned(heap)
+        });
         self.delete_history();
     }
 
@@ -246,7 +248,7 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
             .iter()
             .chain(&self.state.current_frame.heaps_i_am_keeping_alive)
             {
-                if Some(heap) != heap_to_keep {
+                if Some(heap) != heap_to_keep && !self.world_diff.is_decommit_page_pinned(heap) {
                     self.state.heaps.deallocate(heap);
                 }
             }

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -237,12 +237,10 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
 
         std::mem::swap(&mut new_frame, &mut self.state.current_frame);
         self.state.previous_frames.push(new_frame);
-        self.state.increment_callstack_depth();
     }
 
     pub(crate) fn pop_frame(&mut self, heap_to_keep: Option<HeapId>) -> Option<FrameRemnant> {
         let mut frame = self.state.previous_frames.pop()?;
-        self.state.decrement_callstack_depth();
 
         for &heap in [
             self.state.current_frame.heap,

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -237,41 +237,43 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
 
         std::mem::swap(&mut new_frame, &mut self.state.current_frame);
         self.state.previous_frames.push(new_frame);
+        self.state.increment_callstack_depth();
     }
 
     pub(crate) fn pop_frame(&mut self, heap_to_keep: Option<HeapId>) -> Option<FrameRemnant> {
-        self.state.previous_frames.pop().map(|mut frame| {
-            for &heap in [
-                self.state.current_frame.heap,
-                self.state.current_frame.aux_heap,
-            ]
-            .iter()
-            .chain(&self.state.current_frame.heaps_i_am_keeping_alive)
-            {
-                if Some(heap) != heap_to_keep && !self.world_diff.is_decommit_page_pinned(heap) {
-                    self.state.heaps.deallocate(heap);
-                }
+        let mut frame = self.state.previous_frames.pop()?;
+        self.state.decrement_callstack_depth();
+
+        for &heap in [
+            self.state.current_frame.heap,
+            self.state.current_frame.aux_heap,
+        ]
+        .iter()
+        .chain(&self.state.current_frame.heaps_i_am_keeping_alive)
+        {
+            if Some(heap) != heap_to_keep && !self.world_diff.is_decommit_page_pinned(heap) {
+                self.state.heaps.deallocate(heap);
             }
+        }
 
-            std::mem::swap(&mut self.state.current_frame, &mut frame);
-            let Callframe {
-                exception_handler,
-                world_before_this_frame,
-                stack,
-                ..
-            } = frame;
+        std::mem::swap(&mut self.state.current_frame, &mut frame);
+        let Callframe {
+            exception_handler,
+            world_before_this_frame,
+            stack,
+            ..
+        } = frame;
 
-            self.stack_pool.recycle(stack);
+        self.stack_pool.recycle(stack);
 
-            self.state
-                .current_frame
-                .heaps_i_am_keeping_alive
-                .extend(heap_to_keep);
+        self.state
+            .current_frame
+            .heaps_i_am_keeping_alive
+            .extend(heap_to_keep);
 
-            FrameRemnant {
-                exception_handler,
-                snapshot: world_before_this_frame,
-            }
+        Some(FrameRemnant {
+            exception_handler,
+            snapshot: world_before_this_frame,
         })
     }
 

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -7,6 +7,7 @@ use crate::{
     callframe::{Callframe, FrameRemnant},
     decommit::u256_into_address,
     instruction::ExecutionStatus,
+    page_ids::{aux_heap_page_from_base, heap_page_from_base},
     stack::StackPool,
     state::{State, StateSnapshot},
     world_diff::{ExternalSnapshot, Snapshot, WorldDiff},
@@ -205,6 +206,12 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
         calldata_heap: HeapId,
         world_before_this_frame: Snapshot,
     ) {
+        let base_page = self.state.allocate_base_page();
+        let heap_page = heap_page_from_base(base_page);
+        let aux_heap_page = aux_heap_page_from_base(base_page);
+        self.state.heaps.allocate_at(heap_page);
+        self.state.heaps.allocate_at(aux_heap_page);
+
         let mut new_frame = Callframe::new(
             if M::VALUE == CallingMode::Delegate {
                 self.state.current_frame.address
@@ -219,8 +226,8 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
             },
             program,
             self.stack_pool.get(),
-            self.state.heaps.allocate(),
-            self.state.heaps.allocate(),
+            heap_page,
+            aux_heap_page,
             calldata_heap,
             gas,
             exception_handler,

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -32,8 +32,7 @@ pub struct WorldDiff {
     // The fields below are only rolled back when the whole VM is rolled back.
     /// Tracks decommit attempts and successful decommit state for each bytecode hash.
     ///
-    /// This includes failed attempts (out of gas) because they affect old-VM-compatible behavior,
-    /// and successful attempts may or may not already have a materialized decommit page.
+    /// This includes failed attempts (out of gas) because they affect old-VM-compatible behavior.
     ///
     /// This field is rolled back only by external VM snapshots.
     pub(crate) decommitted_hashes: RollbackableMap<U256, DecommitState>,
@@ -72,14 +71,8 @@ pub(crate) enum DecommitState {
     /// in `decommitted_hashes()`, but this state must not make future decommits free.
     #[default]
     Unsuccessful,
-    /// A bytecode hash was successfully decommitted for charging / freshness semantics,
-    /// but no reusable heap page has been materialized yet.
-    ///
-    /// This happens when `pay_for_decommit` succeeds on non-`Decommit` opcode paths
-    /// (e.g. far call), and the first `Decommit` opcode later materializes the page lazily.
-    SucceededNoPage,
     /// A bytecode hash was successfully decommitted and has an assigned reusable heap page.
-    SucceededWithPage(u32),
+    Succeeded(u32),
 }
 
 impl WorldDiff {
@@ -373,7 +366,7 @@ impl WorldDiff {
             .as_ref()
             .get(&code_hash)
             .and_then(|state| {
-                if let DecommitState::SucceededWithPage(page) = state {
+                if let DecommitState::Succeeded(page) = state {
                     Some(HeapId::from_u32_unchecked(*page))
                 } else {
                     None
@@ -387,7 +380,7 @@ impl WorldDiff {
 
     pub(crate) fn set_decommit_page(&mut self, code_hash: U256, page: HeapId) {
         self.decommitted_hashes
-            .insert(code_hash, DecommitState::SucceededWithPage(page.as_u32()));
+            .insert(code_hash, DecommitState::Succeeded(page.as_u32()));
         self.decommit_pinned_pages.add(page.as_u32());
     }
 

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -130,6 +130,8 @@ impl WorldDiff {
 
         self.pubdata_costs.push(0);
         let value = self.just_read_storage(world, contract, key);
+        // Note: timestamp logic does not match `zk_evm`, we're only ensuring that the timestamps
+        // are unique. This is fine as long as we don't need to actually generate witness based on these logs.
         self.storage_logs.push(LogQuery {
             timestamp: Timestamp(
                 u32::try_from(self.storage_logs.len()).expect("Too many storage logs"),

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -239,7 +239,9 @@ impl WorldDiff {
     /// Returns all recorded storage log queries.
     ///
     /// These logs are sufficient for vm2 state-transition checks and diagnostics.
-    /// TODO: Fill all `zk_evm` witness metadata before using these queries to build prover witness data.
+    // TODO: We don't fill all the `zk_evm` witness metadata, so this is not suitable for
+    // generating EraVM prover witness data. This is not the goal, however, as we only need
+    // to emit enough data to verify the correctness of the state transition.
     pub fn storage_log_queries(&self) -> &[LogQuery] {
         &self.storage_logs
     }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -38,6 +38,11 @@ pub struct WorldDiff {
     ///
     /// Like `decommitted_hashes`, this is rolled back only by external VM snapshots.
     decommit_pages: RollbackableMap<U256, u32>,
+    /// Reverse index for `decommit_pages` to quickly check whether a heap page is globally pinned
+    /// by decommitment reuse semantics.
+    ///
+    /// This follows external snapshot / rollback semantics together with `decommit_pages`.
+    decommit_pinned_pages: RollbackableSet<u32>,
     read_storage_slots: RollbackableSet<(H160, U256)>,
     written_storage_slots: RollbackableSet<(H160, U256)>,
 
@@ -50,6 +55,7 @@ pub(crate) struct ExternalSnapshot {
     internal_snapshot: Snapshot,
     pub(crate) decommitted_hashes: <RollbackableMap<U256, bool> as Rollback>::Snapshot,
     decommit_pages: <RollbackableMap<U256, u32> as Rollback>::Snapshot,
+    decommit_pinned_pages: <RollbackableSet<u32> as Rollback>::Snapshot,
     read_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
     written_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
     storage_refunds: <RollbackableLog<u32> as Rollback>::Snapshot,
@@ -350,8 +356,13 @@ impl WorldDiff {
             .map(HeapId::from_u32_unchecked)
     }
 
+    pub(crate) fn is_decommit_page_pinned(&self, page: HeapId) -> bool {
+        self.decommit_pinned_pages.as_ref().contains(&page.as_u32())
+    }
+
     pub(crate) fn set_decommit_page(&mut self, code_hash: U256, page: HeapId) {
         self.decommit_pages.insert(code_hash, page.as_u32());
+        self.decommit_pinned_pages.add(page.as_u32());
     }
 
     /// Get a snapshot for selecting which logs & co. to output using [`Self::events_after()`] and other methods.
@@ -401,6 +412,7 @@ impl WorldDiff {
             },
             decommitted_hashes: self.decommitted_hashes.snapshot(),
             decommit_pages: self.decommit_pages.snapshot(),
+            decommit_pinned_pages: self.decommit_pinned_pages.snapshot(),
             read_storage_slots: self.read_storage_slots.snapshot(),
             written_storage_slots: self.written_storage_slots.snapshot(),
             storage_refunds: self.storage_refunds.snapshot(),
@@ -417,6 +429,8 @@ impl WorldDiff {
         self.decommitted_hashes
             .rollback(snapshot.decommitted_hashes);
         self.decommit_pages.rollback(snapshot.decommit_pages);
+        self.decommit_pinned_pages
+            .rollback(snapshot.decommit_pinned_pages);
         self.read_storage_slots
             .rollback(snapshot.read_storage_slots);
         self.written_storage_slots
@@ -437,6 +451,7 @@ impl WorldDiff {
         self.pubdata_costs.delete_history();
         self.decommitted_hashes.delete_history();
         self.decommit_pages.delete_history();
+        self.decommit_pinned_pages.delete_history();
         self.read_storage_slots.delete_history();
         self.written_storage_slots.delete_history();
     }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -61,8 +61,10 @@ impl WorldDiff {
         tracer: &mut impl Tracer,
         contract: H160,
         key: U256,
+        tx_number_in_block: u16,
     ) -> (U256, u32) {
-        let (value, newly_added) = self.read_storage_inner(world, tracer, contract, key);
+        let (value, newly_added) =
+            self.read_storage_inner(world, tracer, contract, key, tx_number_in_block);
         let refund = if !newly_added || world.is_free_storage_slot(&contract, &key) {
             WARM_READ_REFUND
         } else {
@@ -81,8 +83,10 @@ impl WorldDiff {
         tracer: &mut impl Tracer,
         contract: H160,
         key: U256,
+        tx_number_in_block: u16,
     ) -> U256 {
-        self.read_storage_inner(world, tracer, contract, key).0
+        self.read_storage_inner(world, tracer, contract, key, tx_number_in_block)
+            .0
     }
 
     fn read_storage_inner(
@@ -91,6 +95,7 @@ impl WorldDiff {
         tracer: &mut impl Tracer,
         contract: H160,
         key: U256,
+        tx_number_in_block: u16,
     ) -> (U256, bool) {
         let newly_added = self.read_storage_slots.add((contract, key));
         if newly_added {
@@ -101,13 +106,13 @@ impl WorldDiff {
         let value = self.just_read_storage(world, contract, key);
         self.storage_logs.push(LogQuery {
             timestamp: Timestamp(u32::try_from(self.storage_logs.len()).unwrap_or(u32::MAX)),
-            tx_number_in_block: 0,
+            tx_number_in_block,
             aux_byte: STORAGE_AUX_BYTE,
             shard_id: 0,
             address: contract,
             key,
             read_value: value,
-            written_value: U256::zero(),
+            written_value: value,
             rw_flag: false,
             rollback: false,
             is_service: false,
@@ -138,11 +143,12 @@ impl WorldDiff {
         contract: H160,
         key: U256,
         value: U256,
+        tx_number_in_block: u16,
     ) -> u32 {
         let read_value = self.just_read_storage(world, contract, key);
         let log_query = LogQuery {
             timestamp: Timestamp(u32::try_from(self.storage_logs.len()).unwrap_or(u32::MAX)),
-            tx_number_in_block: 0,
+            tx_number_in_block,
             aux_byte: STORAGE_AUX_BYTE,
             shard_id: 0,
             address: contract,
@@ -220,6 +226,9 @@ impl WorldDiff {
     }
 
     /// Returns all recorded storage log queries.
+    ///
+    /// These logs are sufficient for vm2 state-transition checks and diagnostics.
+    /// TODO: Fill all `zk_evm` witness metadata before using these queries to build prover witness data.
     pub fn storage_log_queries(&self) -> &[LogQuery] {
         &self.storage_logs
     }
@@ -466,7 +475,7 @@ mod tests {
 
         let checkpoint1 = world_diff.snapshot();
         for (key, value) in &first_changes {
-            world_diff.write_storage(&mut NoWorld, &mut (), key.0, key.1, *value);
+            world_diff.write_storage(&mut NoWorld, &mut (), key.0, key.1, *value, 0);
         }
         let actual_changes = world_diff
             .get_storage_changes_after(&checkpoint1)
@@ -494,7 +503,7 @@ mod tests {
 
         let checkpoint2 = world_diff.snapshot();
         for (key, value) in &second_changes {
-            world_diff.write_storage(&mut NoWorld, &mut (), key.0, key.1, *value);
+            world_diff.write_storage(&mut NoWorld, &mut (), key.0, key.1, *value, 0);
         }
         let actual_changes = world_diff
             .get_storage_changes_after(&checkpoint2)
@@ -680,12 +689,12 @@ mod tests {
         let contract = H160::zero();
         let key = U256::from(1);
 
-        let (value, _) = world_diff.read_storage(&mut world, &mut (), contract, key);
+        let (value, _) = world_diff.read_storage(&mut world, &mut (), contract, key, 0);
         assert_eq!(value, U256::zero());
 
-        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(10));
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(10), 0);
         let snapshot = world_diff.snapshot();
-        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(20));
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(20), 0);
         world_diff.rollback(snapshot);
 
         let logs = world_diff.storage_log_queries();
@@ -707,7 +716,7 @@ mod tests {
         let value = U256::from(33);
         world.values.insert((contract, key), value);
 
-        let (read_value, _) = world_diff.read_storage(&mut world, &mut (), contract, key);
+        let (read_value, _) = world_diff.read_storage(&mut world, &mut (), contract, key, 0);
         assert_eq!(read_value, value);
 
         let logs = world_diff.storage_log_queries();

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -61,8 +61,6 @@ pub(crate) struct ExternalSnapshot {
     written_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
     storage_refunds: <RollbackableLog<u32> as Rollback>::Snapshot,
     pubdata_costs: <RollbackableLog<i32> as Rollback>::Snapshot,
-    storage_logs_len: usize,
-    rollback_storage_logs_len: usize,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -407,8 +405,11 @@ impl WorldDiff {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)] // intentional: we require a snapshot to be rolled back to no more than once
-    pub(crate) fn rollback(&mut self, snapshot: Snapshot) {
+    /// Appends rollback storage logs recorded after `snapshot` to `storage_logs`.
+    ///
+    /// This is needed for failed frame returns (revert / panic) where rolled-back writes
+    /// must remain observable in the storage log stream.
+    pub(crate) fn append_rollback_logs(&mut self, snapshot: &Snapshot) {
         if self.rollback_storage_logs.len() > snapshot.rollback_storage_logs_len {
             let rollback_logs = self
                 .rollback_storage_logs
@@ -417,6 +418,10 @@ impl WorldDiff {
                 self.storage_logs.push(log);
             }
         }
+    }
+
+    #[allow(clippy::needless_pass_by_value)] // intentional: we require a snapshot to be rolled back to no more than once
+    pub(crate) fn rollback(&mut self, snapshot: Snapshot) {
         self.storage_changes.rollback(snapshot.storage_changes);
         self.paid_changes.rollback(snapshot.paid_changes);
         self.events.rollback(snapshot.events);
@@ -444,12 +449,13 @@ impl WorldDiff {
             written_storage_slots: self.written_storage_slots.snapshot(),
             storage_refunds: self.storage_refunds.snapshot(),
             pubdata_costs: self.pubdata_costs.snapshot(),
-            storage_logs_len: self.storage_logs.len(),
-            rollback_storage_logs_len: self.rollback_storage_logs.len(),
         }
     }
 
     pub(crate) fn external_rollback(&mut self, snapshot: ExternalSnapshot) {
+        let storage_logs_len = snapshot.internal_snapshot.storage_logs_len;
+        let rollback_storage_logs_len = snapshot.internal_snapshot.rollback_storage_logs_len;
+
         self.rollback(snapshot.internal_snapshot);
         self.storage_refunds.rollback(snapshot.storage_refunds);
         self.pubdata_costs.rollback(snapshot.pubdata_costs);
@@ -461,9 +467,9 @@ impl WorldDiff {
             .rollback(snapshot.read_storage_slots);
         self.written_storage_slots
             .rollback(snapshot.written_storage_slots);
-        self.storage_logs.truncate(snapshot.storage_logs_len);
+        self.storage_logs.truncate(storage_logs_len);
         self.rollback_storage_logs
-            .truncate(snapshot.rollback_storage_logs_len);
+            .truncate(rollback_storage_logs_len);
     }
 
     pub(crate) fn delete_history(&mut self) {
@@ -755,6 +761,7 @@ mod tests {
         world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(10), 0);
         let snapshot = world_diff.snapshot();
         world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(20), 0);
+        world_diff.append_rollback_logs(&snapshot);
         world_diff.rollback(snapshot);
 
         let logs = world_diff.storage_log_queries();
@@ -765,6 +772,43 @@ mod tests {
         assert!(logs[3].rw_flag && logs[3].rollback);
         assert_eq!(logs[3].read_value, logs[2].read_value);
         assert_eq!(logs[3].written_value, logs[2].written_value);
+    }
+
+    #[test]
+    fn rollback_without_append_keeps_storage_log_stream_unchanged() {
+        let mut world_diff = WorldDiff::default();
+        let mut world = TestWorld::default();
+        let contract = H160::zero();
+        let key = U256::from(1);
+
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(10), 0);
+        let snapshot = world_diff.snapshot();
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(20), 0);
+        world_diff.rollback(snapshot);
+
+        let logs = world_diff.storage_log_queries();
+        assert_eq!(logs.len(), 2);
+        assert!(logs.iter().all(|log| log.rw_flag && !log.rollback));
+        assert_eq!(world_diff.rollback_storage_logs.len(), 2);
+    }
+
+    #[test]
+    fn external_rollback_truncates_storage_logs_to_internal_snapshot() {
+        let mut world_diff = WorldDiff::default();
+        let mut world = TestWorld::default();
+        let contract = H160::zero();
+        let key = U256::from(1);
+
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(10), 0);
+        let snapshot = world_diff.external_snapshot();
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(20), 0);
+
+        world_diff.external_rollback(snapshot);
+
+        let logs = world_diff.storage_log_queries();
+        assert_eq!(logs.len(), 1);
+        assert!(logs[0].rw_flag && !logs[0].rollback);
+        assert_eq!(world_diff.rollback_storage_logs.len(), 1);
     }
 
     #[test]

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -30,18 +30,19 @@ pub struct WorldDiff {
     rollback_storage_logs: Vec<LogQuery>,
 
     // The fields below are only rolled back when the whole VM is rolled back.
-    /// Values indicate whether a bytecode was successfully decommitted. When accessing decommitted hashes
-    /// for the execution state, we need to track both successful and failed decommitments; OTOH, only successful ones
-    /// matter when computing decommitment cost.
-    pub(crate) decommitted_hashes: RollbackableMap<U256, bool>,
-    /// Memory page assigned to each successfully decommitted hash by the `Decommit` opcode.
+    /// Tracks decommit attempts and successful decommit state for each bytecode hash.
     ///
-    /// Like `decommitted_hashes`, this is rolled back only by external VM snapshots.
-    decommit_pages: RollbackableMap<U256, u32>,
-    /// Reverse index for `decommit_pages` to quickly check whether a heap page is globally pinned
-    /// by decommitment reuse semantics.
+    /// This includes failed attempts (out of gas) because they affect old-VM-compatible behavior,
+    /// and successful attempts may or may not already have a materialized decommit page.
     ///
-    /// This follows external snapshot / rollback semantics together with `decommit_pages`.
+    /// This field is rolled back only by external VM snapshots.
+    pub(crate) decommitted_hashes: RollbackableMap<U256, DecommitState>,
+    /// Reverse index for `decommitted_hashes` entries that carry materialized heap pages.
+    ///
+    /// This is used to quickly check whether a heap page is globally pinned by decommitment reuse
+    /// semantics.
+    ///
+    /// This follows external snapshot / rollback semantics together with `decommitted_hashes`.
     decommit_pinned_pages: RollbackableSet<u32>,
     read_storage_slots: RollbackableSet<(H160, U256)>,
     written_storage_slots: RollbackableSet<(H160, U256)>,
@@ -53,8 +54,7 @@ pub struct WorldDiff {
 #[derive(Debug)]
 pub(crate) struct ExternalSnapshot {
     internal_snapshot: Snapshot,
-    pub(crate) decommitted_hashes: <RollbackableMap<U256, bool> as Rollback>::Snapshot,
-    decommit_pages: <RollbackableMap<U256, u32> as Rollback>::Snapshot,
+    pub(crate) decommitted_hashes: <RollbackableMap<U256, DecommitState> as Rollback>::Snapshot,
     decommit_pinned_pages: <RollbackableSet<u32> as Rollback>::Snapshot,
     read_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
     written_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
@@ -62,6 +62,24 @@ pub(crate) struct ExternalSnapshot {
     pubdata_costs: <RollbackableLog<i32> as Rollback>::Snapshot,
     storage_logs_len: usize,
     rollback_storage_logs_len: usize,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DecommitState {
+    /// A decommit was attempted, but did not finish successfully (e.g. due to out-of-gas).
+    ///
+    /// We still record this state to preserve old VM behavior where failed attempts are visible
+    /// in `decommitted_hashes()`, but this state must not make future decommits free.
+    #[default]
+    Unsuccessful,
+    /// A bytecode hash was successfully decommitted for charging / freshness semantics,
+    /// but no reusable heap page has been materialized yet.
+    ///
+    /// This happens when `pay_for_decommit` succeeds on non-`Decommit` opcode paths
+    /// (e.g. far call), and the first `Decommit` opcode later materializes the page lazily.
+    SucceededNoPage,
+    /// A bytecode hash was successfully decommitted and has an assigned reusable heap page.
+    SucceededWithPage(u32),
 }
 
 impl WorldDiff {
@@ -351,11 +369,16 @@ impl WorldDiff {
     }
 
     pub(crate) fn decommit_page(&self, code_hash: U256) -> Option<HeapId> {
-        self.decommit_pages
+        self.decommitted_hashes
             .as_ref()
             .get(&code_hash)
-            .copied()
-            .map(HeapId::from_u32_unchecked)
+            .and_then(|state| {
+                if let DecommitState::SucceededWithPage(page) = state {
+                    Some(HeapId::from_u32_unchecked(*page))
+                } else {
+                    None
+                }
+            })
     }
 
     pub(crate) fn is_decommit_page_pinned(&self, page: HeapId) -> bool {
@@ -363,7 +386,8 @@ impl WorldDiff {
     }
 
     pub(crate) fn set_decommit_page(&mut self, code_hash: U256, page: HeapId) {
-        self.decommit_pages.insert(code_hash, page.as_u32());
+        self.decommitted_hashes
+            .insert(code_hash, DecommitState::SucceededWithPage(page.as_u32()));
         self.decommit_pinned_pages.add(page.as_u32());
     }
 
@@ -413,7 +437,6 @@ impl WorldDiff {
                 ..self.snapshot()
             },
             decommitted_hashes: self.decommitted_hashes.snapshot(),
-            decommit_pages: self.decommit_pages.snapshot(),
             decommit_pinned_pages: self.decommit_pinned_pages.snapshot(),
             read_storage_slots: self.read_storage_slots.snapshot(),
             written_storage_slots: self.written_storage_slots.snapshot(),
@@ -430,7 +453,6 @@ impl WorldDiff {
         self.pubdata_costs.rollback(snapshot.pubdata_costs);
         self.decommitted_hashes
             .rollback(snapshot.decommitted_hashes);
-        self.decommit_pages.rollback(snapshot.decommit_pages);
         self.decommit_pinned_pages
             .rollback(snapshot.decommit_pinned_pages);
         self.read_storage_slots
@@ -452,7 +474,6 @@ impl WorldDiff {
         self.storage_refunds.delete_history();
         self.pubdata_costs.delete_history();
         self.decommitted_hashes.delete_history();
-        self.decommit_pages.delete_history();
         self.decommit_pinned_pages.delete_history();
         self.read_storage_slots.delete_history();
         self.written_storage_slots.delete_history();

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -30,9 +30,11 @@ pub struct WorldDiff {
     rollback_storage_logs: Vec<LogQuery>,
 
     // The fields below are only rolled back when the whole VM is rolled back.
-    /// Tracks decommit attempts and successful decommit state for each bytecode hash.
+    /// Tracks decommit visibility state for each bytecode hash.
     ///
-    /// This includes failed attempts (out of gas) because they affect old-VM-compatible behavior.
+    /// Besides successful decommits, we also retain far-call decommit attempts that failed with
+    /// out-of-gas in `pay_for_decommit()`. Legacy VM includes those hashes into "used contracts"
+    /// output, and shadow-mode compares that output (`CurrentExecutionState.used_contract_hashes`).
     ///
     /// This field is rolled back only by external VM snapshots.
     pub(crate) decommitted_hashes: RollbackableMap<U256, DecommitState>,
@@ -65,10 +67,14 @@ pub(crate) struct ExternalSnapshot {
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DecommitState {
-    /// A decommit was attempted, but did not finish successfully (e.g. due to out-of-gas).
+    /// A far-call decommit attempt ran out of gas before materialization.
     ///
-    /// We still record this state to preserve old VM behavior where failed attempts are visible
-    /// in `decommitted_hashes()`, but this state must not make future decommits free.
+    /// We preserve this state for legacy compatibility: old VM exposes these hashes as used
+    /// contracts. This state is observable via `decommitted_hashes()`, but it must not make
+    /// future decommits free.
+    ///
+    /// Note that `log.decommit` out-of-gas is not represented by this state because that opcode
+    /// exits before decommit bookkeeping.
     #[default]
     Unsuccessful,
     /// A bytecode hash was successfully decommitted and has an assigned reusable heap page.
@@ -355,8 +361,11 @@ impl WorldDiff {
         self.l2_to_l1_logs.logs_after(snapshot.l2_to_l1_logs)
     }
 
-    /// Returns hashes of decommitted contract bytecodes in no particular order. Note that this includes
-    /// failed (out-of-gas) decommitments.
+    /// Returns hashes of contract bytecodes that were observed by decommit bookkeeping in no
+    /// particular order.
+    ///
+    /// This includes successful decommits and far-call out-of-gas attempts recorded as
+    /// [`DecommitState::Unsuccessful`] for legacy `used_contract_hashes` compatibility.
     pub fn decommitted_hashes(&self) -> impl Iterator<Item = U256> + '_ {
         self.decommitted_hashes.as_ref().keys().copied()
     }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -6,7 +6,7 @@ use zkevm_opcode_defs::system_params::{
     STORAGE_ACCESS_COLD_READ_COST, STORAGE_ACCESS_COLD_WRITE_COST, STORAGE_ACCESS_WARM_READ_COST,
     STORAGE_ACCESS_WARM_WRITE_COST, STORAGE_AUX_BYTE,
 };
-use zksync_vm2_interface::{CycleStats, Event, L2ToL1Log, Tracer};
+use zksync_vm2_interface::{CycleStats, Event, HeapId, L2ToL1Log, Tracer};
 
 use crate::{
     rollback::{Rollback, RollbackableLog, RollbackableMap, RollbackablePod, RollbackableSet},
@@ -34,6 +34,10 @@ pub struct WorldDiff {
     /// for the execution state, we need to track both successful and failed decommitments; OTOH, only successful ones
     /// matter when computing decommitment cost.
     pub(crate) decommitted_hashes: RollbackableMap<U256, bool>,
+    /// Memory page assigned to each successfully decommitted hash by the `Decommit` opcode.
+    ///
+    /// Like `decommitted_hashes`, this is rolled back only by external VM snapshots.
+    decommit_pages: RollbackableMap<U256, u32>,
     read_storage_slots: RollbackableSet<(H160, U256)>,
     written_storage_slots: RollbackableSet<(H160, U256)>,
 
@@ -44,7 +48,8 @@ pub struct WorldDiff {
 #[derive(Debug)]
 pub(crate) struct ExternalSnapshot {
     internal_snapshot: Snapshot,
-    pub(crate) decommitted_hashes: <RollbackableMap<U256, ()> as Rollback>::Snapshot,
+    pub(crate) decommitted_hashes: <RollbackableMap<U256, bool> as Rollback>::Snapshot,
+    decommit_pages: <RollbackableMap<U256, u32> as Rollback>::Snapshot,
     read_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
     written_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
     storage_refunds: <RollbackableLog<u32> as Rollback>::Snapshot,
@@ -337,6 +342,18 @@ impl WorldDiff {
         self.decommitted_hashes.as_ref().keys().copied()
     }
 
+    pub(crate) fn decommit_page(&self, code_hash: U256) -> Option<HeapId> {
+        self.decommit_pages
+            .as_ref()
+            .get(&code_hash)
+            .copied()
+            .map(HeapId::from_u32_unchecked)
+    }
+
+    pub(crate) fn set_decommit_page(&mut self, code_hash: U256, page: HeapId) {
+        self.decommit_pages.insert(code_hash, page.as_u32());
+    }
+
     /// Get a snapshot for selecting which logs & co. to output using [`Self::events_after()`] and other methods.
     pub fn snapshot(&self) -> Snapshot {
         Snapshot {
@@ -383,6 +400,7 @@ impl WorldDiff {
                 ..self.snapshot()
             },
             decommitted_hashes: self.decommitted_hashes.snapshot(),
+            decommit_pages: self.decommit_pages.snapshot(),
             read_storage_slots: self.read_storage_slots.snapshot(),
             written_storage_slots: self.written_storage_slots.snapshot(),
             storage_refunds: self.storage_refunds.snapshot(),
@@ -398,6 +416,7 @@ impl WorldDiff {
         self.pubdata_costs.rollback(snapshot.pubdata_costs);
         self.decommitted_hashes
             .rollback(snapshot.decommitted_hashes);
+        self.decommit_pages.rollback(snapshot.decommit_pages);
         self.read_storage_slots
             .rollback(snapshot.read_storage_slots);
         self.written_storage_slots
@@ -417,6 +436,7 @@ impl WorldDiff {
         self.storage_refunds.delete_history();
         self.pubdata_costs.delete_history();
         self.decommitted_hashes.delete_history();
+        self.decommit_pages.delete_history();
         self.read_storage_slots.delete_history();
         self.written_storage_slots.delete_history();
     }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -1,9 +1,10 @@
 use std::collections::BTreeMap;
 
 use primitive_types::{H160, U256};
+use zk_evm_abstractions::{aux::Timestamp, queries::LogQuery};
 use zkevm_opcode_defs::system_params::{
     STORAGE_ACCESS_COLD_READ_COST, STORAGE_ACCESS_COLD_WRITE_COST, STORAGE_ACCESS_WARM_READ_COST,
-    STORAGE_ACCESS_WARM_WRITE_COST,
+    STORAGE_ACCESS_WARM_WRITE_COST, STORAGE_AUX_BYTE,
 };
 use zksync_vm2_interface::{CycleStats, Event, L2ToL1Log, Tracer};
 
@@ -25,6 +26,8 @@ pub struct WorldDiff {
     pub(crate) pubdata: RollbackablePod<i32>,
     storage_refunds: RollbackableLog<u32>,
     pubdata_costs: RollbackableLog<i32>,
+    storage_logs: Vec<LogQuery>,
+    rollback_storage_logs: Vec<LogQuery>,
 
     // The fields below are only rolled back when the whole VM is rolled back.
     /// Values indicate whether a bytecode was successfully decommitted. When accessing decommitted hashes
@@ -46,6 +49,8 @@ pub(crate) struct ExternalSnapshot {
     written_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
     storage_refunds: <RollbackableLog<u32> as Rollback>::Snapshot,
     pubdata_costs: <RollbackableLog<i32> as Rollback>::Snapshot,
+    storage_logs_len: usize,
+    rollback_storage_logs_len: usize,
 }
 
 impl WorldDiff {
@@ -93,7 +98,21 @@ impl WorldDiff {
         }
 
         self.pubdata_costs.push(0);
-        (self.just_read_storage(world, contract, key), newly_added)
+        let value = self.just_read_storage(world, contract, key);
+        self.storage_logs.push(LogQuery {
+            timestamp: Timestamp(u32::try_from(self.storage_logs.len()).unwrap_or(u32::MAX)),
+            tx_number_in_block: 0,
+            aux_byte: STORAGE_AUX_BYTE,
+            shard_id: 0,
+            address: contract,
+            key,
+            read_value: value,
+            written_value: U256::zero(),
+            rw_flag: false,
+            rollback: false,
+            is_service: false,
+        });
+        (value, newly_added)
     }
 
     /// Reads the value of a storage slot without any extra bookkeeping.
@@ -120,6 +139,26 @@ impl WorldDiff {
         key: U256,
         value: U256,
     ) -> u32 {
+        let read_value = self.just_read_storage(world, contract, key);
+        let log_query = LogQuery {
+            timestamp: Timestamp(u32::try_from(self.storage_logs.len()).unwrap_or(u32::MAX)),
+            tx_number_in_block: 0,
+            aux_byte: STORAGE_AUX_BYTE,
+            shard_id: 0,
+            address: contract,
+            key,
+            read_value,
+            written_value: value,
+            rw_flag: true,
+            rollback: false,
+            is_service: false,
+        };
+        self.storage_logs.push(log_query);
+        self.rollback_storage_logs.push(LogQuery {
+            rollback: true,
+            ..log_query
+        });
+
         self.storage_changes.insert((contract, key), value);
 
         let initial_value = self
@@ -178,6 +217,16 @@ impl WorldDiff {
     /// Returns recorded pubdata costs for all storage operations.
     pub fn pubdata_costs(&self) -> &[i32] {
         self.pubdata_costs.as_ref()
+    }
+
+    /// Returns all recorded storage log queries.
+    pub fn storage_log_queries(&self) -> &[LogQuery] {
+        &self.storage_logs
+    }
+
+    /// Returns storage log queries recorded after the specified `snapshot` was created.
+    pub fn storage_log_queries_after(&self, snapshot: &Snapshot) -> &[LogQuery] {
+        &self.storage_logs[snapshot.storage_logs_len..]
     }
 
     #[doc(hidden)] // duplicates `StateInterface::get_storage_state()`, but we use random access in some places
@@ -288,11 +337,21 @@ impl WorldDiff {
             l2_to_l1_logs: self.l2_to_l1_logs.snapshot(),
             transient_storage_changes: self.transient_storage_changes.snapshot(),
             pubdata: self.pubdata.snapshot(),
+            storage_logs_len: self.storage_logs.len(),
+            rollback_storage_logs_len: self.rollback_storage_logs.len(),
         }
     }
 
     #[allow(clippy::needless_pass_by_value)] // intentional: we require a snapshot to be rolled back to no more than once
     pub(crate) fn rollback(&mut self, snapshot: Snapshot) {
+        if self.rollback_storage_logs.len() > snapshot.rollback_storage_logs_len {
+            let rollback_logs = self
+                .rollback_storage_logs
+                .split_off(snapshot.rollback_storage_logs_len);
+            for log in rollback_logs.into_iter().rev() {
+                self.storage_logs.push(log);
+            }
+        }
         self.storage_changes.rollback(snapshot.storage_changes);
         self.paid_changes.rollback(snapshot.paid_changes);
         self.events.rollback(snapshot.events);
@@ -319,6 +378,8 @@ impl WorldDiff {
             written_storage_slots: self.written_storage_slots.snapshot(),
             storage_refunds: self.storage_refunds.snapshot(),
             pubdata_costs: self.pubdata_costs.snapshot(),
+            storage_logs_len: self.storage_logs.len(),
+            rollback_storage_logs_len: self.rollback_storage_logs.len(),
         }
     }
 
@@ -332,6 +393,9 @@ impl WorldDiff {
             .rollback(snapshot.read_storage_slots);
         self.written_storage_slots
             .rollback(snapshot.written_storage_slots);
+        self.storage_logs.truncate(snapshot.storage_logs_len);
+        self.rollback_storage_logs
+            .truncate(snapshot.rollback_storage_logs_len);
     }
 
     pub(crate) fn delete_history(&mut self) {
@@ -363,6 +427,8 @@ pub struct Snapshot {
     l2_to_l1_logs: <RollbackableLog<L2ToL1Log> as Rollback>::Snapshot,
     transient_storage_changes: <RollbackableMap<(H160, U256), U256> as Rollback>::Snapshot,
     pubdata: <RollbackablePod<i32> as Rollback>::Snapshot,
+    storage_logs_len: usize,
+    rollback_storage_logs_len: usize,
 }
 
 /// Change in a single storage slot.
@@ -578,5 +644,76 @@ mod tests {
         fn is_free_storage_slot(&self, _: &H160, _: &U256) -> bool {
             false
         }
+    }
+
+    #[derive(Default)]
+    struct TestWorld {
+        values: BTreeMap<(H160, U256), U256>,
+    }
+
+    impl StorageInterface for TestWorld {
+        fn read_storage(&mut self, contract: H160, key: U256) -> StorageSlot {
+            let value = self
+                .values
+                .get(&(contract, key))
+                .copied()
+                .unwrap_or_default();
+            StorageSlot {
+                value,
+                is_write_initial: !self.values.contains_key(&(contract, key)),
+            }
+        }
+
+        fn cost_of_writing_storage(&mut self, _: StorageSlot, _: U256) -> u32 {
+            0
+        }
+
+        fn is_free_storage_slot(&self, _: &H160, _: &U256) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn storage_logs_include_reads_writes_and_rollbacks() {
+        let mut world_diff = WorldDiff::default();
+        let mut world = TestWorld::default();
+        let contract = H160::zero();
+        let key = U256::from(1);
+
+        let (value, _) = world_diff.read_storage(&mut world, &mut (), contract, key);
+        assert_eq!(value, U256::zero());
+
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(10));
+        let snapshot = world_diff.snapshot();
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(20));
+        world_diff.rollback(snapshot);
+
+        let logs = world_diff.storage_log_queries();
+        assert_eq!(logs.len(), 4);
+        assert!(!logs[0].rw_flag);
+        assert!(logs[1].rw_flag && !logs[1].rollback);
+        assert!(logs[2].rw_flag && !logs[2].rollback);
+        assert!(logs[3].rw_flag && logs[3].rollback);
+        assert_eq!(logs[3].read_value, logs[2].read_value);
+        assert_eq!(logs[3].written_value, logs[2].written_value);
+    }
+
+    #[test]
+    fn storage_read_log_sets_written_value_to_read_value() {
+        let mut world_diff = WorldDiff::default();
+        let mut world = TestWorld::default();
+        let contract = H160::repeat_byte(1);
+        let key = U256::from(7);
+        let value = U256::from(33);
+        world.values.insert((contract, key), value);
+
+        let (read_value, _) = world_diff.read_storage(&mut world, &mut (), contract, key);
+        assert_eq!(read_value, value);
+
+        let logs = world_diff.storage_log_queries();
+        assert_eq!(logs.len(), 1);
+        assert!(!logs[0].rw_flag);
+        assert_eq!(logs[0].read_value, value);
+        assert_eq!(logs[0].written_value, value);
     }
 }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -131,7 +131,9 @@ impl WorldDiff {
         self.pubdata_costs.push(0);
         let value = self.just_read_storage(world, contract, key);
         self.storage_logs.push(LogQuery {
-            timestamp: Timestamp(u32::try_from(self.storage_logs.len()).unwrap_or(u32::MAX)),
+            timestamp: Timestamp(
+                u32::try_from(self.storage_logs.len()).expect("Too many storage logs"),
+            ),
             tx_number_in_block,
             aux_byte: STORAGE_AUX_BYTE,
             shard_id: 0,

--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,7 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
 ignore = [
-    "RUSTSEC-2023-0052"
+    "RUSTSEC-2024-0436" # `paste` unmaintained, not a risk for us
 ]
 
 [licenses]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2025-03-19"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-03-19"
+channel = "nightly-2026-02-10"


### PR DESCRIPTION
This PR implements missing functionality required to verify execution via [tee_verifier](https://github.com/matter-labs/zksync-era/blob/main/core/lib/tee_verifier/src/lib.rs).
This is needed to prove EraVM in Airbender.
Additionally, this PR fixes several discovered divergencies vs `zk_evm`.

This is NOT a complete feature parity with `zk_evm` -- some things are explicitly not supported. For example, we don't generate full metadata in logs -- we generate just enough
data to verify execution, not to generate witness.
Similarly, we don't mimic behavior for non-zero shards (except for illegal calls to non-zero shards) as we don't care about them.
The goal was to come up with a minimum set of changes to make it provable and remove _realistic_ risks wrt divergencies.

Disclaimer: changes in this PR were majorly written by an LLM, but with a lot of manual interventions.

Since there is a lot of stuff going on in here, I've tried to add pointers that should make review easier.
Additionally, below is an LLM-generated overview of added features:

## Static UMA read/write support

vm2 now decodes and executes StaticMemoryRead / StaticMemoryWrite instead of treating them as missing functionality. This closes a core opcode-surface gap with zk_evm for static memory operations.

- zk_evm reference:
  - [crates/zk_evm/src/opcodes/execution/uma.rs#L81-L113](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/uma.rs#L81-L113)

## Static-memory isolation and precompile page-0 remapping

vm2 keeps static UMA memory isolated while preserving zk_evm's precompile ABI sentinel semantics for page `0`. This avoids accidental cross-contamination between static memory and regular heap behavior.

- zk_evm reference:
  - [crates/zk_evm/src/opcodes/execution/uma.rs#L109-L113](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/uma.rs#L109-L113)
  - [crates/zk_evm/src/opcodes/execution/log.rs#L315-L335](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/log.rs#L315-L335)

## Nonzero-shard far-call side-effect ordering

vm2 now follows zk_evm-style ordering by failing nonzero-shard far calls before touching deployer storage in the unsupported-shard path. This removes an unnecessary side effect that previously created parity risk.

- zk_evm reference:
  - [crates/zk_evm/src/opcodes/execution/far_call.rs#L110-L164](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/far_call.rs#L110-L164)

## Non-kernel returndata forwarding restriction for older pages

vm2 enforces non-kernel unidirectional returndata forwarding so callees cannot forward pointers to older pages. This aligns a subtle but important safety rule with zk_evm.

- zk_evm reference:
  - [crates/zk_evm/src/opcodes/execution/ret.rs#L58-L75](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/ret.rs#L58-L75)

## Precompile extra-ergs out-of-gas behavior alignment

On insufficient extra ergs, vm2 now follows the non-panicking continuation behavior expected by zk_evm precompile execution semantics. This avoids turning this path into an unnecessary panic divergence.

- zk_evm reference:
  - [crates/zk_evm/src/opcodes/execution/log.rs#L88-L134](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/log.rs#L88-L134)
  - [crates/zk_evm/src/opcodes/execution/log.rs#L294-L305](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/log.rs#L294-L305)

## Non-fresh decommit page reuse and lazy materialization

vm2 no longer assumes non-fresh decommits always have a preassigned page and no longer panics the host when that mapping is missing. It now reuses mapped pages when present and lazily materializes them when needed.

- zk_evm reference:
  - [crates/zk_evm/src/reference_impls/decommitter.rs#L61-L69](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/reference_impls/decommitter.rs#L61-L69)

## Decommit page lifetime protection across frame pop and rollback

vm2 preserves decommit pages that must remain globally reusable even when nested frames are popped or VM snapshots roll back. This prevents accidental deallocation of pages that zk_evm semantics treat as reusable history.

- zk_evm reference:
  - [crates/zk_evm/src/reference_impls/decommitter.rs#L61-L69](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/reference_impls/decommitter.rs#L61-L69)
  - [crates/zk_evm/src/vm_state/helpers.rs#L187-L223](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/vm_state/helpers.rs#L187-L223)
  - [crates/zk_evm/src/vm_state/helpers.rs#L232-L241](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/vm_state/helpers.rs#L232-L241)

## Storage log query stream (reads, writes, rollback markers)

vm2 now records a full storage access stream instead of write-only net diffs, including rollback markers on reverted writes. This is the required shape for parity-oriented dedup and witness-related consumers.

- zk_evm reference:
  - [crates/zk_evm/src/opcodes/execution/log.rs#L143-L178](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/log.rs#L143-L178)
  - [crates/zk_evm/src/opcodes/execution/log.rs#L199-L236](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/log.rs#L199-L236)
  - [crates/zk_evm/src/vm_state/helpers.rs#L148-L176](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/vm_state/helpers.rs#L148-L176)

## Callstack-full masking before instruction execution

vm2 performs callstack-full masking in common instruction boilerplate, matching the high-level zk_evm control-flow behavior. The current depth estimator is intentionally approximate and documented with TODO because practical saturation is considered extremely unlikely.

- zk_evm reference:
  - [crates/zk_evm/src/vm_state/cycle.rs#L199-L223](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/vm_state/cycle.rs#L199-L223)
  - [crates/zk_evm/src/vm_state/mod.rs#L105-L107](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/vm_state/mod.rs#L105-L107)
  - [crates/zk_evm/src/vm_state/execution_stack.rs#L117-L119](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/vm_state/execution_stack.rs#L117-L119)

## Known divergencies that are NOT implemented:

We don't implement them since they don't seem to affect the execution for our use cases.

### Event emission scope parity

Status: Not implemented

vm2 still gates event emission by a specific event-writer address, while zk_evm's event path is broader in kernel context execution. This remains an accepted divergence in the current branch scope.

- vm2 current behavior:
  - `crates/vm2/src/instruction_handlers/event.rs:17-29`
- zk_evm reference:
  - [crates/zk_evm/src/opcodes/execution/log.rs#L252-L289](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/log.rs#L252-L289)

### Full shard metadata and shard behavior parity

Status: Not implemented

vm2 continues to treat shard support as limited scope, with multiple paths hardcoding shard-related values. Full shard semantics and metadata parity with zk_evm are intentionally deferred.

- vm2 current behavior:
  - `crates/vm2/src/instruction_handlers/context.rs:82-98`
  - `crates/vm2/src/instruction_handlers/far_call.rs:160-177`
- zk_evm reference:
  - [crates/zk_evm/src/opcodes/execution/far_call.rs#L94-L122](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/far_call.rs#L94-L122)
  - [crates/zk_evm/src/opcodes/execution/log.rs#L64-L68](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/log.rs#L64-L68)
  - [crates/zk_evm/src/opcodes/execution/log.rs#L276-L281](https://github.com/matter-labs/zksync-protocol/blob/main/crates/zk_evm/src/opcodes/execution/log.rs#L276-L281)
