### PR TITLE
fix: Properly recycle heap pages on snapshot rollback

### DIFF
--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -222,6 +222,12 @@ impl DynamicPageGroup {
         self.code.is_none() && self.heap.is_none() && self.aux.is_none()
     }
 
+    fn recycle(self, pagepool: &mut PagePool) {
+        for heap in [self.code, self.heap, self.aux].into_iter().flatten() {
+            heap.recycle(pagepool);
+        }
+    }
+
     fn slot(&self, kind: DynamicPageKind) -> Option<&Heap> {
         match kind {
             DynamicPageKind::Code => self.code.as_ref(),
@@ -380,6 +386,10 @@ impl Heaps {
         heap.recycle(&mut self.pagepool);
     }
 
+    pub(crate) fn dynamic_len(&self) -> usize {
+        self.dynamic.len()
+    }
+
     pub(crate) fn write_u256(&mut self, page: HeapId, start_address: u32, value: U256) {
         self.record_bootloader_word_rollback(page, start_address);
         let decoded = DecodedPage::decode(page)
@@ -422,6 +432,19 @@ impl Heaps {
         for (address, value) in self.bootloader_aux_rollback_info.drain(aux_snap..).rev() {
             self.bootloader_aux_heap
                 .write_u256(address, value, &mut self.pagepool);
+        }
+    }
+
+    pub(crate) fn truncate_dynamic_to(&mut self, len: usize) {
+        assert!(
+            len <= self.dynamic.len(),
+            "cannot restore dynamic heap length {} from current length {}",
+            len,
+            self.dynamic.len()
+        );
+
+        for group in self.dynamic.drain(len..) {
+            group.recycle(&mut self.pagepool);
         }
     }
 

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -98,6 +98,10 @@ impl Heaps {
 
     pub(crate) fn deallocate(&mut self, _: HeapId) {}
 
+    pub(crate) fn dynamic_len(&self) -> usize {
+        unimplemented!()
+    }
+
     pub(crate) fn from_id(
         heap_id: HeapId,
         u: &mut arbitrary::Unstructured<'_>,
@@ -121,6 +125,10 @@ impl Heaps {
     }
 
     pub(crate) fn rollback(&mut self, _: (usize, usize)) {
+        unimplemented!()
+    }
+
+    pub(crate) fn truncate_dynamic_to(&mut self, _: usize) {
         unimplemented!()
     }
 

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -131,6 +131,7 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             flags: self.flags.clone(),
             bootloader_frame: self.current_frame.snapshot(),
             bootloader_heap_snapshot: self.heaps.snapshot(),
+            dynamic_heap_groups: self.heaps.dynamic_len(),
             transaction_number: self.transaction_number,
             context_u128: self.context_u128,
             next_base_page: self.next_base_page,
@@ -148,6 +149,7 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             flags,
             bootloader_frame,
             bootloader_heap_snapshot,
+            dynamic_heap_groups,
             transaction_number,
             context_u128,
             next_base_page,
@@ -159,6 +161,13 @@ impl<T: Tracer, W: World<T>> State<T, W> {
             }
         }
         self.heaps.rollback(bootloader_heap_snapshot);
+
+        // Pages created after the host snapshot may no longer be reachable from any frame-level
+        // keep-alive list. Decommit pages are the important case: rollback first removes the
+        // global pin, so frame bookkeeping alone can miss a dynamic page that was kept alive only
+        // by that pin.
+        self.heaps.truncate_dynamic_to(dynamic_heap_groups);
+
         self.registers = registers;
         self.register_pointer_flags = register_pointer_flags;
         self.flags = flags;
@@ -253,6 +262,7 @@ pub(crate) struct StateSnapshot {
     flags: Flags,
     bootloader_frame: CallframeSnapshot,
     bootloader_heap_snapshot: (usize, usize),
+    dynamic_heap_groups: usize,
     transaction_number: u16,
     context_u128: u128,
     next_base_page: u32,

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -9,7 +9,9 @@ use zkevm_opcode_defs::{
 use zksync_vm2_interface::{opcodes, HeapId, Tracer};
 
 use crate::{
-    addressing_modes::{Arguments, Immediate1, Register, Register1, Register2},
+    addressing_modes::{
+        Arguments, CodePage, Immediate1, Register, Register1, Register2, RegisterAndImmediate,
+    },
     decode::decode,
     fat_pointer::FatPointer,
     instruction_handlers::address_into_u256,
@@ -132,6 +134,45 @@ fn masked_default_aa_far_call(version_byte: u8) -> VirtualMachine<(), TestWorld<
 
     execute_one_instruction(&mut vm, &mut world, &mut ());
     vm
+}
+
+fn load_code_page_word<T: Tracer, W: World<T>>(
+    index: u16,
+    destination: Register,
+) -> Instruction<T, W> {
+    Instruction::from_add(
+        CodePage(RegisterAndImmediate {
+            immediate: index,
+            register: Register::new(0),
+        })
+        .into(),
+        Register2(Register::new(0)),
+        Register1(destination).into(),
+        Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
+        false,
+        false,
+    )
+}
+
+fn normal_far_call<T: Tracer, W: World<T>>(
+    abi_register: Register,
+    address_register: Register,
+) -> Instruction<T, W> {
+    Instruction::from_far_call::<opcodes::Normal>(
+        Register1(abi_register),
+        Register2(address_register),
+        Immediate1(0),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    )
+}
+
+fn system_far_call_abi(gas_to_pass: u32) -> U256 {
+    let mut abi = U256::zero();
+    let system_call_bit_within_settings = 1_u64 << 24;
+    abi.0[3] = u64::from(gas_to_pass) | (system_call_bit_within_settings << 32);
+    abi
 }
 
 #[test]
@@ -1236,4 +1277,109 @@ fn rollback_should_restore_bootloader_heap_after_fresh_decommit() {
 
     vm.rollback();
     assert_eq!(vm.state.heaps[bootloader_heap].read_u256(0), sentinel);
+}
+
+#[test]
+fn rollback_should_deallocate_dynamic_decommit_page_from_nested_frame() {
+    let validation_address = Address::from_low_u64_be(2);
+    let decommitter_address = Address::from_low_u64_be(3);
+    let target_address = Address::from_low_u64_be(4);
+
+    let validation_program = Program::from_raw(
+        vec![
+            load_code_page_word(0, Register::new(1)),
+            load_code_page_word(1, Register::new(2)),
+            normal_far_call(Register::new(1), Register::new(2)),
+            ret_instruction(),
+        ],
+        vec![
+            system_far_call_abi(1_000_000),
+            U256::from(decommitter_address.to_low_u64_be()),
+        ],
+    );
+    let decommitter_program = Program::from_raw(
+        vec![
+            Instruction::from_decommit(
+                Register1(Register::new(3)),
+                Register2(Register::new(2)),
+                Register1(Register::new(4)),
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+            ),
+            ret_instruction(),
+        ],
+        vec![],
+    );
+    let target_program = Program::from_raw(vec![ret_instruction()], vec![U256::from(0xfeed_u64)]);
+
+    let mut world = TestWorld::new(&[
+        (validation_address, validation_program),
+        (decommitter_address, decommitter_program),
+        (target_address, target_program),
+    ]);
+    let target_hash = *world
+        .address_to_hash
+        .get(&U256::from(target_address.to_low_u64_be()))
+        .expect("target contract hash must exist");
+
+    let bootloader_program = Program::from_raw(
+        vec![
+            normal_far_call(Register::new(1), Register::new(2)),
+            ret_instruction(),
+        ],
+        vec![],
+    );
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        bootloader_program,
+        Address::zero(),
+        &[],
+        10_000_000,
+        default_settings(),
+    );
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = system_far_call_abi(5_000_000);
+    vm.state.registers[2] = U256::from(validation_address.to_low_u64_be());
+    vm.state.registers[3] = target_hash;
+
+    vm.make_snapshot();
+    let first_run_end = vm.run(&mut world, &mut ());
+    assert!(
+        matches!(first_run_end, ExecutionEnd::ProgramFinished(_)),
+        "first run should finish cleanly: {first_run_end:?}"
+    );
+
+    // The decommitter frame is the second far-call frame. Its Decommit opcode materializes the
+    // target code into that frame's own heap, then frame popping keeps the heap alive only through
+    // the global decommit pin.
+    let decommitter_base = next_page_group(first_dynamic_base_page());
+    let decommitter_heap = heap_page_from_base(decommitter_base);
+    assert_eq!(
+        vm.world_diff.decommit_page(target_hash),
+        Some(decommitter_heap)
+    );
+    assert!(vm.world_diff.is_decommit_page_pinned(decommitter_heap));
+    assert!(vm.state.heaps.contains(decommitter_heap));
+    assert!(!vm
+        .state
+        .current_frame
+        .heaps_i_am_keeping_alive
+        .contains(&decommitter_heap));
+
+    vm.rollback();
+    assert!(!vm.world_diff.is_decommit_page_pinned(decommitter_heap));
+    assert!(
+        !vm.state.heaps.contains(decommitter_heap),
+        "rollback must sweep dynamic heaps that were reachable only through post-snapshot pins"
+    );
+
+    let replay_end = vm.run(&mut world, &mut ());
+    assert!(
+        matches!(replay_end, ExecutionEnd::ProgramFinished(_)),
+        "replay after rollback should not hit a dynamic heap allocation conflict: {replay_end:?}"
+    );
+    assert_eq!(
+        vm.world_diff.decommit_page(target_hash),
+        Some(decommitter_heap)
+    );
+    assert!(vm.state.heaps.contains(decommitter_heap));
 }


### PR DESCRIPTION
Context: https://github.com/matter-labs/vm2/pull/95#discussion_r3195221995

In snapshots, we now record the heap dynamic length, and on rollback, we properly recycle pages to get back to the same length.