### PR TITLE
fix: charge return-ABI heap growth on far ret.panic

### DIFF
--- a/crates/vm2/src/decode.rs
+++ b/crates/vm2/src/decode.rs
@@ -211,7 +211,9 @@ pub(crate) fn decode<T: Tracer, W: World<T>>(raw: u64, is_bootloader: bool) -> I
                 zkevm_opcode_defs::RetOpcode::Revert => {
                     Instruction::from_revert(src1.try_into().unwrap(), label, arguments)
                 }
-                zkevm_opcode_defs::RetOpcode::Panic => Instruction::from_panic(label, arguments),
+                zkevm_opcode_defs::RetOpcode::Panic => {
+                    Instruction::from_panic(src1.try_into().unwrap(), label, arguments)
+                }
             }
         }
         Opcode::Log(x) => match x {

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -41,17 +41,16 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
 
         (snapshot, near_call_leftover_gas)
     } else {
+        let (raw_abi, is_pointer) = Register1::get_with_pointer_flag(args, &mut vm.state);
         let return_value_or_panic = if return_type == ReturnType::Panic {
             // A panic forwards no returndata, but the return-ABI pointer must still be resolved for
             // its heap-growth cost: a fresh-heap pointer whose `start + length` overflows `u32`
             // grows the heap to `u32::MAX`, draining the frame's gas. Passing `already_failed = true`
             // charges exactly that penalty while discarding the (unused) returndata pointer. This
             // mirrors the proving circuit and post-#217 zk_evm; see `get_calldata`.
-            let (raw_abi, is_pointer) = Register1::get_with_pointer_flag(args, &mut vm.state);
             get_calldata(raw_abi, is_pointer, vm, true);
             None
         } else {
-            let (raw_abi, is_pointer) = Register1::get_with_pointer_flag(args, &mut vm.state);
             let result = get_calldata(raw_abi, is_pointer, vm, false).filter(|pointer| {
                 if vm.state.current_frame.is_kernel {
                     true
@@ -157,7 +156,9 @@ pub(crate) fn free_panic<T: Tracer, W: World<T>>(
     tracer: &mut T,
 ) -> ExecutionStatus {
     tracer.before_instruction::<opcodes::Ret<Panic>, _>(&mut VmAndWorld { vm, world });
-    // args aren't used for panics unless TO_LABEL
+    // A spontaneous panic has no return ABI: these empty args encode source register r0, so
+    // naked_ret's return-ABI resolution reads zero and charges no heap growth. (args are otherwise
+    // only consulted for the jump label when TO_LABEL is set, which it isn't here.)
     naked_ret::<T, W, Panic, false>(
         vm,
         &Arguments::new(Predicate::Always, 0, ModeRequirements::none()),

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -42,6 +42,13 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
         (snapshot, near_call_leftover_gas)
     } else {
         let return_value_or_panic = if return_type == ReturnType::Panic {
+            // A panic forwards no returndata, but the return-ABI pointer must still be resolved for
+            // its heap-growth cost: a fresh-heap pointer whose `start + length` overflows `u32`
+            // grows the heap to `u32::MAX`, draining the frame's gas. Passing `already_failed = true`
+            // charges exactly that penalty while discarding the (unused) returndata pointer. This
+            // mirrors the proving circuit and post-#217 zk_evm; see `get_calldata`.
+            let (raw_abi, is_pointer) = Register1::get_with_pointer_flag(args, &mut vm.state);
+            get_calldata(raw_abi, is_pointer, vm, true);
             None
         } else {
             let (raw_abi, is_pointer) = Register1::get_with_pointer_flag(args, &mut vm.state);
@@ -213,11 +220,14 @@ impl<T: Tracer, W: World<T>> Instruction<T, W> {
     }
 
     /// Creates a panic [`Ret`](opcodes::Ret) instruction with the provided params.
-    pub fn from_panic(label: Option<Immediate1>, arguments: Arguments) -> Self {
+    ///
+    /// `src1` carries the return-ABI register. Even though a panic forwards no returndata, the
+    /// register is still resolved for its heap-growth cost (see `naked_ret`).
+    pub fn from_panic(src1: Register1, label: Option<Immediate1>, arguments: Arguments) -> Self {
         let to_label = label.is_some();
         Self {
             handler: monomorphize!(ret [T W Panic] match_boolean to_label),
-            arguments: arguments.write_source(&label),
+            arguments: arguments.write_source(&src1).write_source(&label),
         }
     }
 

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -1701,3 +1701,75 @@ fn unsatisfied_predicate_does_not_clear_dst1() {
     // dst0 (r3) is likewise untouched by the skipped instruction.
     assert_eq!(vm.state.registers[3], U256::zero());
 }
+
+/// A far `ret.panic` must still resolve its return-ABI pointer for *cost*: a fresh-heap pointer
+/// whose `start + length` overflows `u32` grows the heap to `u32::MAX`, draining the frame's gas
+/// to zero, matching the proving circuit / post-#217 `zk_evm` (see zksync-protocol#217). Before the
+/// fix, vm2 short-circuited on panic and never parsed the return ABI, so the callee kept its gas
+/// and returned it to the caller.
+#[test]
+fn far_ret_panic_charges_heap_growth_for_overflowing_pointer() {
+    let callee_address = Address::from_low_u64_be(0x00C0_FFEE);
+    // `ret.panic r3` — r3 carries the crafted return-ABI pointer (set once inside the callee frame).
+    let panicking_program = Program::from_raw(
+        vec![Instruction::from_panic(
+            Register1(Register::new(3)),
+            None,
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        )],
+        vec![],
+    );
+    let mut world = TestWorld::new(&[(callee_address, panicking_program)]);
+
+    let gas_to_pass = 50_000;
+    let mut far_call_abi = U256::zero();
+    far_call_abi.0[3] = u64::from(gas_to_pass);
+    let far_call = Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(1), // exception handler -> caller instruction #1 (the trailing `ret`)
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    );
+    let caller_program = Program::from_raw(vec![far_call, ret_instruction()], vec![]);
+
+    let mut vm = VirtualMachine::new(
+        kernel_address(),
+        caller_program,
+        Address::zero(),
+        &[],
+        70_000,
+        default_settings(),
+    );
+
+    vm.state.registers[1] = far_call_abi;
+    vm.state.registers[2] = U256::from(callee_address.to_low_u64_be());
+    vm.state.register_pointer_flags &= !(1 << 1);
+
+    // Step 1: the far call pushes the callee frame (registers are cleared on entry).
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+    assert_eq!(
+        vm.state.current_frame.gas, gas_to_pass,
+        "callee should receive the passed gas"
+    );
+
+    // Craft the return-ABI pointer in r3: start = u32::MAX, length = 1 (so start + length overflows
+    // u32), MakeNewPointer / UseHeap (raw source byte 0), integer (no pointer flag).
+    let mut ret_abi = U256::zero();
+    ret_abi.0[1] = (1u64 << 32) | u64::from(u32::MAX); // length = 1 (bits 96..128), start = u32::MAX (bits 64..96)
+    vm.state.registers[3] = ret_abi;
+    vm.state.register_pointer_flags &= !(1 << 3);
+
+    // Step 2: the callee's `ret.panic r3` returns to the caller's exception handler.
+    execute_one_instruction(&mut vm, &mut world, &mut ());
+
+    // Back in the caller frame: with the fix the callee drained all its gas on heap growth and
+    // returned nothing, so the caller's remaining gas is well below the gas it passed in.
+    assert!(
+        vm.state.current_frame.gas < gas_to_pass,
+        "caller gas {} should be below the {gas_to_pass} passed in — the callee's gas must have \
+         been drained by u32::MAX heap growth",
+        vm.state.current_frame.gas,
+    );
+}

--- a/crates/vm2/src/tests/panic.rs
+++ b/crates/vm2/src/tests/panic.rs
@@ -17,7 +17,7 @@ proptest! {
                 Immediate2(0xFFFF),
                 Arguments::new(Predicate::Always, 25, ModeRequirements::none()),
             ),
-            Instruction::from_panic(Some(Immediate1(label)), Arguments::new(Predicate::Always, 5, ModeRequirements::none())),
+            Instruction::from_panic(Register1(Register::new(0)), Some(Immediate1(label)), Arguments::new(Predicate::Always, 5, ModeRequirements::none())),
         ];
         for _ in 0..98 {
             instructions.push(Instruction::from_ret(


### PR DESCRIPTION
## Summary

Follow-up to #110. The [security review issue](https://github.com/ninolipartiia/vm2/blob/popzxc-airbender-eravm-review/security-review/08-dst1-register-not-pre-zeroed.md) is **cumulative** and documents two PR #217 divergences; #110 fixes the `dst1` one (Divergence 1), this PR fixes the second: the `ret.panic` return-ABI heap-growth charge (Divergence 2), as flagged in [#110's review](https://github.com/matter-labs/vm2/pull/110#issuecomment).

**Stacked on `vv/dst1-clear`** because the fix relies on the post-#217 `zk_evm` pin that #110 introduces — landing it against the pre-#217 pin would make vm2 newly diverge from its `single_instruction_test` differential reference. Retarget to `master` once #110 merges.

## The divergence

On a **far** return the proving circuit and post-#217 `zk_evm` parse the return-ABI fat pointer from the raw source register and charge implied heap growth **even on panic**. A crafted fresh-heap pointer (`UseHeap`, `start = 0xFFFFFFFF, length = 1`) is non-addressable → `u32::MAX` growth → the frame's ergs drain to zero.

vm2 short-circuited to `None` on `ReturnType::Panic` and never parsed the return ABI, so the callee kept its gas and returned it to the caller. That's observable state the stricter circuit cannot reproduce → unprovable batch / differential mismatch against post-#217 `zk_evm`. Same MEDIUM class as #110 (vm2 is *more permissive* — no theft risk).

## Fix

Resolve the return-ABI register for **cost** on the panic path, passing `already_failed = true` so `get_calldata` charges the growth penalty while discarding the (unused) returndata pointer. This mirrors the circuit's "erase returndata, keep `upper_bound`" split and how vm2's own `ret.ok`/`ret.revert` already charge via `get_calldata`.

I verified against the pinned post-#217 `zk_evm` source (`ret.rs`): on `ret.panic` it empties the pointer (→ no growth for a *valid* pointer) but keeps the pre-erasure validation exceptions, so an overflowing pointer still triggers the `u32::MAX` penalty. `already_failed = true` reproduces exactly this (valid → `None` before `grow(bound)`; overflow → `grow(u32::MAX)`).

Plumbing: `from_panic` and the decoder previously dropped the source register (the value was never read); they now pass it through.

## Testing

- New regression test `far_ret_panic_charges_heap_growth_for_overflowing_pointer` in `divergence_regressions.rs`: a far callee does `ret.panic r3` with an overflowing fresh-heap pointer; asserts the callee's gas was drained (caller receives ~nothing back). Written test-first — confirmed it **fails** before the fix (caller keeps 69795 gas) and **passes** after.
- Full suite: 57 tests pass, clippy clean, `cargo fmt` clean, builds under `--features single_instruction_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)