### PR TITLE
perf: cut verifier memory — gate storage_logs trace (Boojum-safe) + consolidate WorldDiff maps

### DIFF
--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -344,6 +344,18 @@ impl Heaps {
         }
     }
 
+    /// Pre-reserve capacity for the dynamic heap-pages Vec to avoid Vec
+    /// doubling during execution. Each `far_call` allocates a new
+    /// `DynamicPageGroup`; large batches push this Vec past 70+ MiB through
+    /// the doubling sequence. A one-shot reserve keeps it as a single
+    /// allocation.
+    pub(crate) fn reserve_dynamic_groups(&mut self, n: usize) {
+        let extra = n.saturating_sub(self.dynamic.len());
+        if extra > 0 {
+            self.dynamic.reserve_exact(extra);
+        }
+    }
+
     pub(crate) fn allocate_at(&mut self, page: HeapId) -> HeapId {
         self.allocate_with_content_at(page, &[])
     }

--- a/crates/vm2/src/lib.rs
+++ b/crates/vm2/src/lib.rs
@@ -18,7 +18,7 @@ pub use self::{
     predication::Predicate,
     program::Program,
     vm::{Settings, VirtualMachine},
-    world_diff::{Snapshot, StorageChange, WorldDiff},
+    world_diff::{Snapshot, StorageChange, StorageWriteEntry, WorldDiff},
 };
 use crate::precompiles::{LegacyPrecompiles, Precompiles};
 

--- a/crates/vm2/src/rollback.rs
+++ b/crates/vm2/src/rollback.rs
@@ -36,6 +36,35 @@ impl<K: Ord + Clone, V: Clone> RollbackableMap<K, V> {
     }
 }
 
