### PR TITLE
fix: Use empty heap for reading unallocated heaps

### DIFF
--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -398,26 +398,16 @@ impl Heaps {
     pub(crate) fn write_u256(&mut self, page: HeapId, start_address: u32, value: U256) {
         self.record_bootloader_word_rollback(page, start_address);
         let decoded = DecodedPage::decode(page)
-            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
-        let (heap, pagepool) = self
-            .try_decoded_page_mut(decoded)
-            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
+            .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
+        let (heap, pagepool) = self.decoded_page_mut_for_write(decoded);
         heap.write_u256(start_address, value, pagepool);
     }
 
     pub(crate) fn write_bytes(&mut self, page: HeapId, start_address: u32, bytes: &[u8]) {
         self.record_bootloader_range_rollback(page, start_address, bytes.len());
         let decoded = DecodedPage::decode(page)
-            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
-        if let DecodedPage::Dynamic { .. } = decoded {
-            let slot = decoded_dynamic_slot_mut(&mut self.dynamic, decoded);
-            if slot.is_none() {
-                *slot = Some(Heap::default());
-            }
-        }
-        let (heap, pagepool) = self
-            .try_decoded_page_mut(decoded)
-            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
+            .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
+        let (heap, pagepool) = self.decoded_page_mut_for_write(decoded);
         heap.write_bytes(start_address, bytes, pagepool);
     }
 
@@ -504,7 +494,7 @@ impl Heaps {
         self.try_decoded_page(page).unwrap_or(&EMPTY_HEAP)
     }
 
-    fn try_decoded_page_mut(&mut self, page: DecodedPage) -> Option<(&mut Heap, &mut PagePool)> {
+    fn decoded_page_mut_for_write(&mut self, page: DecodedPage) -> (&mut Heap, &mut PagePool) {
         let Self {
             static_memory,
             bootloader_calldata,
@@ -515,16 +505,19 @@ impl Heaps {
             ..
         } = self;
 
+        // The reference memory model materializes a page before writing to it.
+        // vm2 keeps the stricter page-id classification, but decodable dynamic
+        // pages are valid write targets and should be allocated lazily.
         let heap = match page {
             DecodedPage::Static => static_memory,
             DecodedPage::BootloaderCalldata => bootloader_calldata,
             DecodedPage::BootloaderHeap => bootloader_heap,
             DecodedPage::BootloaderAuxHeap => bootloader_aux_heap,
-            DecodedPage::Dynamic { group, kind } => dynamic
-                .get_mut(group)
-                .and_then(|group| group.slot_mut(kind).as_mut())?,
+            DecodedPage::Dynamic { group, kind } => {
+                dynamic_slot_mut(dynamic, group, kind).get_or_insert_with(Heap::default)
+            }
         };
-        Some((heap, pagepool))
+        (heap, pagepool)
     }
 }
 

--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -359,6 +359,10 @@ impl Heaps {
         );
 
         let slot = decoded_dynamic_slot_mut(&mut self.dynamic, decoded);
+        // `decoded_page_mut_for_write` populates dynamic slots lazily, so in principle a prior
+        // write could materialize this slot. In production, `allocate_at` is only called from
+        // far-call setup on the heap/aux slots of a freshly assigned base group, which no
+        // prior code path writes to. If this fires, that invariant has been broken.
         assert!(
             slot.is_none(),
             "heap page {} is already allocated",
@@ -375,6 +379,11 @@ impl Heaps {
         })
     }
 
+    // The three panics in this function flag VM-internal bookkeeping bugs, not
+    // reachable conditions: the VM only deallocates pages it previously allocated via
+    // `allocate_at` (frame pop in `pop_frame`, snapshot rollback in `State::rollback`). The
+    // reference `zk_evm` has no deallocation path of its own, so there is no behaviour to
+    // diverge from here — these panics remain as fail-fast diagnostics for our own bookkeeping.
     pub(crate) fn deallocate(&mut self, page: HeapId) {
         let decoded = DecodedPage::decode(page)
             .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
@@ -397,6 +406,11 @@ impl Heaps {
 
     pub(crate) fn write_u256(&mut self, page: HeapId, start_address: u32, value: U256) {
         self.record_bootloader_word_rollback(page, start_address);
+        // Current callers pass `HeapId`s from VM-controlled sources: store opcodes (current
+        // frame heap/aux), static memory, and kernel-gated precompile output. The
+        // `StateInterface::write_heap_u256` tracer entry can in principle pass an arbitrary
+        // `HeapId`. The reference `zk_evm` would silently materialize any page number; we
+        // keep the panic as a tripwire against any new code path.
         let decoded = DecodedPage::decode(page)
             .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
         let (heap, pagepool) = self.decoded_page_mut_for_write(decoded);
@@ -405,6 +419,11 @@ impl Heaps {
 
     pub(crate) fn write_bytes(&mut self, page: HeapId, start_address: u32, bytes: &[u8]) {
         self.record_bootloader_range_rollback(page, start_address, bytes.len());
+        // Same tripwire rationale as `write_u256`: the only production callers go through
+        // `materialize_decommit_page` (a fresh code page on far call, or the current frame
+        // heap from the `Decommit` opcode), both supplying decodable `HeapId`s. An
+        // undecodable page here indicates a new code path that should be reviewed before
+        // merging.
         let decoded = DecodedPage::decode(page)
             .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
         let (heap, pagepool) = self.decoded_page_mut_for_write(decoded);

--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -30,6 +30,11 @@ pub(crate) struct Heap {
     pages: Vec<Option<HeapPage>>,
 }
 
+// The reference VM treats reads from missing memory pages as reads from an
+// all-zero page. Keep write paths strict, but make read-only indexing total so
+// panic-produced or otherwise empty fat pointers cannot abort the host.
+static EMPTY_HEAP: Heap = Heap { pages: Vec::new() };
+
 // We never remove `HeapPage`s (even after rollbacks – although we do zero all added pages in this case),
 // we allow additional pages to be present if they are zeroed.
 impl PartialEq for Heap {
@@ -496,8 +501,7 @@ impl Heaps {
     }
 
     fn decoded_page(&self, page: DecodedPage) -> &Heap {
-        self.try_decoded_page(page)
-            .unwrap_or_else(|| panic!("decoded page {page:?} is not allocated"))
+        self.try_decoded_page(page).unwrap_or(&EMPTY_HEAP)
     }
 
     fn try_decoded_page_mut(&mut self, page: DecodedPage) -> Option<(&mut Heap, &mut PagePool)> {
@@ -528,9 +532,10 @@ impl Index<HeapId> for Heaps {
     type Output = Heap;
 
     fn index(&self, index: HeapId) -> &Self::Output {
-        let decoded = DecodedPage::decode(index)
-            .unwrap_or_else(|| panic!("heap page {} is not allocated", index.as_u32()));
-        self.decoded_page(decoded)
+        match DecodedPage::decode(index) {
+            Some(decoded) => self.decoded_page(decoded),
+            None => &EMPTY_HEAP,
+        }
     }
 }
 

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -270,6 +270,53 @@ fn masked_native_far_call_should_keep_regular_stipend() {
     );
 }
 
+#[test]
+fn pointer_read_after_failed_far_call_should_return_zero() {
+    let failed_call = Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(1),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    );
+    let read_returned_pointer = Instruction::from_pointer_read(
+        Register1(Register::new(1)),
+        Register1(Register::new(3)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(
+        vec![failed_call, read_returned_pointer, ret_instruction()],
+        vec![],
+    );
+    let mut world = TestWorld::new(&[]);
+    let mut vm = VirtualMachine::new(
+        non_kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    // The missing callee makes `far_call` enter a panicking frame. The reference
+    // VM still returns an empty fat pointer in r1, so reading through it must
+    // behave like a zero-length read rather than crashing the host.
+    let mut far_call_abi = U256::zero();
+    far_call_abi.0[3] = 10_000;
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = far_call_abi;
+    vm.state.registers[2] = U256::zero();
+
+    assert_eq!(
+        vm.run(&mut world, &mut ()),
+        ExecutionEnd::ProgramFinished(vec![])
+    );
+    assert_eq!(vm.state.registers[3], U256::zero());
+    assert_eq!(vm.state.register_pointer_flags & (1 << 1), 1 << 1);
+}
+
 fn static_uma_instruction<T: Tracer, W: World<T>>(opcode: UMAOpcode) -> Instruction<T, W> {
     let variant = OPCODES_TABLE
         .iter()

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -643,6 +643,61 @@ fn precompile_zero_memory_page_should_use_current_heap_instead_of_static_memory(
     assert_eq!(vm.state.registers[8], static_value);
 }
 
+#[test]
+fn precompile_output_write_should_materialize_unallocated_dynamic_page() {
+    let heap_write = Instruction::from_heap_write(
+        Register1(Register::new(1)).into(),
+        Register2(Register::new(2)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        false,
+    );
+    let precompile_call = Instruction::from_precompile_call(
+        Register1(Register::new(4)),
+        Register2(Register::new(5)),
+        Register1(Register::new(6)),
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    );
+    let program = Program::from_raw(vec![heap_write, precompile_call, ret_instruction()], vec![]);
+    let mut world = PrecompileSentinelWorld::default();
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    );
+
+    let output_page = heap_page_from_base(next_page_group(first_dynamic_base_page()));
+    assert!(!vm.state.heaps.contains(output_page));
+
+    let input_value = U256::from(0x33_u64);
+    let expected_output = input_value + U256::one();
+
+    // ABI: read 32 bytes from the current heap via page-zero sentinel, then write
+    // one output word to a valid dynamic page that has not been allocated yet.
+    let mut precompile_abi = U256::zero();
+    precompile_abi.0[0] = 32_u64 << 32;
+    precompile_abi.0[1] = 1_u64 << 32;
+    precompile_abi.0[2] = u64::from(output_page.as_u32()) << 32;
+
+    vm.state.register_pointer_flags &= !(1 << 1);
+    vm.state.registers[1] = U256::zero();
+    vm.state.registers[2] = input_value;
+    vm.state.registers[4] = precompile_abi;
+    vm.state.registers[5] = U256::zero();
+
+    assert_eq!(
+        vm.run(&mut world, &mut ()),
+        ExecutionEnd::ProgramFinished(vec![])
+    );
+    assert_eq!(vm.state.registers[6], U256::one());
+    assert!(vm.state.heaps.contains(output_page));
+    assert_eq!(vm.state.heaps[output_page].read_u256(0), expected_output);
+}
+
 #[derive(Debug, Default)]
 struct CountingWorld {
     storage_reads: usize,


### PR DESCRIPTION
Report: https://github.com/ninolipartiia/vm2/blob/popzxc-airbender-eravm-review/security-review/04-failed-far-call-r1-poison-host-panic.md
Relevant code in zk_evm: https://github.com/matter-labs/zksync-protocol/blob/4a434874c9c7a306ed4bf807c55a86de29e47976/crates/zk_evm/src/reference_impls/memory.rs#L110-L115

On unallocated heap access for reads, return empty heap instead of panicking.