### PR TITLE
fix: Correctly set frame stipend for evm blob frames

### DIFF
--- a/crates/vm2/src/callframe.rs
+++ b/crates/vm2/src/callframe.rs
@@ -72,13 +72,15 @@ impl<T, W> Callframe<T, W> {
         exception_handler: u16,
         context_u128: u128,
         is_static: bool,
-        is_evm_interpreter: bool,
+        is_evm_blob_format: bool,
         world_before_this_frame: Snapshot,
     ) -> Self {
         let is_kernel = is_kernel(address);
+        // The stipend is part of the externally visible frame state. zk_evm keys it on
+        // the deployer-storage version byte, even for calls that are masked to default AA.
         let heap_size = if is_kernel {
             NEW_KERNEL_FRAME_MEMORY_STIPEND
-        } else if is_evm_interpreter {
+        } else if is_evm_blob_format {
             NEW_EVM_FRAME_MEMORY_STIPEND
         } else {
             NEW_FRAME_MEMORY_STIPEND

--- a/crates/vm2/src/decommit.rs
+++ b/crates/vm2/src/decommit.rs
@@ -53,11 +53,16 @@ impl WorldDiff {
         evm_interpreter_code_hash: [u8; 32],
         is_constructor_call: bool,
         tx_number_in_block: u16,
-    ) -> Option<(UnpaidDecommit, bool)> {
+    ) -> Option<(UnpaidDecommit, bool, bool)> {
         let deployer_system_contract_address =
             Address::from_low_u64_be(DEPLOYER_SYSTEM_CONTRACT_ADDRESS_LOW.into());
 
         let mut is_evm = false;
+        // zk_evm grants the larger EVM frame stipend based on the version byte alone.
+        // Keep this separate from `is_evm`: calls masked to default AA should not execute
+        // via the EVM interpreter, but their frame bounds still expose the original blob
+        // format classification.
+        let mut is_evm_blob_format = false;
 
         let mut code_info = {
             let code_info = self.read_storage_without_refund(
@@ -98,6 +103,7 @@ impl WorldDiff {
                     }
                 }
                 2 => {
+                    is_evm_blob_format = true;
                     if is_constructed == is_constructor_call {
                         try_default_aa?
                     } else {
@@ -131,6 +137,7 @@ impl WorldDiff {
                 should_materialize,
             },
             is_evm,
+            is_evm_blob_format,
         ))
     }
 

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -100,7 +100,7 @@ where
                 return None;
             }
             let calldata = maybe_calldata?;
-            let (unpaid_decommit, is_evm) = decommit_result?;
+            let (unpaid_decommit, is_evm, is_evm_blob_format) = decommit_result?;
             let code_hash = unpaid_decommit.code_key();
             let should_materialize = unpaid_decommit.should_materialize();
             let program = vm.world_diff.pay_for_decommit(
@@ -119,7 +119,7 @@ where
                 materialize_decommit_page(vm, code_hash, &code, code_page_from_base(new_base_page));
             }
 
-            Some((calldata, program, is_evm))
+            Some((calldata, program, is_evm, is_evm_blob_format))
         })();
 
         let maximum_gas = vm.state.current_frame.gas / 64 * 63;
@@ -128,8 +128,8 @@ where
         let new_frame_gas = normally_passed_gas + mandated_gas;
 
         // A far call pushes a new frame and returns from it in the next instruction if it panics.
-        let (calldata, program, is_evm_interpreter) =
-            fallible_part.unwrap_or_else(|| (U256::zero().into(), Program::new_panicking(), false));
+        let (calldata, program, is_evm_interpreter, is_evm_blob_format) = fallible_part
+            .unwrap_or_else(|| (U256::zero().into(), Program::new_panicking(), false, false));
 
         let new_frame_is_static = IS_STATIC || vm.state.current_frame.is_static;
         vm.push_frame::<M>(
@@ -138,7 +138,7 @@ where
             new_frame_gas,
             exception_handler,
             new_frame_is_static && !is_evm_interpreter,
-            is_evm_interpreter,
+            is_evm_blob_format,
             calldata.memory_page,
             vm.world_diff.snapshot(),
         );

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -1,6 +1,8 @@
 use primitive_types::{H160, U256};
 use zkevm_opcode_defs::{
-    decoding::EncodingModeProduction, ethereum_types::Address, system_params::VM_MAX_STACK_DEPTH,
+    decoding::EncodingModeProduction,
+    ethereum_types::Address,
+    system_params::{NEW_EVM_FRAME_MEMORY_STIPEND, NEW_FRAME_MEMORY_STIPEND, VM_MAX_STACK_DEPTH},
     Condition, DecodedOpcode, ImmMemHandlerFlags, Opcode, Operand, RegOrImmFlags, UMAOpcode,
     OPCODES_TABLE, UMA_INCREMENT_FLAG_IDX,
 };
