### PR TITLE
fix: Guarantee FatPointer memory layout for U256 transmutes

### DIFF
--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -156,6 +156,7 @@ pub trait CallframeInterface {
 ///
 /// EraVM docs sometimes refer to heaps as *heap pages*; docs in these crate don't to avoid confusion with internal heap structure.
 #[derive(Copy, Clone, PartialEq, Debug)]
+#[repr(transparent)] // Guarantees `HeapId` has the same layout as `u32`; relied on by `FatPointer` transmutes.
 pub struct HeapId(u32);
 
 impl HeapId {

--- a/crates/vm2/src/fat_pointer.rs
+++ b/crates/vm2/src/fat_pointer.rs
@@ -17,6 +17,15 @@ pub struct FatPointer {
     pub length: u32,
 }
 
+// The `FatPointer <-> U256`/`u128` conversions below reinterpret memory, so they rely on the
+// exact layout of `FatPointer` (and, for the `&mut U256` cast, on `U256` being a little-endian
+// `[u64; 4]`). These assertions fail to compile if that layout ever drifts, turning silent UB
+// into a build error. `HeapId` is `#[repr(transparent)]` so `memory_page` is laid out as a `u32`.
+const _: () = assert!(std::mem::size_of::<FatPointer>() == 16);
+const _: () = assert!(std::mem::size_of::<FatPointer>() == std::mem::size_of::<u128>());
+const _: () = assert!(std::mem::size_of::<HeapId>() == std::mem::size_of::<u32>());
+const _: () = assert!(std::mem::align_of::<FatPointer>() <= std::mem::align_of::<U256>());
+
 #[cfg(target_endian = "little")]
 impl From<&mut U256> for &mut FatPointer {
     fn from(value: &mut U256) -> Self {

--- a/crates/vm2/src/fat_pointer.rs
+++ b/crates/vm2/src/fat_pointer.rs
@@ -24,6 +24,9 @@ pub struct FatPointer {
 const _: () = assert!(std::mem::size_of::<FatPointer>() == 16);
 const _: () = assert!(std::mem::size_of::<FatPointer>() == std::mem::size_of::<u128>());
 const _: () = assert!(std::mem::size_of::<HeapId>() == std::mem::size_of::<u32>());
+// The `&mut U256 -> &mut FatPointer` cast reinterprets `U256` storage in place, so `FatPointer`
+// must fit within a `U256` (size) and be no more aligned than it (alignment) to stay in bounds.
+const _: () = assert!(std::mem::size_of::<FatPointer>() <= std::mem::size_of::<U256>());
 const _: () = assert!(std::mem::align_of::<FatPointer>() <= std::mem::align_of::<U256>());
 
 #[cfg(target_endian = "little")]


### PR DESCRIPTION
## Summary

Addresses the **Undefined Behaviour** audit finding (U-1) about `FatPointer` ↔ `U256` conversions relying on unspecified memory layout.

`crates/vm2/src/fat_pointer.rs` reinterprets memory to convert between `FatPointer` and `U256`/`u128` (via `transmute` and a `&mut U256 → &mut FatPointer` pointer cast used on the pointer-opcode hot path). These rely on `FatPointer` having a fixed layout. `FatPointer` was already `#[repr(C)]`, **but** its `memory_page: HeapId` field was a plain `#[repr(Rust)]` newtype — and Rust does *not* guarantee that a single-field `struct HeapId(u32)` has the same size/alignment as `u32`. It works in every current rustc, but that is an implementation detail, not a language guarantee, so the transmutes were technically unsound.

## Changes

- Add `#[repr(transparent)]` to `HeapId` so it is *guaranteed* to be laid out identically to `u32`. This closes the actual gap: `FatPointer` becomes a guaranteed `4 × u32 = 16` bytes with no padding, making the `u128` transmutes sound and the `&mut U256` cast sound on little-endian (where all these conversions are already `#[cfg(target_endian = "little")]`-gated).
- Add four compile-time `size_of`/`align_of` assertions in `fat_pointer.rs` so any future layout drift (an added field, a changed `HeapId`) becomes a **build error** instead of silent UB.

Zero runtime cost; no public API change.

## Notes

- `U256` (from `primitive-types` / `uint 0.9.5`) is confirmed `#[repr(C)] struct U256([u64; 4])` little-endian, so the in-place `&mut U256 → &mut FatPointer` cast is well-defined once `HeapId`'s layout is pinned. The alignment assertion (`align_of::<FatPointer>() <= align_of::<U256>()`) guards that cast's precondition.
- The assertions catch size/align drift but not a hypothetical word-order change in the external `uint` crate — that residual cross-crate coupling is inherent to the in-place cast and out of scope here.

## Testing

- `cargo build -p zksync_vm2 -p zksync_vm2_interface` — passes (const assertions hold at compile time)
- `cargo test -p zksync_vm2 -p zksync_vm2_interface` — 55 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)