+impl<K: Ord + Clone> RollbackableMap<K, u8> {
+    /// OR `flags` into the entry for `key` (an absent entry counts as `0`) in a
+    /// single map traversal, journaling the prior value so the change rolls
+    /// back. Returns `true` iff at least one previously-unset bit was set.
+    ///
+    /// Equivalent to a `get` followed by a conditional `insert`, but with one
+    /// traversal instead of two, and no journal entry when no bit changes.
+    pub(crate) fn add_flags(&mut self, key: K, flags: u8) -> bool {
+        use std::collections::btree_map::Entry;
+        match self.map.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let old = *entry.get();
+                let new = old | flags;
+                if new == old {
+                    return false;
+                }
+                entry.insert(new);
+                self.old_entries.push((entry.key().clone(), Some(old)));
+                true
+            }
+            Entry::Vacant(entry) => {
+                self.old_entries.push((entry.key().clone(), None));
+                entry.insert(flags);
+                true
+            }
+        }
+    }
+}
+
 impl<K: Ord, V> Rollback for RollbackableMap<K, V> {
     type Snapshot = usize;
 

--- a/crates/vm2/src/rollback.rs
+++ b/crates/vm2/src/rollback.rs
@@ -21,6 +21,26 @@ impl<K: Ord + Clone, V: Clone> RollbackableMap<K, V> {
         old_value
     }
 
+    /// Inserts or updates the entry for `key` in a single map traversal,
+    /// journaling the prior value for rollback. `compute` receives the current
+    /// value (`None` if absent) and returns the new value. Saves the separate
+    /// `get` a read-modify-write would otherwise need.
+    pub(crate) fn update(&mut self, key: K, compute: impl FnOnce(Option<&V>) -> V) {
+        use std::collections::btree_map::Entry;
+        match self.map.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let new = compute(Some(entry.get()));
+                let old = std::mem::replace(entry.get_mut(), new);
+                self.old_entries.push((entry.key().clone(), Some(old)));
+            }
+            Entry::Vacant(entry) => {
+                let new = compute(None);
+                self.old_entries.push((entry.key().clone(), None));
+                entry.insert(new);
+            }
+        }
+    }
+
     pub(crate) fn changes_after(
         &self,
         snapshot: <Self as Rollback>::Snapshot,

--- a/crates/vm2/src/rollback.rs
+++ b/crates/vm2/src/rollback.rs
@@ -137,6 +137,13 @@ impl<T> RollbackableLog<T> {
         self.entries.push(entry);
     }
 
+    pub(crate) fn reserve(&mut self, n: usize) {
+        let extra = n.saturating_sub(self.entries.len());
+        if extra > 0 {
+            self.entries.reserve_exact(extra);
+        }
+    }
+
     pub(crate) fn logs_after(&self, snapshot: <RollbackableLog<T> as Rollback>::Snapshot) -> &[T] {
         &self.entries[snapshot..]
     }

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -82,6 +82,9 @@ impl Heaps {
     }
 
     #[allow(dead_code)] // For API compatibility with real implementation.
+    pub(crate) fn reserve_dynamic_groups(&mut self, _n: usize) {}
+
+    #[allow(dead_code)] // For API compatibility with real implementation.
     pub(crate) fn allocate_with_content(&mut self, content: &[u8]) -> HeapId {
         let id = self.allocate();
         self.read

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -115,7 +115,7 @@ impl<T: Tracer, W: World<T>> StateInterface for VirtualMachine<T, W> {
         self.world_diff
             .get_storage_state()
             .iter()
-            .map(|(key, value)| (*key, *value))
+            .map(|(key, entry)| (*key, entry.value))
     }
 
     fn get_transient_storage_state(&self) -> impl Iterator<Item = ((H160, U256), U256)> {

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -66,6 +66,13 @@ impl<T: Tracer, W: World<T>> VirtualMachine<T, W> {
         }
     }
 
+    /// Pre-reserve dynamic heap-group capacity to suppress mid-execution
+    /// Vec doublings inside `Heaps`. Hint with the worst-case far-call
+    /// count estimable from the witness.
+    pub fn reserve_dynamic_heap_capacity(&mut self, n: usize) {
+        self.state.heaps.reserve_dynamic_groups(n);
+    }
+
     /// Provides a reference to the [`World`] diff accumulated by VM execution so far.
     pub fn world_diff(&self) -> &WorldDiff {
         &self.world_diff

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -74,22 +74,16 @@ pub struct WorldDiff {
     // This is never rolled back. It is just a cache to avoid asking these from DB every time.
     storage_initial_values: BTreeMap<(H160, U256), StorageSlot>,
 
-    /// Selects between two mutually exclusive bookkeeping modes, configured once
-    /// before execution via [`Self::set_record_storage_logs`]; never rolled back.
+    /// Selects two mutually exclusive bookkeeping modes (see
+    /// [`Self::set_record_storage_logs`] for the rationale); set once before
+    /// execution, never rolled back.
     ///
-    /// Defaults to `false` (recording on): `read_storage_inner` / `write_storage`
-    /// append the per-access `storage_logs` / `rollback_storage_logs` trace and
-    /// otherwise behave exactly like the pre-optimization base (read-only slots
-    /// are *not* cached in `storage_initial_values`). This is what consumers that
-    /// build an in-circuit storage argument from `storage_log_queries()` need
-    /// (e.g. Boojum witness generation via `sort_storage_access_queries`).
-    ///
-    /// When `true`, the trace is dropped and instead the inputs a re-execution
-    /// verifier needs are recorded: the `SLOT_COMMITTED_READ_Z0` flag and the
-    /// read-only `storage_initial_values` cache. A verifier with no in-circuit
-    /// storage argument (e.g. Airbender) derives the deduplicated set from the
-    /// flag + `storage_writes`, dropping the trace's memory cost (~270 MiB on
-    /// large batches) without adding any per-read map entries to Boojum's path.
+    /// - `false` (default): append the `storage_logs` / `rollback_storage_logs`
+    ///   trace; otherwise behave like the pre-optimization base — read-only slots
+    ///   are *not* cached in `storage_initial_values`.
+    /// - `true`: drop the trace; instead record the `SLOT_COMMITTED_READ_Z0` flag
+    ///   and the read-only `storage_initial_values` cache, the inputs a
+    ///   re-execution verifier derives the deduplicated set from.
     skip_storage_logs: bool,
 }
 
@@ -131,12 +125,9 @@ impl WorldDiff {
     /// flag + `storage_writes` instead, can pass `false` to avoid the trace's
     /// memory cost (~270 MiB on large batches).
     ///
-    /// Must be called before any storage access; toggling mid-execution would
-    /// leave a partial trace (recording) or partial dedup state (opt-out).
-    /// Enforced by the assertion below rather than left to the caller.
-    ///
     /// # Panics
-    /// Panics if any storage slot has already been read or written.
+    /// Panics if any storage slot has already been read or written — toggling
+    /// mid-execution would leave a partial trace or partial dedup state.
     pub fn set_record_storage_logs(&mut self, record: bool) {
         assert!(
             self.storage_logs.is_empty()
@@ -225,11 +216,9 @@ impl WorldDiff {
 
         self.pubdata_costs.push(0);
         let value = if self.skip_storage_logs {
-            // Opt-out mode: no per-access trace is kept, so the deduplicated set
-            // is derived from the maps instead. Cache the initial value on first
-            // read (write_storage already caches for writes) so it can be
-            // recovered without a separate backend call, and record the
-            // depth-zero read predicate.
+            // Opt-out mode: no trace is kept, so record what the deduplicated set
+            // is derived from instead — cache the initial value on first read
+            // (writes already cache it) and flag a depth-zero read.
             let initial_value = self
                 .storage_initial_values
                 .entry((contract, key))
@@ -241,25 +230,20 @@ impl WorldDiff {
                 .get(&(contract, key))
                 .map(|e| e.value);
             if live_write.is_none() {
-                // No pending write for this slot at read time — mirrors the dedup
-                // function's `did_read_at_depth_zero` flag.
+                // No pending write at read time: `did_read_at_depth_zero`.
                 self.slot_add_flag((contract, key), SLOT_COMMITTED_READ_Z0);
             }
             live_write.unwrap_or(initial_value)
         } else {
-            // Boojum mode: behave exactly like the pre-optimization base — read
-            // the value without populating `storage_initial_values` for
-            // read-only slots, so memory behavior is unchanged. The dedup-input
-            // bookkeeping above is the opt-out path's alternative to this trace.
+            // Recording mode: read like the pre-optimization base, without
+            // caching read-only slots (keeps Boojum's memory unchanged).
             self.just_read_storage(world, contract, key)
         };
         if !self.skip_storage_logs {
-            // Boojum mode: accumulate the per-access trace. `value` equals what
-            // `just_read_storage` would return, so the log matches the legacy
-            // shape (read_value == written_value for a read).
-            // Note: timestamp logic does not match `zk_evm`, we're only ensuring
-            // that the timestamps are unique. This is fine as long as the witness
-            // is not generated from these logs.
+            // Record the per-access trace; read_value == written_value for a read.
+            // Note: timestamp logic does not match `zk_evm`; we only ensure
+            // timestamps are unique, which is fine as the witness is not
+            // generated from these logs.
             self.storage_logs.push(LogQuery {
                 timestamp: Timestamp(
                     u32::try_from(self.storage_logs.len()).expect("Too many storage logs"),

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -306,27 +306,20 @@ impl WorldDiff {
                 ..log_query
             });
         }
-        let prior_paid = self
-            .storage_writes
-            .as_ref()
-            .get(&(contract, key))
-            .map_or(0, |e| e.paid);
-
         let initial_value = self
             .storage_initial_values
             .entry((contract, key))
             .or_insert_with(|| world.read_storage(contract, key));
 
         if world.is_free_storage_slot(&contract, &key) {
-            // Free write: the value changes but no pubdata is paid, so the
-            // entry keeps its prior paid amount. Single insert.
-            self.storage_writes.insert(
-                (contract, key),
-                StorageWriteEntry {
+            // Free write: the value changes but no pubdata is paid, so the entry
+            // keeps its prior paid amount. One journaling traversal — no
+            // separate read-back of the prior entry.
+            self.storage_writes
+                .update((contract, key), |prev| StorageWriteEntry {
                     value,
-                    paid: prior_paid,
-                },
-            );
+                    paid: prev.map_or(0, |e| e.paid),
+                });
             if self.slot_add_flag((contract, key), SLOT_WRITTEN) {
                 tracer.on_extra_prover_cycles(CycleStats::StorageWrite);
             }
@@ -338,15 +331,18 @@ impl WorldDiff {
         }
 
         let update_cost = world.cost_of_writing_storage(*initial_value, value);
-        let prepaid = prior_paid;
-        // Single insert with the final paid amount (no intermediate write).
-        self.storage_writes.insert(
-            (contract, key),
-            StorageWriteEntry {
-                value,
-                paid: update_cost,
-            },
-        );
+        // Single insert with the final paid amount; `prepaid` (the prior paid)
+        // comes from the replaced entry, avoiding a separate lookup.
+        let prepaid = self
+            .storage_writes
+            .insert(
+                (contract, key),
+                StorageWriteEntry {
+                    value,
+                    paid: update_cost,
+                },
+            )
+            .map_or(0, |e| e.paid);
 
         let refund = if self.slot_add_flag((contract, key), SLOT_WRITTEN) {
             tracer.on_extra_prover_cycles(CycleStats::StorageWrite);

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -670,6 +670,8 @@ const COLD_WRITE_AFTER_WARM_READ_REFUND: u32 = STORAGE_ACCESS_COLD_READ_COST;
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use proptest::{bits, collection::btree_map, prelude::*};
 
     use super::*;
@@ -1014,6 +1016,126 @@ mod tests {
             .protective_reads_iter()
             .next()
             .is_none());
+    }
+
+    /// The set of slots a re-execution verifier surfaces in the deduplicated
+    /// storage log when the trace is dropped: protective reads plus writes.
+    fn dedup_input_set(world_diff: &WorldDiff) -> BTreeSet<(H160, U256)> {
+        let mut set: BTreeSet<(H160, U256)> = world_diff.protective_reads_iter().collect();
+        set.extend(world_diff.storage_writes.as_ref().keys().copied());
+        set
+    }
+
+    #[test]
+    fn external_rollback_restores_opt_out_dedup_inputs_for_retry() {
+        // Models the airbender verifier's bytecode-compression retry in
+        // `execute_tx`: make_snapshot -> run tx -> external_rollback -> re-run
+        // the same tx. In opt-out mode the deduplicated-set inputs (protective
+        // reads + writes) reconstructed after the retry must match a clean run
+        // that never did the discarded first attempt -- i.e. external rollback
+        // fully erases the first attempt's effect on `slot_flags`.
+        let a = (H160::zero(), U256::from(1));
+        let b = (H160::zero(), U256::from(2));
+        let c = (H160::zero(), U256::from(3));
+
+        let mut world = TestWorld::default();
+        world.values.insert(b, U256::from(200));
+        world.values.insert(c, U256::from(300));
+
+        // The kept (second) attempt: read b at depth zero (protective), write c.
+        let run_kept_attempt = |wd: &mut WorldDiff, world: &mut TestWorld| {
+            wd.read_storage(world, &mut (), b.0, b.1, 0);
+            wd.write_storage(world, &mut (), c.0, c.1, U256::from(777), 0);
+        };
+
+        // Retried: snapshot, discarded first attempt (read a, write b), roll the
+        // whole tx back, then run the kept attempt.
+        let mut retried = WorldDiff::default();
+        retried.set_record_storage_logs(false);
+        let snapshot = retried.external_snapshot();
+        retried.read_storage(&mut world, &mut (), a.0, a.1, 0);
+        retried.write_storage(&mut world, &mut (), b.0, b.1, U256::from(999), 0);
+        retried.external_rollback(snapshot);
+        run_kept_attempt(&mut retried, &mut world);
+
+        // Clean: only the kept attempt, no discarded first attempt at all.
+        let mut clean = WorldDiff::default();
+        clean.set_record_storage_logs(false);
+        run_kept_attempt(&mut clean, &mut world);
+
+        // The reconstructed dedup input set matches, and slot `a` (touched only
+        // in the discarded attempt) is absent -- external rollback erased it.
+        assert_eq!(dedup_input_set(&retried), dedup_input_set(&clean));
+        assert_eq!(dedup_input_set(&clean), BTreeSet::from([b, c]));
+        assert!(!dedup_input_set(&retried).contains(&a));
+
+        // Written values and cached initial values agree for every slot in the set.
+        for slot in dedup_input_set(&clean) {
+            assert_eq!(
+                retried.storage_writes.as_ref().get(&slot).map(|e| e.value),
+                clean.storage_writes.as_ref().get(&slot).map(|e| e.value),
+            );
+            assert_eq!(
+                retried.initial_storage_value(slot.0, slot.1).map(|s| s.value),
+                clean.initial_storage_value(slot.0, slot.1).map(|s| s.value),
+            );
+        }
+    }
+
+    #[test]
+    fn protective_read_survives_internal_rollback_but_not_external() {
+        // The protective-read (`did_read_at_depth_zero`) bit is global within a
+        // run: a frame revert (internal rollback) must NOT clear it, but a
+        // whole-tx discard (external rollback) must.
+        let a = (H160::zero(), U256::from(1));
+        let mut world = TestWorld::default();
+        world.values.insert(a, U256::from(100));
+
+        let mut wd = WorldDiff::default();
+        wd.set_record_storage_logs(false);
+
+        let external = wd.external_snapshot();
+        wd.read_storage(&mut world, &mut (), a.0, a.1, 0); // protective read at depth zero
+
+        // A nested write that reverts (internal rollback) must leave the bit set.
+        let internal = wd.snapshot();
+        wd.write_storage(&mut world, &mut (), a.0, a.1, U256::from(999), 0);
+        wd.rollback(internal);
+        assert!(
+            wd.protective_reads_iter().any(|s| s == a),
+            "protective read must survive an internal frame rollback",
+        );
+
+        // A whole-tx external rollback must erase it.
+        wd.external_rollback(external);
+        assert!(
+            !wd.protective_reads_iter().any(|s| s == a),
+            "external rollback must clear the protective read",
+        );
+    }
+
+    #[test]
+    fn protective_read_not_set_when_write_is_pending() {
+        // A read is a protective read only at rollback-depth zero: if a write to
+        // the slot is already pending, the read observes that write rather than
+        // the committed value, so the bit must not be set. The slot still enters
+        // the dedup set -- via `storage_writes`, not as a protective read.
+        let a = (H160::zero(), U256::from(1));
+        let mut world = TestWorld::default();
+        world.values.insert(a, U256::from(100));
+
+        let mut wd = WorldDiff::default();
+        wd.set_record_storage_logs(false);
+
+        wd.write_storage(&mut world, &mut (), a.0, a.1, U256::from(5), 0);
+        let (value, _) = wd.read_storage(&mut world, &mut (), a.0, a.1, 0);
+
+        assert_eq!(value, U256::from(5), "read must observe the pending write");
+        assert!(
+            !wd.protective_reads_iter().any(|s| s == a),
+            "a read with a pending write must not be a protective read",
+        );
+        assert!(dedup_input_set(&wd).contains(&a), "slot is still in the dedup set as a write");
     }
 
     #[test]

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -67,23 +67,29 @@ pub struct WorldDiff {
     /// (whole-VM only), matching the original sets. See the `SLOT_*` consts.
     ///
     /// `SLOT_COMMITTED_READ_Z0` keeps the dedup's `did_read_at_depth_zero`
-    /// predicate: set only by `read_storage_inner`, only when `storage_writes`
-    /// has no pending write for the slot at read time.
+    /// predicate: set only by `read_storage_inner`, only in opt-out mode, and
+    /// only when `storage_writes` has no pending write for the slot at read time.
     slot_flags: RollbackableMap<(H160, U256), u8>,
 
     // This is never rolled back. It is just a cache to avoid asking these from DB every time.
     storage_initial_values: BTreeMap<(H160, U256), StorageSlot>,
 
-    /// When set, `read_storage_inner` / `write_storage` skip appending to the
-    /// per-access `storage_logs` / `rollback_storage_logs` trace. Configured
-    /// once before execution via [`Self::set_record_storage_logs`]; never
-    /// rolled back. Defaults to `false` (recording on), so consumers that
-    /// build an in-circuit storage argument from `storage_log_queries()`
-    /// (e.g. Boojum witness generation via `sort_storage_access_queries`) are
-    /// unaffected. Re-execution verifiers that derive the deduplicated set
-    /// from the `SLOT_COMMITTED_READ_Z0` flag + `storage_writes` and have no
-    /// in-circuit storage argument (e.g. Airbender) opt out to drop the
-    /// trace's memory cost.
+    /// Selects between two mutually exclusive bookkeeping modes, configured once
+    /// before execution via [`Self::set_record_storage_logs`]; never rolled back.
+    ///
+    /// Defaults to `false` (recording on): `read_storage_inner` / `write_storage`
+    /// append the per-access `storage_logs` / `rollback_storage_logs` trace and
+    /// otherwise behave exactly like the pre-optimization base (read-only slots
+    /// are *not* cached in `storage_initial_values`). This is what consumers that
+    /// build an in-circuit storage argument from `storage_log_queries()` need
+    /// (e.g. Boojum witness generation via `sort_storage_access_queries`).
+    ///
+    /// When `true`, the trace is dropped and instead the inputs a re-execution
+    /// verifier needs are recorded: the `SLOT_COMMITTED_READ_Z0` flag and the
+    /// read-only `storage_initial_values` cache. A verifier with no in-circuit
+    /// storage argument (e.g. Airbender) derives the deduplicated set from the
+    /// flag + `storage_writes`, dropping the trace's memory cost (~270 MiB on
+    /// large batches) without adding any per-read map entries to Boojum's path.
     skip_storage_logs: bool,
 }
 
@@ -126,8 +132,19 @@ impl WorldDiff {
     /// memory cost (~270 MiB on large batches).
     ///
     /// Must be called before any storage access; toggling mid-execution would
-    /// leave a partial trace.
+    /// leave a partial trace (recording) or partial dedup state (opt-out).
+    /// Enforced by the assertion below rather than left to the caller.
+    ///
+    /// # Panics
+    /// Panics if any storage slot has already been read or written.
     pub fn set_record_storage_logs(&mut self, record: bool) {
+        assert!(
+            self.storage_logs.is_empty()
+                && self.storage_writes.as_ref().is_empty()
+                && self.slot_flags.as_ref().is_empty()
+                && self.storage_initial_values.is_empty(),
+            "set_record_storage_logs must be called before any storage access"
+        );
         self.skip_storage_logs = !record;
     }
 
@@ -207,29 +224,35 @@ impl WorldDiff {
         }
 
         self.pubdata_costs.push(0);
-        // Cache the initial value on first read so downstream summarizers can
-        // recover it without a separate backend call (write_storage already
-        // caches this for writes).
-        let initial_value = self
-            .storage_initial_values
-            .entry((contract, key))
-            .or_insert_with(|| world.read_storage(contract, key))
-            .value;
-        // Live write for this slot? If so, that's the current value; otherwise
-        // the slot still reads its initial. One backend call total (only on
-        // the first read of a slot), versus the previous path which routed
-        // through `just_read_storage` *and* `world.read_storage`.
-        let live_write = self
-            .storage_writes
-            .as_ref()
-            .get(&(contract, key))
-            .map(|e| e.value);
-        let value = live_write.unwrap_or(initial_value);
-        if live_write.is_none() {
-            // No pending write for this slot at read time — mirrors the dedup
-            // function's `did_read_at_depth_zero` flag.
-            self.slot_add_flag((contract, key), SLOT_COMMITTED_READ_Z0);
-        }
+        let value = if self.skip_storage_logs {
+            // Opt-out mode: no per-access trace is kept, so the deduplicated set
+            // is derived from the maps instead. Cache the initial value on first
+            // read (write_storage already caches for writes) so it can be
+            // recovered without a separate backend call, and record the
+            // depth-zero read predicate.
+            let initial_value = self
+                .storage_initial_values
+                .entry((contract, key))
+                .or_insert_with(|| world.read_storage(contract, key))
+                .value;
+            let live_write = self
+                .storage_writes
+                .as_ref()
+                .get(&(contract, key))
+                .map(|e| e.value);
+            if live_write.is_none() {
+                // No pending write for this slot at read time — mirrors the dedup
+                // function's `did_read_at_depth_zero` flag.
+                self.slot_add_flag((contract, key), SLOT_COMMITTED_READ_Z0);
+            }
+            live_write.unwrap_or(initial_value)
+        } else {
+            // Boojum mode: behave exactly like the pre-optimization base — read
+            // the value without populating `storage_initial_values` for
+            // read-only slots, so memory behavior is unchanged. The dedup-input
+            // bookkeeping above is the opt-out path's alternative to this trace.
+            self.just_read_storage(world, contract, key)
+        };
         if !self.skip_storage_logs {
             // Boojum mode: accumulate the per-access trace. `value` equals what
             // `just_read_storage` would return, so the log matches the legacy
@@ -989,6 +1012,37 @@ mod tests {
                 .map(|s| s.value),
             Some(U256::zero())
         );
+    }
+
+    #[test]
+    fn recording_mode_does_not_cache_read_only_slots() {
+        // P2 regression: in default (recording / Boojum) mode a read-only slot
+        // must not be added to `storage_initial_values`, so memory behavior
+        // matches the pre-optimization base. The trace still records the read.
+        let mut world_diff = WorldDiff::default();
+        let mut world = TestWorld::default();
+        let (contract, key) = (H160::zero(), U256::from(1));
+
+        let (value, _) = world_diff.read_storage(&mut world, &mut (), contract, key, 0);
+        assert_eq!(value, U256::zero());
+
+        assert_eq!(world_diff.storage_log_queries().len(), 1);
+        assert!(world_diff.initial_storage_value(contract, key).is_none());
+        assert!(world_diff
+            .committed_reads_at_depth_zero_iter()
+            .next()
+            .is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "before any storage access")]
+    fn set_record_storage_logs_after_access_panics() {
+        // P3 regression: the mode switch must reject being toggled once any
+        // storage access has happened, rather than silently corrupting state.
+        let mut world_diff = WorldDiff::default();
+        let mut world = TestWorld::default();
+        world_diff.read_storage(&mut world, &mut (), H160::zero(), U256::from(1), 0);
+        world_diff.set_record_storage_logs(false);
     }
 
     #[test]

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -215,14 +215,7 @@ impl WorldDiff {
 
         self.pubdata_costs.push(0);
         let value = if self.skip_storage_logs {
-            // Opt-out mode: no trace is kept, so record what the deduplicated set
-            // is derived from instead — cache the initial value on first read
-            // (writes already cache it) and flag a depth-zero read.
-            let initial_value = self
-                .storage_initial_values
-                .entry((contract, key))
-                .or_insert_with(|| world.read_storage(contract, key))
-                .value;
+            // Opt-out mode: no trace kept; record the dedup inputs instead.
             let live_write = self
                 .storage_writes
                 .as_ref()
@@ -231,7 +224,13 @@ impl WorldDiff {
             if let Some(value) = live_write {
                 value
             } else {
-                // No pending write at read time: `did_read_at_depth_zero`.
+                // No pending write: cache the initial value (writes already
+                // cache it) and flag the depth-zero read.
+                let initial_value = self
+                    .storage_initial_values
+                    .entry((contract, key))
+                    .or_insert_with(|| world.read_storage(contract, key))
+                    .value;
                 self.slot_add_flag((contract, key), SLOT_PROTECTIVE_READ);
                 initial_value
             }
@@ -401,6 +400,11 @@ impl WorldDiff {
     /// Returns the initial (pre-batch) value of a slot if it has been
     /// touched by a read or write during execution. Used by per-slot summary
     /// derivation in place of walking the `storage_logs` trace.
+    ///
+    /// The set of slots returning `Some` depends on the recording mode (see
+    /// [`Self::set_record_storage_logs`]): with the trace disabled, read-only
+    /// slots are cached and reported here; in the default mode only written
+    /// slots are.
     pub fn initial_storage_value(&self, contract: H160, key: U256) -> Option<crate::StorageSlot> {
         self.storage_initial_values.get(&(contract, key)).copied()
     }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -13,13 +13,30 @@ use crate::{
     StorageInterface, StorageSlot,
 };
 
+/// Merged value for `storage_writes`: pending written value + pubdata paid
+/// (formerly the separate `storage_changes` + `paid_changes` maps).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StorageWriteEntry {
+    /// Pending written value for the slot.
+    pub value: U256,
+    /// Pubdata cost paid for writing this slot (0 for free-storage slots).
+    pub paid: u32,
+}
+
+/// Per-slot access flags packed into `WorldDiff::slot_flags` (one byte per
+/// `(address, key)`), replacing three separate `(address, key)` sets.
+const SLOT_READ: u8 = 1;
+const SLOT_WRITTEN: u8 = 1 << 1;
+const SLOT_COMMITTED_READ_Z0: u8 = 1 << 2;
+
 /// Pending modifications to the global state that are executed at the end of a block.
 /// In other words, side effects.
 #[derive(Debug, Default)]
 pub struct WorldDiff {
     // These are rolled back on revert or panic (and when the whole VM is rolled back).
-    storage_changes: RollbackableMap<(H160, U256), U256>,
-    paid_changes: RollbackableMap<(H160, U256), u32>,
+    /// Pending storage writes (value + pubdata paid), merged from the former
+    /// `storage_changes` + `paid_changes` to store the (address, key) once.
+    storage_writes: RollbackableMap<(H160, U256), StorageWriteEntry>,
     transient_storage_changes: RollbackableMap<(H160, U256), U256>,
     events: RollbackableLog<Event>,
     l2_to_l1_logs: RollbackableLog<L2ToL1Log>,
@@ -28,22 +45,6 @@ pub struct WorldDiff {
     pubdata_costs: RollbackableLog<i32>,
     storage_logs: Vec<LogQuery>,
     rollback_storage_logs: Vec<LogQuery>,
-    /// Slots that were *committed-read at depth zero* — read at a moment when
-    /// there was no pending write for that slot. This is the dedup's
-    /// `did_read_at_depth_zero` predicate, materialized incrementally so the
-    /// verifier can derive deduplicated storage logs without the full
-    /// `storage_logs` trace.
-    ///
-    /// Why not just use `read_storage_slots`?
-    ///   `read_storage_slots` also gets populated by `write_storage` (for
-    ///   refund/cold-write tracking) and is *not* rolled back on internal
-    ///   frame revert. So a slot whose only operation was a write that
-    ///   reverted still ends up in `read_storage_slots`. The dedup correctly
-    ///   skips such a slot; `committed_reads_at_depth_zero` matches that
-    ///   semantic by only being added by `read_storage_inner` and only when
-    ///   `storage_changes` is empty for the slot at the time of read.
-    committed_reads_at_depth_zero: RollbackableSet<(H160, U256)>,
-
     // The fields below are only rolled back when the whole VM is rolled back.
     /// Tracks decommit visibility state for each bytecode hash.
     ///
@@ -60,8 +61,15 @@ pub struct WorldDiff {
     ///
     /// This follows external snapshot / rollback semantics together with `decommitted_hashes`.
     decommit_pinned_pages: RollbackableSet<u32>,
-    read_storage_slots: RollbackableSet<(H160, U256)>,
-    written_storage_slots: RollbackableSet<(H160, U256)>,
+    /// Per-slot access flags merged from three former `(address, key)` sets
+    /// (read / written / committed-read-at-depth-zero) so the 52-byte key is
+    /// stored once instead of three times. External-rollback semantics
+    /// (whole-VM only), matching the original sets. See the `SLOT_*` consts.
+    ///
+    /// `SLOT_COMMITTED_READ_Z0` keeps the dedup's `did_read_at_depth_zero`
+    /// predicate: set only by `read_storage_inner`, only when `storage_writes`
+    /// has no pending write for the slot at read time.
+    slot_flags: RollbackableMap<(H160, U256), u8>,
 
     // This is never rolled back. It is just a cache to avoid asking these from DB every time.
     storage_initial_values: BTreeMap<(H160, U256), StorageSlot>,
@@ -73,7 +81,7 @@ pub struct WorldDiff {
     /// build an in-circuit storage argument from `storage_log_queries()`
     /// (e.g. Boojum witness generation via `sort_storage_access_queries`) are
     /// unaffected. Re-execution verifiers that derive the deduplicated set
-    /// from `committed_reads_at_depth_zero` + `storage_changes` and have no
+    /// from the `SLOT_COMMITTED_READ_Z0` flag + `storage_writes` and have no
     /// in-circuit storage argument (e.g. Airbender) opt out to drop the
     /// trace's memory cost.
     skip_storage_logs: bool,
@@ -84,9 +92,7 @@ pub(crate) struct ExternalSnapshot {
     internal_snapshot: Snapshot,
     pub(crate) decommitted_hashes: <RollbackableMap<U256, DecommitState> as Rollback>::Snapshot,
     decommit_pinned_pages: <RollbackableSet<u32> as Rollback>::Snapshot,
-    read_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
-    written_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
-    committed_reads_at_depth_zero: <RollbackableSet<(H160, U256)> as Rollback>::Snapshot,
+    slot_flags: <RollbackableMap<(H160, U256), u8> as Rollback>::Snapshot,
     storage_refunds: <RollbackableLog<u32> as Rollback>::Snapshot,
     pubdata_costs: <RollbackableLog<i32> as Rollback>::Snapshot,
 }
@@ -115,8 +121,8 @@ impl WorldDiff {
     /// an in-circuit storage argument from `storage_log_queries()` (e.g. Boojum
     /// witness generation via `sort_storage_access_queries`). A re-execution
     /// verifier with no in-circuit storage argument (e.g. Airbender), which
-    /// derives the deduplicated storage set from `committed_reads_at_depth_zero` +
-    /// `storage_changes` instead, can pass `false` to avoid the trace's
+    /// derives the deduplicated storage set from the `SLOT_COMMITTED_READ_Z0`
+    /// flag + `storage_writes` instead, can pass `false` to avoid the trace's
     /// memory cost (~270 MiB on large batches).
     ///
     /// Must be called before any storage access; toggling mid-execution would
@@ -137,6 +143,19 @@ impl WorldDiff {
         self.events.reserve(events);
         self.pubdata_costs.reserve(pubdata_costs);
         self.storage_refunds.reserve(storage_refunds);
+    }
+
+    /// Set `flag` on a slot's access-flags entry, returning `true` iff the flag
+    /// was newly set (mirrors the former per-set `RollbackableSet::add`). The
+    /// 52-byte `(address, key)` is stored once across all three flags.
+    fn slot_add_flag(&mut self, key: (H160, U256), flag: u8) -> bool {
+        let cur = self.slot_flags.as_ref().get(&key).copied().unwrap_or(0);
+        if cur & flag == 0 {
+            self.slot_flags.insert(key, cur | flag);
+            true
+        } else {
+            false
+        }
     }
 
     /// Returns the storage slot's value and a refund based on its hot/cold status.
@@ -182,7 +201,7 @@ impl WorldDiff {
         key: U256,
         tx_number_in_block: u16,
     ) -> (U256, bool) {
-        let newly_added = self.read_storage_slots.add((contract, key));
+        let newly_added = self.slot_add_flag((contract, key), SLOT_READ);
         if newly_added {
             tracer.on_extra_prover_cycles(CycleStats::StorageRead);
         }
@@ -200,12 +219,16 @@ impl WorldDiff {
         // the slot still reads its initial. One backend call total (only on
         // the first read of a slot), versus the previous path which routed
         // through `just_read_storage` *and* `world.read_storage`.
-        let live_write = self.storage_changes.as_ref().get(&(contract, key)).copied();
+        let live_write = self
+            .storage_writes
+            .as_ref()
+            .get(&(contract, key))
+            .map(|e| e.value);
         let value = live_write.unwrap_or(initial_value);
         if live_write.is_none() {
             // No pending write for this slot at read time — mirrors the dedup
             // function's `did_read_at_depth_zero` flag.
-            self.committed_reads_at_depth_zero.add((contract, key));
+            self.slot_add_flag((contract, key), SLOT_COMMITTED_READ_Z0);
         }
         if !self.skip_storage_logs {
             // Boojum mode: accumulate the per-access trace. `value` equals what
@@ -241,11 +264,10 @@ impl WorldDiff {
         contract: H160,
         key: U256,
     ) -> U256 {
-        self.storage_changes
+        self.storage_writes
             .as_ref()
             .get(&(contract, key))
-            .copied()
-            .unwrap_or_else(|| world.read_storage_value(contract, key))
+            .map_or_else(|| world.read_storage_value(contract, key), |e| e.value)
     }
 
     /// Returns the refund based the hot/cold status of the storage slot and the change in pubdata.
@@ -282,7 +304,11 @@ impl WorldDiff {
                 ..log_query
             });
         }
-        self.storage_changes.insert((contract, key), value);
+        let prior_paid = self
+            .storage_writes
+            .as_ref()
+            .get(&(contract, key))
+            .map_or(0, |e| e.paid);
 
         let initial_value = self
             .storage_initial_values
@@ -290,10 +316,19 @@ impl WorldDiff {
             .or_insert_with(|| world.read_storage(contract, key));
 
         if world.is_free_storage_slot(&contract, &key) {
-            if self.written_storage_slots.add((contract, key)) {
+            // Free write: the value changes but no pubdata is paid, so the
+            // entry keeps its prior paid amount. Single insert.
+            self.storage_writes.insert(
+                (contract, key),
+                StorageWriteEntry {
+                    value,
+                    paid: prior_paid,
+                },
+            );
+            if self.slot_add_flag((contract, key), SLOT_WRITTEN) {
                 tracer.on_extra_prover_cycles(CycleStats::StorageWrite);
             }
-            self.read_storage_slots.add((contract, key));
+            self.slot_add_flag((contract, key), SLOT_READ);
 
             self.storage_refunds.push(WARM_WRITE_REFUND);
             self.pubdata_costs.push(0);
@@ -301,15 +336,20 @@ impl WorldDiff {
         }
 
         let update_cost = world.cost_of_writing_storage(*initial_value, value);
-        let prepaid = self
-            .paid_changes
-            .insert((contract, key), update_cost)
-            .unwrap_or(0);
+        let prepaid = prior_paid;
+        // Single insert with the final paid amount (no intermediate write).
+        self.storage_writes.insert(
+            (contract, key),
+            StorageWriteEntry {
+                value,
+                paid: update_cost,
+            },
+        );
 
-        let refund = if self.written_storage_slots.add((contract, key)) {
+        let refund = if self.slot_add_flag((contract, key), SLOT_WRITTEN) {
             tracer.on_extra_prover_cycles(CycleStats::StorageWrite);
 
-            if self.read_storage_slots.add((contract, key)) {
+            if self.slot_add_flag((contract, key), SLOT_READ) {
                 0
             } else {
                 COLD_WRITE_AFTER_WARM_READ_REFUND
@@ -343,11 +383,15 @@ impl WorldDiff {
     }
 
     /// Iterates over slots that were committed-read at depth zero (the
-    /// dedup's `did_read_at_depth_zero` set). Combined with `storage_changes`
+    /// dedup's `did_read_at_depth_zero` set). Combined with `storage_writes`
     /// this is the set of slots that appear in the deduplicated storage logs.
-    /// Sorted by (address, key) via the `BTreeSet` backing.
+    /// Sorted by (address, key) via the `slot_flags` map's `BTreeMap` backing.
     pub fn committed_reads_at_depth_zero_iter(&self) -> impl Iterator<Item = (H160, U256)> + '_ {
-        self.committed_reads_at_depth_zero.as_ref().iter().copied()
+        self.slot_flags
+            .as_ref()
+            .iter()
+            .filter(|(_, f)| **f & SLOT_COMMITTED_READ_Z0 != 0)
+            .map(|(k, _)| *k)
     }
 
     /// Returns the initial (pre-batch) value of a slot if it has been
@@ -372,26 +416,26 @@ impl WorldDiff {
         &self.storage_logs[snapshot.storage_logs_len..]
     }
 
-    #[doc(hidden)] // duplicates `StateInterface::get_storage_state()`, but we use random access in some places
-    pub fn get_storage_state(&self) -> &BTreeMap<(H160, U256), U256> {
-        self.storage_changes.as_ref()
+    #[doc(hidden)] // like `StateInterface::get_storage_state()` but exposes the full `StorageWriteEntry` (value + paid) for random access
+    pub fn get_storage_state(&self) -> &BTreeMap<(H160, U256), StorageWriteEntry> {
+        self.storage_writes.as_ref()
     }
 
     /// Gets changes for all touched storage slots.
     pub fn get_storage_changes(&self) -> impl Iterator<Item = ((H160, U256), StorageChange)> + '_ {
-        self.storage_changes
+        self.storage_writes
             .as_ref()
             .iter()
-            .filter_map(|(key, &value)| {
+            .filter_map(|(key, entry)| {
                 let initial_slot = &self.storage_initial_values[key];
-                if initial_slot.value == value {
+                if initial_slot.value == entry.value {
                     None
                 } else {
                     Some((
                         *key,
                         StorageChange {
                             before: initial_slot.value,
-                            after: value,
+                            after: entry.value,
                             is_initial: initial_slot.is_write_initial,
                         },
                     ))
@@ -404,16 +448,16 @@ impl WorldDiff {
         &self,
         snapshot: &Snapshot,
     ) -> impl Iterator<Item = ((H160, U256), StorageChange)> + '_ {
-        self.storage_changes
-            .changes_after(snapshot.storage_changes)
+        self.storage_writes
+            .changes_after(snapshot.storage_writes)
             .into_iter()
             .map(|(key, (before, after))| {
                 let initial = self.storage_initial_values[&key];
                 (
                     key,
                     StorageChange {
-                        before: before.unwrap_or(initial.value),
-                        after,
+                        before: before.map_or(initial.value, |e| e.value),
+                        after: after.value,
                         is_initial: initial.is_write_initial,
                     },
                 )
@@ -500,8 +544,7 @@ impl WorldDiff {
     /// Get a snapshot for selecting which logs & co. to output using [`Self::events_after()`] and other methods.
     pub fn snapshot(&self) -> Snapshot {
         Snapshot {
-            storage_changes: self.storage_changes.snapshot(),
-            paid_changes: self.paid_changes.snapshot(),
+            storage_writes: self.storage_writes.snapshot(),
             events: self.events.snapshot(),
             l2_to_l1_logs: self.l2_to_l1_logs.snapshot(),
             transient_storage_changes: self.transient_storage_changes.snapshot(),
@@ -528,8 +571,7 @@ impl WorldDiff {
 
     #[allow(clippy::needless_pass_by_value)] // intentional: we require a snapshot to be rolled back to no more than once
     pub(crate) fn rollback(&mut self, snapshot: Snapshot) {
-        self.storage_changes.rollback(snapshot.storage_changes);
-        self.paid_changes.rollback(snapshot.paid_changes);
+        self.storage_writes.rollback(snapshot.storage_writes);
         self.events.rollback(snapshot.events);
         self.l2_to_l1_logs.rollback(snapshot.l2_to_l1_logs);
         self.transient_storage_changes
@@ -551,9 +593,7 @@ impl WorldDiff {
             },
             decommitted_hashes: self.decommitted_hashes.snapshot(),
             decommit_pinned_pages: self.decommit_pinned_pages.snapshot(),
-            read_storage_slots: self.read_storage_slots.snapshot(),
-            written_storage_slots: self.written_storage_slots.snapshot(),
-            committed_reads_at_depth_zero: self.committed_reads_at_depth_zero.snapshot(),
+            slot_flags: self.slot_flags.snapshot(),
             storage_refunds: self.storage_refunds.snapshot(),
             pubdata_costs: self.pubdata_costs.snapshot(),
         }
@@ -570,20 +610,14 @@ impl WorldDiff {
             .rollback(snapshot.decommitted_hashes);
         self.decommit_pinned_pages
             .rollback(snapshot.decommit_pinned_pages);
-        self.read_storage_slots
-            .rollback(snapshot.read_storage_slots);
-        self.written_storage_slots
-            .rollback(snapshot.written_storage_slots);
-        self.committed_reads_at_depth_zero
-            .rollback(snapshot.committed_reads_at_depth_zero);
+        self.slot_flags.rollback(snapshot.slot_flags);
         self.storage_logs.truncate(storage_logs_len);
         self.rollback_storage_logs
             .truncate(rollback_storage_logs_len);
     }
 
     pub(crate) fn delete_history(&mut self) {
-        self.storage_changes.delete_history();
-        self.paid_changes.delete_history();
+        self.storage_writes.delete_history();
         self.transient_storage_changes.delete_history();
         self.events.delete_history();
         self.l2_to_l1_logs.delete_history();
@@ -592,9 +626,7 @@ impl WorldDiff {
         self.pubdata_costs.delete_history();
         self.decommitted_hashes.delete_history();
         self.decommit_pinned_pages.delete_history();
-        self.read_storage_slots.delete_history();
-        self.written_storage_slots.delete_history();
-        self.committed_reads_at_depth_zero.delete_history();
+        self.slot_flags.delete_history();
     }
 
     pub(crate) fn clear_transient_storage(&mut self) {
@@ -606,8 +638,7 @@ impl WorldDiff {
 /// Can be provided to [`WorldDiff::events_after()`] etc. to get data after the snapshot was created.
 #[derive(Clone, PartialEq, Debug)]
 pub struct Snapshot {
-    storage_changes: <RollbackableMap<(H160, U256), U256> as Rollback>::Snapshot,
-    paid_changes: <RollbackableMap<(H160, U256), u32> as Rollback>::Snapshot,
+    storage_writes: <RollbackableMap<(H160, U256), StorageWriteEntry> as Rollback>::Snapshot,
     events: <RollbackableLog<Event> as Rollback>::Snapshot,
     l2_to_l1_logs: <RollbackableLog<L2ToL1Log> as Rollback>::Snapshot,
     transient_storage_changes: <RollbackableMap<(H160, U256), U256> as Rollback>::Snapshot,
@@ -829,6 +860,47 @@ mod tests {
         fn is_free_storage_slot(&self, _: &H160, _: &U256) -> bool {
             false
         }
+    }
+
+    /// A world with a fixed non-zero write cost, to exercise the merged `paid`
+    /// accounting (`prior_paid` / `prepaid`) that `NoWorld`/`TestWorld` (cost 0)
+    /// leave untested.
+    struct CostWorld;
+
+    impl StorageInterface for CostWorld {
+        fn read_storage(&mut self, _: H160, _: U256) -> StorageSlot {
+            StorageSlot::EMPTY
+        }
+
+        fn cost_of_writing_storage(&mut self, _: StorageSlot, _: U256) -> u32 {
+            100
+        }
+
+        fn is_free_storage_slot(&self, _: &H160, _: &U256) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn merged_storage_write_tracks_paid_and_rolls_back() {
+        let mut world_diff = WorldDiff::default();
+        let (contract, key) = (H160::zero(), U256::from(1));
+
+        // First write: prior_paid = 0, entry's paid set to the write cost.
+        world_diff.write_storage(&mut CostWorld, &mut (), contract, key, U256::from(5), 0);
+        let e = world_diff.storage_writes.as_ref()[&(contract, key)];
+        assert_eq!((e.value, e.paid), (U256::from(5), 100));
+
+        // Second write reuses prior_paid (=100) as `prepaid`; entry re-set.
+        let snapshot = world_diff.snapshot();
+        world_diff.write_storage(&mut CostWorld, &mut (), contract, key, U256::from(6), 0);
+        let e = world_diff.storage_writes.as_ref()[&(contract, key)];
+        assert_eq!((e.value, e.paid), (U256::from(6), 100));
+
+        // Rollback restores both the value and the paid amount of the merged entry.
+        world_diff.rollback(snapshot);
+        let e = world_diff.storage_writes.as_ref()[&(contract, key)];
+        assert_eq!((e.value, e.paid), (U256::from(5), 100));
     }
 
     #[derive(Default)]

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -228,13 +228,12 @@ impl WorldDiff {
                 .as_ref()
                 .get(&(contract, key))
                 .map(|e| e.value);
-            match live_write {
-                Some(value) => value,
-                None => {
-                    // No pending write at read time: `did_read_at_depth_zero`.
-                    self.slot_add_flag((contract, key), SLOT_PROTECTIVE_READ);
-                    initial_value
-                }
+            if let Some(value) = live_write {
+                value
+            } else {
+                // No pending write at read time: `did_read_at_depth_zero`.
+                self.slot_add_flag((contract, key), SLOT_PROTECTIVE_READ);
+                initial_value
             }
         } else {
             // Recording mode: read like the pre-optimization base, without

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -155,15 +155,10 @@ impl WorldDiff {
 
     /// Set `flag` on a slot's access-flags entry, returning `true` iff the flag
     /// was newly set (mirrors the former per-set `RollbackableSet::add`). The
-    /// 52-byte `(address, key)` is stored once across all three flags.
+    /// 52-byte `(address, key)` is stored once across all three flags. Single
+    /// map traversal — see [`RollbackableMap::add_flags`].
     fn slot_add_flag(&mut self, key: (H160, U256), flag: u8) -> bool {
-        let cur = self.slot_flags.as_ref().get(&key).copied().unwrap_or(0);
-        if cur & flag == 0 {
-            self.slot_flags.insert(key, cur | flag);
-            true
-        } else {
-            false
-        }
+        self.slot_flags.add_flags(key, flag)
     }
 
     /// Returns the storage slot's value and a refund based on its hot/cold status.

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -28,6 +28,21 @@ pub struct WorldDiff {
     pubdata_costs: RollbackableLog<i32>,
     storage_logs: Vec<LogQuery>,
     rollback_storage_logs: Vec<LogQuery>,
+    /// Slots that were *committed-read at depth zero* — read at a moment when
+    /// there was no pending write for that slot. This is the dedup's
+    /// `did_read_at_depth_zero` predicate, materialized incrementally so the
+    /// verifier can derive deduplicated storage logs without the full
+    /// storage_logs trace.
+    ///
+    /// Why not just use `read_storage_slots`?
+    ///   `read_storage_slots` also gets populated by `write_storage` (for
+    ///   refund/cold-write tracking) and is *not* rolled back on internal
+    ///   frame revert. So a slot whose only operation was a write that
+    ///   reverted still ends up in `read_storage_slots`. The dedup correctly
+    ///   skips such a slot; `committed_reads_at_depth_zero` matches that
+    ///   semantic by only being added by `read_storage_inner` and only when
+    ///   `storage_changes` is empty for the slot at the time of read.
+    committed_reads_at_depth_zero: RollbackableSet<(H160, U256)>,
 
     // The fields below are only rolled back when the whole VM is rolled back.
     /// Tracks decommit visibility state for each bytecode hash.
@@ -59,6 +74,7 @@ pub(crate) struct ExternalSnapshot {
     decommit_pinned_pages: <RollbackableSet<u32> as Rollback>::Snapshot,
     read_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
     written_storage_slots: <RollbackableMap<(H160, U256), ()> as Rollback>::Snapshot,
+    committed_reads_at_depth_zero: <RollbackableSet<(H160, U256)> as Rollback>::Snapshot,
     storage_refunds: <RollbackableLog<u32> as Rollback>::Snapshot,
     pubdata_costs: <RollbackableLog<i32> as Rollback>::Snapshot,
 }
@@ -80,6 +96,20 @@ pub(crate) enum DecommitState {
 }
 
 impl WorldDiff {
+    /// Reserve capacity for the auxiliary log Vecs (events, pubdata_costs,
+    /// storage_refunds). Each of these doubles during execution and the
+    /// transient peak is non-trivial inside the verifier guest.
+    pub fn reserve_auxiliary_log_capacity(
+        &mut self,
+        events: usize,
+        pubdata_costs: usize,
+        storage_refunds: usize,
+    ) {
+        self.events.reserve(events);
+        self.pubdata_costs.reserve(pubdata_costs);
+        self.storage_refunds.reserve(storage_refunds);
+    }
+
     /// Returns the storage slot's value and a refund based on its hot/cold status.
     pub(crate) fn read_storage(
         &mut self,
@@ -129,24 +159,30 @@ impl WorldDiff {
         }
 
         self.pubdata_costs.push(0);
-        let value = self.just_read_storage(world, contract, key);
-        // Note: timestamp logic does not match `zk_evm`, we're only ensuring that the timestamps
-        // are unique. This is fine as long as we don't need to actually generate witness based on these logs.
-        self.storage_logs.push(LogQuery {
-            timestamp: Timestamp(
-                u32::try_from(self.storage_logs.len()).expect("Too many storage logs"),
-            ),
-            tx_number_in_block,
-            aux_byte: STORAGE_AUX_BYTE,
-            shard_id: 0,
-            address: contract,
-            key,
-            read_value: value,
-            written_value: value,
-            rw_flag: false,
-            rollback: false,
-            is_service: false,
-        });
+        // Cache the initial value on first read so downstream summarizers can
+        // recover it without a separate backend call (write_storage already
+        // caches this for writes).
+        let initial_value = self
+            .storage_initial_values
+            .entry((contract, key))
+            .or_insert_with(|| world.read_storage(contract, key))
+            .value;
+        // Live write for this slot? If so, that's the current value; otherwise
+        // the slot still reads its initial. One backend call total (only on
+        // the first read of a slot), versus the previous path which routed
+        // through `just_read_storage` *and* `world.read_storage`.
+        let live_write = self
+            .storage_changes
+            .as_ref()
+            .get(&(contract, key))
+            .copied();
+        let value = live_write.unwrap_or(initial_value);
+        if live_write.is_none() {
+            // No pending write for this slot at read time — mirrors the dedup
+            // function's `did_read_at_depth_zero` flag.
+            self.committed_reads_at_depth_zero.add((contract, key));
+        }
+        let _ = tx_number_in_block;
         (value, newly_added)
     }
 
@@ -175,26 +211,7 @@ impl WorldDiff {
         value: U256,
         tx_number_in_block: u16,
     ) -> u32 {
-        let read_value = self.just_read_storage(world, contract, key);
-        let log_query = LogQuery {
-            timestamp: Timestamp(u32::try_from(self.storage_logs.len()).unwrap_or(u32::MAX)),
-            tx_number_in_block,
-            aux_byte: STORAGE_AUX_BYTE,
-            shard_id: 0,
-            address: contract,
-            key,
-            read_value,
-            written_value: value,
-            rw_flag: true,
-            rollback: false,
-            is_service: false,
-        };
-        self.storage_logs.push(log_query);
-        self.rollback_storage_logs.push(LogQuery {
-            rollback: true,
-            ..log_query
-        });
-
+        let _ = tx_number_in_block;
         self.storage_changes.insert((contract, key), value);
 
         let initial_value = self
@@ -253,6 +270,21 @@ impl WorldDiff {
     /// Returns recorded pubdata costs for all storage operations.
     pub fn pubdata_costs(&self) -> &[i32] {
         self.pubdata_costs.as_ref()
+    }
+
+    /// Iterates over slots that were committed-read at depth zero (the
+    /// dedup's `did_read_at_depth_zero` set). Combined with `storage_changes`
+    /// this is the set of slots that appear in the deduplicated storage logs.
+    /// Sorted by (address, key) via the BTreeSet backing.
+    pub fn committed_reads_at_depth_zero_iter(&self) -> impl Iterator<Item = (H160, U256)> + '_ {
+        self.committed_reads_at_depth_zero.as_ref().iter().copied()
+    }
+
+    /// Returns the initial (pre-batch) value of a slot if it has been
+    /// touched by a read or write during execution. Used by per-slot summary
+    /// derivation in place of walking the storage_logs trace.
+    pub fn initial_storage_value(&self, contract: H160, key: U256) -> Option<crate::StorageSlot> {
+        self.storage_initial_values.get(&(contract, key)).copied()
     }
 
     /// Returns all recorded storage log queries.
@@ -451,6 +483,7 @@ impl WorldDiff {
             decommit_pinned_pages: self.decommit_pinned_pages.snapshot(),
             read_storage_slots: self.read_storage_slots.snapshot(),
             written_storage_slots: self.written_storage_slots.snapshot(),
+            committed_reads_at_depth_zero: self.committed_reads_at_depth_zero.snapshot(),
             storage_refunds: self.storage_refunds.snapshot(),
             pubdata_costs: self.pubdata_costs.snapshot(),
         }
@@ -471,6 +504,8 @@ impl WorldDiff {
             .rollback(snapshot.read_storage_slots);
         self.written_storage_slots
             .rollback(snapshot.written_storage_slots);
+        self.committed_reads_at_depth_zero
+            .rollback(snapshot.committed_reads_at_depth_zero);
         self.storage_logs.truncate(storage_logs_len);
         self.rollback_storage_logs
             .truncate(rollback_storage_logs_len);
@@ -489,6 +524,7 @@ impl WorldDiff {
         self.decommit_pinned_pages.delete_history();
         self.read_storage_slots.delete_history();
         self.written_storage_slots.delete_history();
+        self.committed_reads_at_depth_zero.delete_history();
     }
 
     pub(crate) fn clear_transient_storage(&mut self) {

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -32,7 +32,7 @@ pub struct WorldDiff {
     /// there was no pending write for that slot. This is the dedup's
     /// `did_read_at_depth_zero` predicate, materialized incrementally so the
     /// verifier can derive deduplicated storage logs without the full
-    /// storage_logs trace.
+    /// `storage_logs` trace.
     ///
     /// Why not just use `read_storage_slots`?
     ///   `read_storage_slots` also gets populated by `write_storage` (for
@@ -115,8 +115,8 @@ impl WorldDiff {
     /// an in-circuit storage argument from `storage_log_queries()` (e.g. Boojum
     /// witness generation via `sort_storage_access_queries`). A re-execution
     /// verifier with no in-circuit storage argument (e.g. Airbender), which
-    /// derives the deduplicated storage set from `committed_reads_at_depth_zero`
-    /// + `storage_changes` instead, can pass `false` to avoid the trace's
+    /// derives the deduplicated storage set from `committed_reads_at_depth_zero` +
+    /// `storage_changes` instead, can pass `false` to avoid the trace's
     /// memory cost (~270 MiB on large batches).
     ///
     /// Must be called before any storage access; toggling mid-execution would
@@ -125,8 +125,8 @@ impl WorldDiff {
         self.skip_storage_logs = !record;
     }
 
-    /// Reserve capacity for the auxiliary log Vecs (events, pubdata_costs,
-    /// storage_refunds). Each of these doubles during execution and the
+    /// Reserve capacity for the auxiliary log Vecs (events, `pubdata_costs`,
+    /// `storage_refunds`). Each of these doubles during execution and the
     /// transient peak is non-trivial inside the verifier guest.
     pub fn reserve_auxiliary_log_capacity(
         &mut self,
@@ -200,11 +200,7 @@ impl WorldDiff {
         // the slot still reads its initial. One backend call total (only on
         // the first read of a slot), versus the previous path which routed
         // through `just_read_storage` *and* `world.read_storage`.
-        let live_write = self
-            .storage_changes
-            .as_ref()
-            .get(&(contract, key))
-            .copied();
+        let live_write = self.storage_changes.as_ref().get(&(contract, key)).copied();
         let value = live_write.unwrap_or(initial_value);
         if live_write.is_none() {
             // No pending write for this slot at read time — mirrors the dedup
@@ -349,14 +345,14 @@ impl WorldDiff {
     /// Iterates over slots that were committed-read at depth zero (the
     /// dedup's `did_read_at_depth_zero` set). Combined with `storage_changes`
     /// this is the set of slots that appear in the deduplicated storage logs.
-    /// Sorted by (address, key) via the BTreeSet backing.
+    /// Sorted by (address, key) via the `BTreeSet` backing.
     pub fn committed_reads_at_depth_zero_iter(&self) -> impl Iterator<Item = (H160, U256)> + '_ {
         self.committed_reads_at_depth_zero.as_ref().iter().copied()
     }
 
     /// Returns the initial (pre-batch) value of a slot if it has been
     /// touched by a read or write during execution. Used by per-slot summary
-    /// derivation in place of walking the storage_logs trace.
+    /// derivation in place of walking the `storage_logs` trace.
     pub fn initial_storage_value(&self, contract: H160, key: U256) -> Option<crate::StorageSlot> {
         self.storage_initial_values.get(&(contract, key)).copied()
     }
@@ -916,7 +912,9 @@ mod tests {
             .committed_reads_at_depth_zero_iter()
             .any(|slot| slot == (contract, key)));
         assert_eq!(
-            world_diff.initial_storage_value(contract, key).map(|s| s.value),
+            world_diff
+                .initial_storage_value(contract, key)
+                .map(|s| s.value),
             Some(U256::zero())
         );
     }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -65,6 +65,18 @@ pub struct WorldDiff {
 
     // This is never rolled back. It is just a cache to avoid asking these from DB every time.
     storage_initial_values: BTreeMap<(H160, U256), StorageSlot>,
+
+    /// When set, `read_storage_inner` / `write_storage` skip appending to the
+    /// per-access `storage_logs` / `rollback_storage_logs` trace. Configured
+    /// once before execution via [`Self::set_record_storage_logs`]; never
+    /// rolled back. Defaults to `false` (recording on), so consumers that
+    /// build an in-circuit storage argument from `storage_log_queries()`
+    /// (e.g. Boojum witness generation via `sort_storage_access_queries`) are
+    /// unaffected. Re-execution verifiers that derive the deduplicated set
+    /// from `committed_reads_at_depth_zero` + `storage_changes` and have no
+    /// in-circuit storage argument (e.g. Airbender) opt out to drop the
+    /// trace's memory cost.
+    skip_storage_logs: bool,
 }
 
 #[derive(Debug)]
@@ -96,6 +108,23 @@ pub(crate) enum DecommitState {
 }
 
 impl WorldDiff {
+    /// Controls whether the per-access storage log trace
+    /// (`storage_logs` / `rollback_storage_logs`) is accumulated.
+    ///
+    /// Recording is **on by default** — it is required by consumers that build
+    /// an in-circuit storage argument from `storage_log_queries()` (e.g. Boojum
+    /// witness generation via `sort_storage_access_queries`). A re-execution
+    /// verifier with no in-circuit storage argument (e.g. Airbender), which
+    /// derives the deduplicated storage set from `committed_reads_at_depth_zero`
+    /// + `storage_changes` instead, can pass `false` to avoid the trace's
+    /// memory cost (~270 MiB on large batches).
+    ///
+    /// Must be called before any storage access; toggling mid-execution would
+    /// leave a partial trace.
+    pub fn set_record_storage_logs(&mut self, record: bool) {
+        self.skip_storage_logs = !record;
+    }
+
     /// Reserve capacity for the auxiliary log Vecs (events, pubdata_costs,
     /// storage_refunds). Each of these doubles during execution and the
     /// transient peak is non-trivial inside the verifier guest.
@@ -182,7 +211,29 @@ impl WorldDiff {
             // function's `did_read_at_depth_zero` flag.
             self.committed_reads_at_depth_zero.add((contract, key));
         }
-        let _ = tx_number_in_block;
+        if !self.skip_storage_logs {
+            // Boojum mode: accumulate the per-access trace. `value` equals what
+            // `just_read_storage` would return, so the log matches the legacy
+            // shape (read_value == written_value for a read).
+            // Note: timestamp logic does not match `zk_evm`, we're only ensuring
+            // that the timestamps are unique. This is fine as long as the witness
+            // is not generated from these logs.
+            self.storage_logs.push(LogQuery {
+                timestamp: Timestamp(
+                    u32::try_from(self.storage_logs.len()).expect("Too many storage logs"),
+                ),
+                tx_number_in_block,
+                aux_byte: STORAGE_AUX_BYTE,
+                shard_id: 0,
+                address: contract,
+                key,
+                read_value: value,
+                written_value: value,
+                rw_flag: false,
+                rollback: false,
+                is_service: false,
+            });
+        }
         (value, newly_added)
     }
 
@@ -211,7 +262,30 @@ impl WorldDiff {
         value: U256,
         tx_number_in_block: u16,
     ) -> u32 {
-        let _ = tx_number_in_block;
+        if !self.skip_storage_logs {
+            // Boojum mode: record the write and its rollback twin before the
+            // change lands, so `read_value` is the pre-write value (matching
+            // the legacy trace shape).
+            let read_value = self.just_read_storage(world, contract, key);
+            let log_query = LogQuery {
+                timestamp: Timestamp(u32::try_from(self.storage_logs.len()).unwrap_or(u32::MAX)),
+                tx_number_in_block,
+                aux_byte: STORAGE_AUX_BYTE,
+                shard_id: 0,
+                address: contract,
+                key,
+                read_value,
+                written_value: value,
+                rw_flag: true,
+                rollback: false,
+                is_service: false,
+            };
+            self.storage_logs.push(log_query);
+            self.rollback_storage_logs.push(LogQuery {
+                rollback: true,
+                ..log_query
+            });
+        }
         self.storage_changes.insert((contract, key), value);
 
         let initial_value = self
@@ -812,6 +886,39 @@ mod tests {
         assert!(logs[3].rw_flag && logs[3].rollback);
         assert_eq!(logs[3].read_value, logs[2].read_value);
         assert_eq!(logs[3].written_value, logs[2].written_value);
+    }
+
+    #[test]
+    fn skip_storage_logs_drops_trace_but_keeps_dedup_inputs() {
+        let mut world_diff = WorldDiff::default();
+        world_diff.set_record_storage_logs(false);
+        let mut world = TestWorld::default();
+        let contract = H160::zero();
+        let key = U256::from(1);
+
+        // Same access pattern as `storage_logs_include_reads_writes_and_rollbacks`.
+        let (value, _) = world_diff.read_storage(&mut world, &mut (), contract, key, 0);
+        assert_eq!(value, U256::zero());
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(10), 0);
+        let snapshot = world_diff.snapshot();
+        world_diff.write_storage(&mut world, &mut (), contract, key, U256::from(20), 0);
+        world_diff.append_rollback_logs(&snapshot);
+        world_diff.rollback(snapshot);
+
+        // The per-access trace is empty — the whole point of opting out.
+        assert!(world_diff.storage_log_queries().is_empty());
+        assert!(world_diff.rollback_storage_logs.is_empty());
+
+        // ...but the maps a re-execution verifier derives the deduplicated set
+        // from are still populated: the slot was committed-read at depth zero
+        // and its initial value cached.
+        assert!(world_diff
+            .committed_reads_at_depth_zero_iter()
+            .any(|slot| slot == (contract, key)));
+        assert_eq!(
+            world_diff.initial_storage_value(contract, key).map(|s| s.value),
+            Some(U256::zero())
+        );
     }
 
     #[test]

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -224,11 +224,14 @@ impl WorldDiff {
                 .as_ref()
                 .get(&(contract, key))
                 .map(|e| e.value);
-            if live_write.is_none() {
-                // No pending write at read time: `did_read_at_depth_zero`.
-                self.slot_add_flag((contract, key), SLOT_COMMITTED_READ_Z0);
+            match live_write {
+                Some(value) => value,
+                None => {
+                    // No pending write at read time: `did_read_at_depth_zero`.
+                    self.slot_add_flag((contract, key), SLOT_COMMITTED_READ_Z0);
+                    initial_value
+                }
             }
-            live_write.unwrap_or(initial_value)
         } else {
             // Recording mode: read like the pre-optimization base, without
             // caching read-only slots (keeps Boojum's memory unchanged).

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -27,7 +27,11 @@ pub struct StorageWriteEntry {
 /// `(address, key)`), replacing three separate `(address, key)` sets.
 const SLOT_READ: u8 = 1;
 const SLOT_WRITTEN: u8 = 1 << 1;
-const SLOT_COMMITTED_READ_Z0: u8 = 1 << 2;
+/// Set on a read at rollback-depth zero (`did_read_at_depth_zero` in
+/// `circuit_sequencer_api::sort_storage_access`). Downstream this forces a
+/// *protective read* into the deduplicated storage set — unless the slot is
+/// also written, in which case the write entry subsumes it.
+const SLOT_PROTECTIVE_READ: u8 = 1 << 2;
 
 /// Pending modifications to the global state that are executed at the end of a block.
 /// In other words, side effects.
@@ -62,11 +66,11 @@ pub struct WorldDiff {
     /// This follows external snapshot / rollback semantics together with `decommitted_hashes`.
     decommit_pinned_pages: RollbackableSet<u32>,
     /// Per-slot access flags merged from three former `(address, key)` sets
-    /// (read / written / committed-read-at-depth-zero) so the 52-byte key is
-    /// stored once instead of three times. External-rollback semantics
-    /// (whole-VM only), matching the original sets. See the `SLOT_*` consts.
+    /// (read / written / protective-read) so the 52-byte key is stored once
+    /// instead of three times. External-rollback semantics (whole-VM only),
+    /// matching the original sets. See the `SLOT_*` consts.
     ///
-    /// `SLOT_COMMITTED_READ_Z0` keeps the dedup's `did_read_at_depth_zero`
+    /// `SLOT_PROTECTIVE_READ` keeps the dedup's `did_read_at_depth_zero`
     /// predicate: set only by `read_storage_inner`, only in opt-out mode, and
     /// only when `storage_writes` has no pending write for the slot at read time.
     slot_flags: RollbackableMap<(H160, U256), u8>,
@@ -81,7 +85,7 @@ pub struct WorldDiff {
     /// - `false` (default): append the `storage_logs` / `rollback_storage_logs`
     ///   trace; otherwise behave like the pre-optimization base — read-only slots
     ///   are *not* cached in `storage_initial_values`.
-    /// - `true`: drop the trace; instead record the `SLOT_COMMITTED_READ_Z0` flag
+    /// - `true`: drop the trace; instead record the `SLOT_PROTECTIVE_READ` flag
     ///   and the read-only `storage_initial_values` cache, the inputs a
     ///   re-execution verifier derives the deduplicated set from.
     skip_storage_logs: bool,
@@ -121,7 +125,7 @@ impl WorldDiff {
     /// an in-circuit storage argument from `storage_log_queries()` (e.g. Boojum
     /// witness generation via `sort_storage_access_queries`). A re-execution
     /// verifier with no in-circuit storage argument (e.g. Airbender), which
-    /// derives the deduplicated storage set from the `SLOT_COMMITTED_READ_Z0`
+    /// derives the deduplicated storage set from the `SLOT_PROTECTIVE_READ`
     /// flag + `storage_writes` instead, can pass `false` to avoid the trace's
     /// memory cost (~270 MiB on large batches).
     ///
@@ -228,7 +232,7 @@ impl WorldDiff {
                 Some(value) => value,
                 None => {
                     // No pending write at read time: `did_read_at_depth_zero`.
-                    self.slot_add_flag((contract, key), SLOT_COMMITTED_READ_Z0);
+                    self.slot_add_flag((contract, key), SLOT_PROTECTIVE_READ);
                     initial_value
                 }
             }
@@ -382,15 +386,16 @@ impl WorldDiff {
         self.pubdata_costs.as_ref()
     }
 
-    /// Iterates over slots that were committed-read at depth zero (the
-    /// dedup's `did_read_at_depth_zero` set). Combined with `storage_writes`
-    /// this is the set of slots that appear in the deduplicated storage logs.
-    /// Sorted by (address, key) via the `slot_flags` map's `BTreeMap` backing.
-    pub fn committed_reads_at_depth_zero_iter(&self) -> impl Iterator<Item = (H160, U256)> + '_ {
+    /// Iterates over slots that need a *protective read* — read at rollback-depth
+    /// zero (the dedup's `did_read_at_depth_zero` set). Combined with
+    /// `storage_writes` this is the set of slots that appear in the deduplicated
+    /// storage logs. Sorted by (address, key) via the `slot_flags` map's
+    /// `BTreeMap` backing.
+    pub fn protective_reads_iter(&self) -> impl Iterator<Item = (H160, U256)> + '_ {
         self.slot_flags
             .as_ref()
             .iter()
-            .filter(|(_, f)| **f & SLOT_COMMITTED_READ_Z0 != 0)
+            .filter(|(_, f)| **f & SLOT_PROTECTIVE_READ != 0)
             .map(|(k, _)| *k)
     }
 
@@ -978,10 +983,10 @@ mod tests {
         assert!(world_diff.rollback_storage_logs.is_empty());
 
         // ...but the maps a re-execution verifier derives the deduplicated set
-        // from are still populated: the slot was committed-read at depth zero
-        // and its initial value cached.
+        // from are still populated: the slot needs a protective read (read at
+        // depth zero) and its initial value cached.
         assert!(world_diff
-            .committed_reads_at_depth_zero_iter()
+            .protective_reads_iter()
             .any(|slot| slot == (contract, key)));
         assert_eq!(
             world_diff
@@ -1006,7 +1011,7 @@ mod tests {
         assert_eq!(world_diff.storage_log_queries().len(), 1);
         assert!(world_diff.initial_storage_value(contract, key).is_none());
         assert!(world_diff
-            .committed_reads_at_depth_zero_iter()
+            .protective_reads_iter()
             .next()
             .is_none());
     }

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -232,9 +232,7 @@ impl WorldDiff {
         } else {
             // Recording mode: read like the pre-optimization base, without
             // caching read-only slots (keeps Boojum's memory unchanged).
-            self.just_read_storage(world, contract, key)
-        };
-        if !self.skip_storage_logs {
+            let value = self.just_read_storage(world, contract, key);
             // Record the per-access trace; read_value == written_value for a read.
             // Note: timestamp logic does not match `zk_evm`; we only ensure
             // timestamps are unique, which is fine as the witness is not
@@ -254,7 +252,8 @@ impl WorldDiff {
                 rollback: false,
                 is_service: false,
             });
-        }
+            value
+        };
         (value, newly_added)
     }
 

--- a/crates/vm2/src/world_diff.rs
+++ b/crates/vm2/src/world_diff.rs
@@ -1011,10 +1011,7 @@ mod tests {
 
         assert_eq!(world_diff.storage_log_queries().len(), 1);
         assert!(world_diff.initial_storage_value(contract, key).is_none());
-        assert!(world_diff
-            .protective_reads_iter()
-            .next()
-            .is_none());
+        assert!(world_diff.protective_reads_iter().next().is_none());
     }
 
     /// The set of slots a re-execution verifier surfaces in the deduplicated
@@ -1075,7 +1072,9 @@ mod tests {
                 clean.storage_writes.as_ref().get(&slot).map(|e| e.value),
             );
             assert_eq!(
-                retried.initial_storage_value(slot.0, slot.1).map(|s| s.value),
+                retried
+                    .initial_storage_value(slot.0, slot.1)
+                    .map(|s| s.value),
                 clean.initial_storage_value(slot.0, slot.1).map(|s| s.value),
             );
         }
@@ -1134,7 +1133,10 @@ mod tests {
             !wd.protective_reads_iter().any(|s| s == a),
             "a read with a pending write must not be a protective read",
         );
-        assert!(dedup_input_set(&wd).contains(&a), "slot is still in the dedup set as a write");
+        assert!(
+            dedup_input_set(&wd).contains(&a),
+            "slot is still in the dedup set as a write"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three independent optimizations to reduce WorldDiff verifier memory:

1. Gate `storage_logs` recording (dual-mode) — conditional per-access trace
   recording, Boojum-memory-identical, opt-out saves ~270 MiB on large batches.
2. Consolidate WorldDiff `(address, key)` maps — merge duplicate keyed
   collections into unified entries with bit flags.
3. Capacity reservation helpers — pre-allocate to suppress mid-execution
   vector-doubling transients.

## Impact

- Worst-case production batch (size 67912): ~920–952 MiB → ~720 MiB (~200 MiB saved).
- Cycle-neutral (−0.007% measured).
- Public API: downstream consumers project `.value` from the new `StorageWriteEntry` type.

## Changes

Net diff vs `master`: 7 source files (`world_diff.rs`, `rollback.rs`, `heap.rs`,
`vm.rs`, `tracing.rs`, `lib.rs`, `single_instruction_test/heap.rs`).
`Cargo.lock` unchanged; no dependency changes.