### PR TITLE
docs: Explain EventWriter-only event recording divergence from zk_evm

### DIFF
--- a/crates/vm2-interface/src/state_interface.rs
+++ b/crates/vm2-interface/src/state_interface.rs
@@ -180,8 +180,11 @@ impl HeapId {
 
 /// Event emitted by EraVM.
 ///
-/// There is no address field because nobody is interested in events that don't come
-/// from the event writer, so we simply do not record events coming from anywhere else.
+/// vm2 records events only from the `EventWriter` system contract (`0x800d`), the sole contract
+/// that runs the `Event` opcode in practice. `zk_evm` instead records events from any emitter
+/// (keeping the emitter address) and filters down to the `EventWriter` later. Both yield the same
+/// event set, so there is no `address` field here — the originating contract is encoded in the
+/// event payload, as in `zk_evm`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Event {
     /// Event key.

--- a/crates/vm2/src/instruction_handlers/event.rs
+++ b/crates/vm2/src/instruction_handlers/event.rs
@@ -15,6 +15,8 @@ fn event<T: Tracer, W: World<T>>(
     tracer: &mut T,
 ) -> ExecutionStatus {
     boilerplate_ext::<opcodes::Event, _, _>(vm, world, tracer, |vm, args, _, _| {
+        // Record only `EventWriter` events; `zk_evm` records all emitters and filters later. Since
+        // only the `EventWriter` runs this opcode in practice, both agree. See the `Event` docs.
         if vm.state.current_frame.address == H160::from_low_u64_be(ADDRESS_EVENT_WRITER.into()) {
             let key = Register1::get(args, &mut vm.state);
             let value = Register2::get(args, &mut vm.state);


### PR DESCRIPTION
## Summary

Documents the **Informational** audit finding (I-1) about event recording — an intentional, output-equivalent divergence from `zk_evm` that was previously only tersely noted.

`zk_evm` records the `Event` opcode from *any* emitter (keeping the emitter address) and filters down to the `EventWriter` system contract (`0x800d`) later in the pipeline. vm2 instead only records events emitted by the `EventWriter` in the first place — the only contract that runs the `Event` opcode in real execution — which is why `Event` has no `address` field. Both approaches produce the same event set; the true originating contract is encoded in the event payload in both.

No behavior change — comments only.

## Changes

- Expand the `Event` doc comment (`state_interface.rs`) to explain the `zk_evm` behavior and why vm2 omits the address field.
- Add a short comment at the recording condition in the `Event` handler (`event.rs`) pointing to the `Event` docs.

## Testing

- `cargo build -p zksync_vm2 -p zksync_vm2_interface` — passes
- `cargo doc -p zksync_vm2_interface --no-deps` — generates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)