### PR TITLE
fix: Preserve pointer flag on load increment

### DIFF
--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     addressing_modes::{
-        Arguments, Destination, DestinationWriter, Immediate1, Register1, Register2,
+        Addressable, Arguments, Destination, DestinationWriter, Immediate1, Register1, Register2,
         RegisterOrImmediate, Source,
     },
     fat_pointer::FatPointer,
@@ -68,6 +68,23 @@ fn bigger_than_last_address(x: U256) -> bool {
     x.0[0] > LAST_ADDRESS.into() || x.0[1] != 0 || x.0[2] != 0 || x.0[3] != 0
 }
 
+fn set_incremented_read_offset(
+    args: &Arguments,
+    state: &mut impl Addressable,
+    value: U256,
+    is_pointer: bool,
+) {
+    // zk_evm treats heap and static memory reads as raw offset accesses, but the
+    // incremented dst1 register still inherits src0's pointer tag. The observable
+    // case is a zero-valued panic returndata pointer: the range check accepts it,
+    // and later pointer operations must still see a pointer.
+    if is_pointer {
+        Register2::set_fat_ptr(args, state, value);
+    } else {
+        Register2::set(args, state, value);
+    }
+}
+
 fn load<T: Tracer, W: World<T>, H: HeapFromState, In: Source, const INCREMENT: bool>(
     vm: &mut VirtualMachine<T, W>,
     world: &mut W,
@@ -76,7 +93,7 @@ fn load<T: Tracer, W: World<T>, H: HeapFromState, In: Source, const INCREMENT: b
     boilerplate::<H::Read, _, _>(vm, world, tracer, |vm, args| {
         // Pointers need not be masked here even though we do not care about them being pointers.
         // They will panic, though because they are larger than 2^32.
-        let (pointer, _) = In::get_with_pointer_flag(args, &mut vm.state);
+        let (pointer, input_is_pointer) = In::get_with_pointer_flag(args, &mut vm.state);
 
         if bigger_than_last_address(pointer) {
             let _ = vm.state.use_gas(u32::MAX);
@@ -96,7 +113,7 @@ fn load<T: Tracer, W: World<T>, H: HeapFromState, In: Source, const INCREMENT: b
         Register1::set(args, &mut vm.state, value);
 
         if INCREMENT {
-            Register2::set(args, &mut vm.state, pointer + 32);
+            set_incremented_read_offset(args, &mut vm.state, pointer + 32, input_is_pointer);
         }
     })
 }
@@ -202,7 +219,7 @@ fn load_static<T: Tracer, W: World<T>, In: Source, const INCREMENT: bool>(
     boilerplate::<opcodes::StaticMemoryRead, _, _>(vm, world, tracer, |vm, args| {
         // Static memory uses a plain 32-bit offset in src0, same as heap UMA ops.
         // Pointer-typed values are still accepted as raw words and then validated by range check.
-        let (pointer, _) = In::get_with_pointer_flag(args, &mut vm.state);
+        let (pointer, input_is_pointer) = In::get_with_pointer_flag(args, &mut vm.state);
 
         if bigger_than_last_address(pointer) {
             vm.state.current_frame.pc = spontaneous_panic();
@@ -214,7 +231,7 @@ fn load_static<T: Tracer, W: World<T>, In: Source, const INCREMENT: bool>(
         Register1::set(args, &mut vm.state, value);
 
         if INCREMENT {
-            Register2::set(args, &mut vm.state, pointer + 32);
+            set_incremented_read_offset(args, &mut vm.state, pointer + 32, input_is_pointer);
         }
     })
 }

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -269,6 +269,66 @@ fn static_memory_should_be_isolated_from_regular_heap() {
     assert_eq!(vm.state.registers[4], static_value);
 }
 
+fn assert_uma_read_increment_preserves_pointer_flag(
+    read_instruction: Instruction<(), TestWorld<()>>,
+    address: Address,
+) {
+    let program = Program::from_raw(vec![read_instruction], vec![]);
+    let mut world = TestWorld::new(&[]);
+    let mut vm = VirtualMachine::new(
+        address,
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    // Panic returndata is represented as an empty fat pointer: value zero, with
+    // the pointer tag still set. UMA range checks accept that value, so the
+    // incremented register must preserve the tag exactly as zk_evm does.
+    vm.state.registers[1] = U256::zero();
+    vm.state.register_pointer_flags = 1 << 1;
+
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+
+    assert_eq!(vm.state.registers[3], U256::from(32));
+    assert_eq!(vm.state.register_pointer_flags & (1 << 3), 1 << 3);
+}
+
+#[test]
+fn uma_read_increment_should_preserve_source_pointer_flag() {
+    assert_uma_read_increment_preserves_pointer_flag(
+        Instruction::from_heap_read(
+            Register1(Register::new(1)).into(),
+            Register1(Register::new(2)),
+            Some(Register2(Register::new(3))),
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        ),
+        non_kernel_address(),
+    );
+
+    assert_uma_read_increment_preserves_pointer_flag(
+        Instruction::from_aux_heap_read(
+            Register1(Register::new(1)).into(),
+            Register1(Register::new(2)),
+            Some(Register2(Register::new(3))),
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        ),
+        non_kernel_address(),
+    );
+
+    assert_uma_read_increment_preserves_pointer_flag(
+        Instruction::from_static_memory_read(
+            Register1(Register::new(1)).into(),
+            Register1(Register::new(2)),
+            Some(Register2(Register::new(3))),
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        ),
+        kernel_address(),
+    );
+}
+
 #[derive(Debug, Default)]
 struct IncrementingPrecompiles;
 


### PR DESCRIPTION
Report: https://github.com/ninolipartiia/vm2/blob/popzxc-airbender-eravm-review/security-review/01-static-memory-pointer-flag-divergence.md
Relevant code: https://github.com/matter-labs/zksync-protocol/blob/4a434874c9c7a306ed4bf807c55a86de29e47976/crates/zk_evm/src/opcodes/execution/uma.rs#L404-L412

Preserve far pointer flag where zk_evm also preserves it