@@ -10,6 +12,7 @@ use crate::{
     addressing_modes::{Arguments, Immediate1, Register, Register1, Register2},
     decode::decode,
     fat_pointer::FatPointer,
+    instruction_handlers::address_into_u256,
     page_ids::{
         aux_heap_page_from_base, first_dynamic_base_page, heap_page_from_base, next_page_group,
     },
@@ -67,6 +70,68 @@ fn ret_instruction<T: Tracer, W: World<T>>() -> Instruction<T, W> {
         None,
         Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
     )
+}
+
+fn bytes32(value: U256) -> [u8; 32] {
+    let mut bytes = [0; 32];
+    value.to_big_endian(&mut bytes);
+    bytes
+}
+
+fn masked_default_aa_far_call(version_byte: u8) -> VirtualMachine<(), TestWorld<()>> {
+    let default_aa_address = Address::from_low_u64_be(0x100);
+    let destination_address = non_kernel_address();
+    let default_aa_program = Program::from_raw(vec![ret_instruction()], vec![]);
+    let mut world = TestWorld::new(&[(default_aa_address, default_aa_program)]);
+
+    let default_aa_hash = *world
+        .address_to_hash
+        .get(&address_into_u256(default_aa_address))
+        .expect("default AA hash must be registered in test world");
+
+    // The target storage slot describes code that cannot be called in this mode:
+    // byte 1 marks the contract as still in construction, while the call below is
+    // a regular non-constructor call. Reference zk_evm masks this to default AA but
+    // still uses byte 0 when selecting the new frame memory stipend.
+    let mut masked_code_info = [0; 32];
+    masked_code_info[0] = version_byte;
+    masked_code_info[1] = 1;
+    world.address_to_hash.insert(
+        address_into_u256(destination_address),
+        U256::from_big_endian(&masked_code_info),
+    );
+
+    let far_call = Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(1),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![far_call, ret_instruction()], vec![]);
+    let mut vm = VirtualMachine::new(
+        non_kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        Settings {
+            default_aa_code_hash: bytes32(default_aa_hash),
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+        },
+    );
+
+    let mut far_call_abi = U256::zero();
+    far_call_abi.0[3] = 10_000;
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = far_call_abi;
+    vm.state.registers[2] = address_into_u256(destination_address);
+    vm.state.current_frame.is_static = true;
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    vm
 }
 
 #[test]
@@ -132,6 +197,35 @@ fn far_call_calldata_pointer_should_use_caller_heap_reference_page() {
     assert_eq!(
         vm.state.current_frame.aux_heap,
         aux_heap_page_from_base(first_dynamic_base_page())
+    );
+}
+
+#[test]
+fn masked_evm_blob_far_call_should_keep_evm_stipend() {
+    let vm = masked_default_aa_far_call(2);
+
+    assert_eq!(
+        vm.state.current_frame.heap_size,
+        NEW_EVM_FRAME_MEMORY_STIPEND
+    );
+    assert_eq!(
+        vm.state.current_frame.aux_heap_size,
+        NEW_EVM_FRAME_MEMORY_STIPEND
+    );
+    assert!(
+        vm.state.current_frame.is_static,
+        "masked EVM blob calls should keep default-AA static behavior; only the stipend uses the blob version byte"
+    );
+}
+
+#[test]
+fn masked_native_far_call_should_keep_regular_stipend() {
+    let vm = masked_default_aa_far_call(1);
+
+    assert_eq!(vm.state.current_frame.heap_size, NEW_FRAME_MEMORY_STIPEND);
+    assert_eq!(
+        vm.state.current_frame.aux_heap_size,
+        NEW_FRAME_MEMORY_STIPEND
     );
 }
 

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -202,7 +202,7 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
         gas: u32,
         exception_handler: u16,
         is_static: bool,
-        is_evm_interpreter: bool,
+        is_evm_blob_format: bool,
         calldata_heap: HeapId,
         world_before_this_frame: Snapshot,
     ) {
@@ -237,7 +237,7 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
                 self.state.context_u128
             },
             is_static,
-            is_evm_interpreter,
+            is_evm_blob_format,
             world_before_this_frame,
         );
         self.state.context_u128 = 0;


### PR DESCRIPTION
Report: https://github.com/ninolipartiia/vm2/blob/popzxc-airbender-eravm-review/security-review/evm-stipend-divergence.md
Relevant zk_evm code: https://github.com/matter-labs/zksync-protocol/blob/4a434874c9c7a306ed4bf807c55a86de29e47976/crates/zk_evm/src/opcodes/execution/far_call.rs#L660-L668

Choose stipend value based on the code marker only.