### PR TITLE
perf: reclaim bootloader returndata heaps at tx commit

### DIFF
--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -381,7 +381,8 @@ impl Heaps {
 
     // The three panics in this function flag VM-internal bookkeeping bugs, not
     // reachable conditions: the VM only deallocates pages it previously allocated via
-    // `allocate_at` (frame pop in `pop_frame`, snapshot rollback in `State::rollback`). The
+    // `allocate_at` (frame pop in `pop_frame`, snapshot rollback in `State::rollback`, and
+    // returndata-heap reclaim at tx commit in `reclaim_bootloader_returndata_heaps`). The
     // reference `zk_evm` has no deallocation path of its own, so there is no behaviour to
     // diverge from here — these panics remain as fail-fast diagnostics for our own bookkeeping.
     pub(crate) fn deallocate(&mut self, page: HeapId) {

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -203,16 +203,21 @@ impl<T: Tracer, W: World<T>> VirtualMachine<T, W> {
     /// reused by the next transaction, so peak page usage stays at roughly one
     /// transaction's worth instead of growing with the transaction count.
     fn reclaim_bootloader_returndata_heaps(&mut self) {
-        let kept = std::mem::take(&mut self.state.current_frame.heaps_i_am_keeping_alive);
-        let mut still_pinned = Vec::new();
-        for heap in kept {
-            if self.world_diff.is_decommit_page_pinned(heap) {
-                still_pinned.push(heap);
-            } else {
+        // `kept` is owned after the take, so the `retain` closure can borrow
+        // `self.world_diff`/`self.state.heaps` without conflicting with the
+        // borrow of the field it compacts. Retain drops the deallocated heaps
+        // in place, avoiding a second allocation. Reordering is irrelevant here:
+        // there is no live snapshot to consume the tail ordering (see the len()
+        // snapshot / tail-drain rollback path in `Callframe`).
+        let mut kept = std::mem::take(&mut self.state.current_frame.heaps_i_am_keeping_alive);
+        kept.retain(|&heap| {
+            let pinned = self.world_diff.is_decommit_page_pinned(heap);
+            if !pinned {
                 self.state.heaps.deallocate(heap);
             }
-        }
-        self.state.current_frame.heaps_i_am_keeping_alive = still_pinned;
+            pinned
+        });
+        self.state.current_frame.heaps_i_am_keeping_alive = kept;
     }
 
     /// This must only be called when it is known that the VM cannot be rolled back,

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -181,6 +181,38 @@ impl<T: Tracer, W: World<T>> VirtualMachine<T, W> {
         );
         self.snapshot = None;
         self.delete_history();
+        self.reclaim_bootloader_returndata_heaps();
+    }
+
+    /// Frees the returndata heaps that accumulated on the bootloader frame while
+    /// the just-committed transaction(s) executed.
+    ///
+    /// Every far-call keeps the heap holding its returndata alive and bubbles it
+    /// up to the caller (see [`Self::pop_frame`]); heaps forwarded all the way to
+    /// the bootloader frame — which never pops during a batch — otherwise live
+    /// until the VM is dropped, so they accumulate across every transaction (the
+    /// dominant heap-memory consumer on large batches).
+    ///
+    /// This is the safe point to release them: the callstack is unwound to the
+    /// bootloader (`previous_frames` is empty), the external snapshot has just
+    /// been discarded (`self.snapshot` is `None`) and history deleted, so no
+    /// rollback can reference these heaps; and a committed transaction's
+    /// returndata is dead once the bootloader moves on. Decommit-pinned code
+    /// pages (shared across transactions by hash) are kept — the same predicate
+    /// [`Self::pop_frame`] uses. Freed pages return to the `PagePool` and are
+    /// reused by the next transaction, so peak page usage stays at roughly one
+    /// transaction's worth instead of growing with the transaction count.
+    fn reclaim_bootloader_returndata_heaps(&mut self) {
+        let kept = std::mem::take(&mut self.state.current_frame.heaps_i_am_keeping_alive);
+        let mut still_pinned = Vec::new();
+        for heap in kept {
+            if self.world_diff.is_decommit_page_pinned(heap) {
+                still_pinned.push(heap);
+            } else {
+                self.state.heaps.deallocate(heap);
+            }
+        }
+        self.state.current_frame.heaps_i_am_keeping_alive = still_pinned;
     }
 
     /// This must only be called when it is known that the VM cannot be rolled back,


### PR DESCRIPTION
## Problem

Every far-call keeps the heap holding its **returndata** alive and bubbles it up to the caller (`pop_frame`, via `heaps_i_am_keeping_alive`). Heaps forwarded all the way to the **bootloader frame — which never pops during a batch** — otherwise live until the VM is dropped, so they accumulate across *every* transaction.

On large batches this is the dominant heap-memory consumer: **~23 retained heaps/tx**, e.g. **~419 MiB (~103K × 4 KiB pages)** on a 4,487-tx era mainnet batch. It grows linearly with tx count (intermediate frames free their own subcalls' returndata on pop; only heaps bubbling to the immortal bootloader frame accumulate).

## Fix

Reclaim those heaps in **`pop_snapshot`** (transaction commit). Safe point: the callstack is unwound to the bootloader (`previous_frames` empty), the external snapshot has just been discarded and history deleted (so no rollback can reference these heaps), and a committed tx's returndata is dead.

- **Decommit-pinned code pages** (EVM/era bytecode, shared across txs by hash) are **kept** — the same `is_decommit_page_pinned` predicate `pop_frame` already uses.
- Freed pages return to the `PagePool` and are **reused by the next tx**, so peak page usage plateaus at ~one tx's worth instead of growing with tx count (no explicit pool-trim needed).

**Why not `start_new_tx`:** that opcode fires *inside* the external-snapshot window, where `StateSnapshot` captures `heaps_i_am_keeping_alive.len()` and rollback frees the tail — releasing the older accumulation there would corrupt rollback.

## Validation

End-to-end via the eravm-airbender-verifier on era mainnet batch **67912** (native; talc + System + dhat all agree):

| | before | after |
|---|---|---|
| peak heap | 686.9 MiB | **276.2 MiB** (−410, −60%) |
| returndata heaps live | ~419 MiB (103,779) | ~13 MiB (one tx, pool-reused) |
| pinned bytecode | 3.8 MiB | **3.8 MiB — preserved** |
| commitment `proof_public_input` / `value_hash` | — | **byte-identical** with vs without |
| freed-heap re-read panics | — | none |

`cargo test -p zksync_vm2` passes; clippy clean.

**Follow-ups before relying on this in production:** broaden the differential to more batches (esp. compression-retry-heavy ones — reclaim is on the commit path, so a retried tx's heaps clear one tx later) and confirm the in-guest peak via the verifier's `probe_guest_memory.sh`. A vm2 in-tree test (far-call → return → pop_snapshot → assert reclaim, pinned page kept) is worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)