### PR TITLE
chore: pin zksync-protocol to git tag v0.153.13; disable crates.io publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,5 +28,8 @@ jobs:
       config: '.github/release-please/config.json'     # Specify the path to the configuration file
       manifest: '.github/release-please/manifest.json' # Specify the path to the manifest file
       update-cargo-lock: true                          # Update Cargo.lock file
-      publish-to-crates-io: true                       # Enable publishing to crates.io
+      # Publishing to crates.io is disabled: vm2 pins zksync-protocol via a git tag
+      # (protocol has a git-only airbender-crypto dep and is not on crates.io), which
+      # makes vm2 unpublishable to crates.io. Consumers pin vm2 via git rev/tag.
+      publish-to-crates-io: false                      # Disabled (git-only protocol dep)
       cargo_build_args: '--workspace --exclude zksync_vm2_afl_fuzz' # Do not build fuzzer during publishing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 [[package]]
 name = "airbender-crypto"
 version = "0.2.3"
-source = "git+https://github.com/matter-labs/airbender-platform?branch=main#db2767d9ba871bb556ad8a2c8b4d39717f36cd47"
+source = "git+https://github.com/matter-labs/airbender-platform?tag=v0.2.3#db2767d9ba871bb556ad8a2c8b4d39717f36cd47"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1748,8 +1748,8 @@ dependencies = [
 
 [[package]]
 name = "zk_evm"
-version = "0.153.12"
-source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#ac58f32895502dfcbaa827810d2904500146637f"
+version = "0.153.13"
+source = "git+https://github.com/matter-labs/zksync-protocol?tag=v0.153.13#b60b7bde6cd5809593b4753c26e3072957c47e38"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -1762,8 +1762,8 @@ dependencies = [
 
 [[package]]
 name = "zk_evm_abstractions"
-version = "0.153.12"
-source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#ac58f32895502dfcbaa827810d2904500146637f"
+version = "0.153.13"
+source = "git+https://github.com/matter-labs/zksync-protocol?tag=v0.153.13#b60b7bde6cd5809593b4753c26e3072957c47e38"
 dependencies = [
  "airbender-crypto",
  "anyhow",
@@ -1776,8 +1776,8 @@ dependencies = [
 
 [[package]]
 name = "zkevm_opcode_defs"
-version = "0.153.12"
-source = "git+https://github.com/matter-labs/zksync-protocol?branch=popzxc-airbender-precompiles#ac58f32895502dfcbaa827810d2904500146637f"
+version = "0.153.13"
+source = "git+https://github.com/matter-labs/zksync-protocol?tag=v0.153.13#b60b7bde6cd5809593b4753c26e3072957c47e38"
 dependencies = [
  "bitflags",
  "blake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ primitive-types = "0.12.1"
 proptest = "1.4"
 
 # "Internal" dependencies
-zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
-zk_evm_abstractions = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
-zk_evm = { git = "https://github.com/matter-labs/zksync-protocol", branch = "popzxc-airbender-precompiles" } # TODO: Must be pinned before merge
+zkevm_opcode_defs = { git = "https://github.com/matter-labs/zksync-protocol", tag = "v0.153.13" }
+zk_evm_abstractions = { git = "https://github.com/matter-labs/zksync-protocol", tag = "v0.153.13" }
+zk_evm = { git = "https://github.com/matter-labs/zksync-protocol", tag = "v0.153.13" }
 
 # Dependencies within the workspace
 zksync_vm2_interface = { version = "=0.5.0", path = "crates/vm2-interface" }


### PR DESCRIPTION
## Why

`zksync-protocol` is no longer published to crates.io (it has a git-only `airbender-crypto` dependency). vm2's protocol deps were pointing at an **unpinned branch** (`popzxc-airbender-precompiles`, flagged "must be pinned before merge").

## Change

- Pin `zkevm_opcode_defs` / `zk_evm_abstractions` / `zk_evm` → `tag = "v0.153.13"`.
- `release-please.yml`: `publish-to-crates-io: false` — vm2 now carries a git dep, so it is itself unpublishable to crates.io. Consumers (era) pin vm2 by git rev/tag.
- `Cargo.lock` updated.

Part of the coordinated switch to git-tag deps (zksync-protocol #229, zksync-crypto-gpu, zksync-era).

🤖 Generated with [Claude Code](https://claude.com/claude-code)