### PR TITLE
feat: tx-wide revert on invariant violation + configurable per-tx heap ceiling

### DIFF
--- a/crates/vm2/benches/nested_near_call.rs
+++ b/crates/vm2/benches/nested_near_call.rs
@@ -38,6 +38,7 @@ fn nested_near_call(bencher: Bencher) {
                 default_aa_code_hash: [0; 32],
                 evm_interpreter_code_hash: [0; 32],
                 hook_address: 0,
+                memory_ceiling_bytes: u64::MAX,
             },
         );
 
@@ -85,6 +86,7 @@ fn nested_near_call_with_storage_write(bencher: Bencher) {
                 default_aa_code_hash: [0; 32],
                 evm_interpreter_code_hash: [0; 32],
                 hook_address: 0,
+                memory_ceiling_bytes: u64::MAX,
             },
         );
 

--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -423,6 +423,9 @@ impl Heaps {
             page.as_u32()
         );
 
+        // `self[page]` falls back to `EMPTY_HEAP` (`counted_size == 0`) for a page that was
+        // never counted or is already removed, so this decrement is a safe no-op in that case;
+        // the `.take().unwrap_or_else(...)` panic below still fires for an unallocated page.
         self.live_logical_bytes -= u64::from(self[page].counted_size);
 
         let heap = decoded_dynamic_slot_mut(&mut self.dynamic, decoded)
@@ -506,6 +509,11 @@ impl Heaps {
         self.live_logical_bytes = live_logical_bytes;
     }
 
+    /// Does not touch `live_logical_bytes`: every caller runs [`Self::rollback`] first, whose
+    /// flat overwrite of the counter already subsumes any truncation, because dynamic groups
+    /// only grow within a snapshot's scope (so nothing truncated here could have added to the
+    /// counter *after* that snapshot was taken). If a future caller ever invokes this without a
+    /// preceding `rollback` to the same snapshot, `live_logical_bytes` will silently drift.
     pub(crate) fn truncate_dynamic_to(&mut self, len: usize) {
         assert!(
             len <= self.dynamic.len(),
@@ -953,6 +961,16 @@ mod tests {
         assert_eq!(heaps.live_logical_bytes(), 10_000);
         heaps.deallocate(p);
         assert_eq!(heaps.live_logical_bytes(), 0);
+    }
+
+    #[test]
+    fn counter_tracks_shrink() {
+        let mut heaps = Heaps::new(&[]);
+        let page = crate::page_ids::heap_page_from_base(crate::page_ids::first_dynamic_base_page());
+        let p = heaps.allocate_at(page);
+        heaps.set_counted_size(p, 10_000);
+        heaps.set_counted_size(p, 2_000); // shrink
+        assert_eq!(heaps.live_logical_bytes(), 2_000);
     }
 
     #[test]

--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -28,12 +28,20 @@ impl Default for HeapPage {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Heap {
     pages: Vec<Option<HeapPage>>,
+    /// Logical byte size counted against [`Heaps::live_logical_bytes`]. This is a purely
+    /// host-side bookkeeping quantity (not part of VM-visible state) used to enforce a
+    /// per-transaction heap ceiling; it defaults to 0 and is only ever set explicitly via
+    /// [`Heaps::set_counted_size`].
+    counted_size: u32,
 }
 
 // The reference VM treats reads from missing memory pages as reads from an
 // all-zero page. Keep write paths strict, but make read-only indexing total so
 // panic-produced or otherwise empty fat pointers cannot abort the host.
-static EMPTY_HEAP: Heap = Heap { pages: Vec::new() };
+static EMPTY_HEAP: Heap = Heap {
+    pages: Vec::new(),
+    counted_size: 0,
+};
 
 // We never remove `HeapPage`s (even after rollbacks – although we do zero all added pages in this case),
 // we allow additional pages to be present if they are zeroed.
@@ -76,7 +84,10 @@ impl Heap {
                 })
             })
             .collect();
-        Self { pages }
+        Self {
+            pages,
+            counted_size: 0,
+        }
     }
 
     fn recycle(self, pagepool: &mut PagePool) {
@@ -326,6 +337,10 @@ pub(crate) struct Heaps {
     pagepool: PagePool,
     bootloader_heap_rollback_info: Vec<(u32, U256)>,
     bootloader_aux_rollback_info: Vec<(u32, U256)>,
+    /// Running sum of `counted_size` over all live heaps, excluding the always-allocated
+    /// bootloader heaps (`FIRST`/`FIRST_AUX`, static memory, calldata), whose `counted_size`
+    /// is never set and stays 0. Feeds the per-transaction heap ceiling enforced elsewhere.
+    live_logical_bytes: u64,
 }
 
 impl Heaps {
@@ -341,6 +356,7 @@ impl Heaps {
             pagepool,
             bootloader_heap_rollback_info: vec![],
             bootloader_aux_rollback_info: vec![],
+            live_logical_bytes: 0,
         }
     }
 
@@ -407,6 +423,8 @@ impl Heaps {
             page.as_u32()
         );
 
+        self.live_logical_bytes -= u64::from(self[page].counted_size);
+
         let heap = decoded_dynamic_slot_mut(&mut self.dynamic, decoded)
             .take()
             .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
@@ -415,6 +433,26 @@ impl Heaps {
 
     pub(crate) fn dynamic_len(&self) -> usize {
         self.dynamic.len()
+    }
+
+    /// Sets the logical byte size counted against [`Self::live_logical_bytes`] for `page`,
+    /// adjusting the running total by the signed delta between the old and new sizes. Safe to
+    /// call repeatedly (idempotent for an unchanged `size`); used both for initial accounting
+    /// and later growth.
+    pub(crate) fn set_counted_size(&mut self, page: HeapId, size: u32) {
+        let decoded = DecodedPage::decode(page)
+            .unwrap_or_else(|| panic!("heap page {} is not decodable", page.as_u32()));
+        let heap = self
+            .try_decoded_page_mut(decoded)
+            .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
+        let old = heap.counted_size;
+        heap.counted_size = size;
+        self.live_logical_bytes = self.live_logical_bytes - u64::from(old) + u64::from(size);
+    }
+
+    /// Running sum of [`set_counted_size`](Self::set_counted_size) sizes over all live heaps.
+    pub(crate) fn live_logical_bytes(&self) -> u64 {
+        self.live_logical_bytes
     }
 
     pub(crate) fn write_u256(&mut self, page: HeapId, start_address: u32, value: U256) {
@@ -443,14 +481,18 @@ impl Heaps {
         heap.write_bytes(start_address, bytes, pagepool);
     }
 
-    pub(crate) fn snapshot(&self) -> (usize, usize) {
+    pub(crate) fn snapshot(&self) -> (usize, usize, u64) {
         (
             self.bootloader_heap_rollback_info.len(),
             self.bootloader_aux_rollback_info.len(),
+            self.live_logical_bytes,
         )
     }
 
-    pub(crate) fn rollback(&mut self, (heap_snap, aux_snap): (usize, usize)) {
+    pub(crate) fn rollback(
+        &mut self,
+        (heap_snap, aux_snap, live_logical_bytes): (usize, usize, u64),
+    ) {
         for (address, value) in self.bootloader_heap_rollback_info.drain(heap_snap..).rev() {
             self.bootloader_heap
                 .write_u256(address, value, &mut self.pagepool);
@@ -460,6 +502,8 @@ impl Heaps {
             self.bootloader_aux_heap
                 .write_u256(address, value, &mut self.pagepool);
         }
+
+        self.live_logical_bytes = live_logical_bytes;
     }
 
     pub(crate) fn truncate_dynamic_to(&mut self, len: usize) {
@@ -524,6 +568,19 @@ impl Heaps {
 
     fn decoded_page(&self, page: DecodedPage) -> &Heap {
         self.try_decoded_page(page).unwrap_or(&EMPTY_HEAP)
+    }
+
+    fn try_decoded_page_mut(&mut self, page: DecodedPage) -> Option<&mut Heap> {
+        match page {
+            DecodedPage::Static => Some(&mut self.static_memory),
+            DecodedPage::BootloaderCalldata => Some(&mut self.bootloader_calldata),
+            DecodedPage::BootloaderHeap => Some(&mut self.bootloader_heap),
+            DecodedPage::BootloaderAuxHeap => Some(&mut self.bootloader_aux_heap),
+            DecodedPage::Dynamic { group, kind } => self
+                .dynamic
+                .get_mut(group)
+                .and_then(|group| group.slot_mut(kind).as_mut()),
+        }
     }
 
     fn decoded_page_mut_for_write(&mut self, page: DecodedPage) -> (&mut Heap, &mut PagePool) {
@@ -846,7 +903,7 @@ mod tests {
         assert_eq!(heaps[HeapId::FIRST_AUX].read_u256(0), 42.into());
 
         let snapshot = heaps.snapshot();
-        assert_eq!(snapshot, (1, 1));
+        assert_eq!(snapshot, (1, 1, 0));
 
         heaps.write_u256(HeapId::FIRST, 7, U256::MAX);
         assert_eq!(
@@ -882,6 +939,37 @@ mod tests {
         assert_eq!(heaps[HeapId::FIRST].read_u256(0), first_word);
         assert_eq!(heaps[HeapId::FIRST].read_u256(32), second_word);
         assert_eq!(heaps.bootloader_heap_rollback_info.len(), 2);
+    }
+
+    #[test]
+    fn counter_tracks_set_and_deallocate() {
+        let mut heaps = Heaps::new(&[]);
+        assert_eq!(heaps.live_logical_bytes(), 0);
+        let page = crate::page_ids::heap_page_from_base(crate::page_ids::first_dynamic_base_page());
+        let p = heaps.allocate_at(page);
+        heaps.set_counted_size(p, 4096);
+        assert_eq!(heaps.live_logical_bytes(), 4096);
+        heaps.set_counted_size(p, 10_000); // grow
+        assert_eq!(heaps.live_logical_bytes(), 10_000);
+        heaps.deallocate(p);
+        assert_eq!(heaps.live_logical_bytes(), 0);
+    }
+
+    #[test]
+    fn counter_saved_and_restored_by_snapshot() {
+        let mut heaps = Heaps::new(&[]);
+        let base_page = crate::page_ids::first_dynamic_base_page();
+        let page = crate::page_ids::heap_page_from_base(base_page);
+        let other_page =
+            crate::page_ids::heap_page_from_base(crate::page_ids::next_page_group(base_page));
+        let p = heaps.allocate_at(page);
+        heaps.set_counted_size(p, 8192);
+        let snap = heaps.snapshot();
+        let q = heaps.allocate_at(other_page);
+        heaps.set_counted_size(q, 5000);
+        assert_eq!(heaps.live_logical_bytes(), 13_192);
+        heaps.rollback(snap);
+        assert_eq!(heaps.live_logical_bytes(), 8192);
     }
 
     #[test]

--- a/crates/vm2/src/heap.rs
+++ b/crates/vm2/src/heap.rs
@@ -426,7 +426,17 @@ impl Heaps {
         // `self[page]` falls back to `EMPTY_HEAP` (`counted_size == 0`) for a page that was
         // never counted or is already removed, so this decrement is a safe no-op in that case;
         // the `.take().unwrap_or_else(...)` panic below still fires for an unallocated page.
-        self.live_logical_bytes -= u64::from(self[page].counted_size);
+        let counted = u64::from(self[page].counted_size);
+        // Invariant: `live_logical_bytes == Σ live counted_size`, so a page's counted size can
+        // never exceed the running total. Fail loudly in debug if that is ever violated, instead
+        // of wrapping silently in release.
+        debug_assert!(
+            self.live_logical_bytes >= counted,
+            "live_logical_bytes underflow: {} < {}",
+            self.live_logical_bytes,
+            counted
+        );
+        self.live_logical_bytes -= counted;
 
         let heap = decoded_dynamic_slot_mut(&mut self.dynamic, decoded)
             .take()
@@ -450,6 +460,14 @@ impl Heaps {
             .unwrap_or_else(|| panic!("heap page {} is not allocated", page.as_u32()));
         let old = heap.counted_size;
         heap.counted_size = size;
+        // Invariant: `live_logical_bytes == Σ live counted_size`, so the old counted size can never
+        // exceed the running total. Fail loudly in debug if violated rather than wrapping silently.
+        debug_assert!(
+            self.live_logical_bytes >= u64::from(old),
+            "live_logical_bytes underflow: {} < {}",
+            self.live_logical_bytes,
+            old
+        );
         self.live_logical_bytes = self.live_logical_bytes - u64::from(old) + u64::from(size);
     }
 
@@ -988,6 +1006,18 @@ mod tests {
         assert_eq!(heaps.live_logical_bytes(), 13_192);
         heaps.rollback(snap);
         assert_eq!(heaps.live_logical_bytes(), 8192);
+    }
+
+    #[test]
+    fn live_logical_bytes_excluded_from_heaps_eq() {
+        // Guards the consensus-invisibility invariant at the heap layer: the running counter must
+        // never leak into `Heaps::eq`. Two heaps identical except for `live_logical_bytes` compare
+        // equal, so a future edit adding it to equality would fail this test loudly.
+        let a = Heaps::new(&[]);
+        let mut b = a.clone();
+        b.live_logical_bytes = 1_234_567; // private field; in-module access only
+        assert_eq!(a, b, "live_logical_bytes must be excluded from Heaps::eq");
+        assert_eq!(b, a);
     }
 
     #[test]

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -1,8 +1,13 @@
 use primitive_types::U256;
-use zkevm_opcode_defs::{system_params::MSG_VALUE_SIMULATOR_ADDITIVE_COST, ADDRESS_MSG_VALUE};
+use zkevm_opcode_defs::{
+    system_params::{
+        MSG_VALUE_SIMULATOR_ADDITIVE_COST, NEW_EVM_FRAME_MEMORY_STIPEND, NEW_FRAME_MEMORY_STIPEND,
+    },
+    ADDRESS_MSG_VALUE,
+};
 use zksync_vm2_interface::{
     opcodes::{FarCall, TypeLevelCallingMode},
-    Tracer,
+    CallingMode, Tracer,
 };
 
 use super::{
@@ -131,6 +136,18 @@ where
         let (calldata, program, is_evm_interpreter, is_evm_blob_format) = fallible_part
             .unwrap_or_else(|| (U256::zero().into(), Program::new_panicking(), false, false));
 
+        // Enforce the per-user-tx heap-bytes ceiling BEFORE pushing the new frame (see
+        // `far_call_would_exceed_ceiling`). On a breach, do NOT push: `abort_transaction` sets
+        // `current_frame.pc` to `spontaneous_panic` on the *caller* frame and arms the tx-wide
+        // unwind; returning `Running` lets the next step panic there, and the `Ret<Panic>` cascade
+        // (which sees `aborting`) unwinds the whole transaction past every exception handler. This
+        // differs from far_call's ordinary pre-push failures, which push a *panicking* frame (a
+        // one-level, catchable panic) — the ceiling breach must be uncatchable.
+        if far_call_would_exceed_ceiling::<_, _, M>(vm, destination_address, is_evm_blob_format) {
+            vm.state.abort_transaction();
+            return ExecutionStatus::Running;
+        }
+
         let new_frame_is_static = IS_STATIC || vm.state.current_frame.is_static;
         vm.push_frame::<M>(
             u256_into_address(destination_address),
@@ -167,6 +184,34 @@ where
 
         ExecutionStatus::Running
     })
+}
+
+/// Returns `true` if pushing the new frame would raise `live_logical_bytes` above the configured
+/// per-user-tx ceiling. Replicates `push_frame`/`Callframe::new`'s frame-address and stipend
+/// selection exactly, so the prospective total matches what the push would actually count: the
+/// frame address depends on the calling mode (Delegate keeps the caller's address), the stipend is
+/// EVM- vs default-sized (kernel targets can't reach here — they're filtered out first), and a
+/// pushed frame counts both its heap and aux-heap stipends (`2 *`). Kernel target frames are exempt
+/// (never counted — see `Heaps::live_logical_bytes`), so they can never breach the ceiling.
+fn far_call_would_exceed_ceiling<T, W, M: TypeLevelCallingMode>(
+    vm: &VirtualMachine<T, W>,
+    destination_address: U256,
+    is_evm_blob_format: bool,
+) -> bool {
+    let new_frame_address = if M::VALUE == CallingMode::Delegate {
+        vm.state.current_frame.address
+    } else {
+        u256_into_address(destination_address)
+    };
+    if is_kernel(new_frame_address) {
+        return false;
+    }
+    let stipend = if is_evm_blob_format {
+        NEW_EVM_FRAME_MEMORY_STIPEND
+    } else {
+        NEW_FRAME_MEMORY_STIPEND
+    };
+    vm.state.heaps.live_logical_bytes() + 2 * u64::from(stipend) > vm.state.memory_ceiling_bytes
 }
 
 #[derive(Debug)]
@@ -206,7 +251,7 @@ fn program_to_bytes<T, W>(program: &Program<T, W>) -> Vec<u8> {
 ///
 /// This function needs to be called even if we already know we will panic because
 /// overflowing start + length makes the heap resize even when already panicking.
-pub(crate) fn get_calldata<T, W>(
+pub(crate) fn get_calldata<T: Tracer, W: World<T>>(
     raw_abi: U256,
     is_pointer: bool,
     vm: &mut VirtualMachine<T, W>,

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -136,22 +136,30 @@ where
         let (calldata, program, is_evm_interpreter, is_evm_blob_format) = fallible_part
             .unwrap_or_else(|| (U256::zero().into(), Program::new_panicking(), false, false));
 
-        // Enforce the per-user-tx heap-bytes ceiling BEFORE pushing the new frame (see
-        // `far_call_would_exceed_ceiling`). On a breach, do NOT push: `abort_transaction` sets
-        // `current_frame.pc` to `spontaneous_panic` on the *caller* frame and arms the tx-wide
-        // unwind; returning `Running` lets the next step panic there, and the `Ret<Panic>` cascade
-        // (which sees `aborting`) unwinds the whole transaction past every exception handler. This
-        // differs from far_call's ordinary pre-push failures, which push a *panicking* frame (a
-        // one-level, catchable panic) — the ceiling breach must be uncatchable.
+        // Enforce the per-user-tx heap-bytes ceiling. On a breach we STILL push the frame (below)
+        // and then arm the uncatchable tx-wide abort on it. Two reasons to push rather than return
+        // early without one:
+        //   * Balance: the `FarCall` opcode's `after_instruction` fires regardless, so a
+        //     call-tree-reconstructing tracer opens a callee node here. Not pushing would leave that
+        //     node unbalanced against a `Ret` (a phantom open frame). Pushing keeps `FarCall`<->`Ret`
+        //     matched, exactly like every other far_call failure.
+        //   * Gas burn: `abort_transaction` zeroes the *current* frame's gas and points its pc at
+        //     `spontaneous_panic`. Called *after* the push (when the pushed frame is current), it
+        //     zeroes that frame's `new_frame_gas` so the unwind can't recover it up the stack
+        //     (`naked_ret` adds a popped frame's leftover gas to its caller) and overrides its pc so
+        //     it panics immediately without running any of the callee's real code.
+        // The pushed frame therefore does nothing: it immediately panics and rolls back to a no-op,
+        // its transient 2*stipend is freed when it pops (the counter returns to where it was), and
+        // the `Ret<Panic>` cascade (seeing `aborting`) unwinds the whole transaction past every
+        // exception handler to the bootloader, burning all gas. Final state is identical to not
+        // pushing at all — only the (now balanced) call tree differs.
         //
         // Note this is NOT the only way the ceiling aborts a far_call: `get_calldata` (inside
         // `fallible_part` above) can itself grow a heap via `grow_heap`, so a breach there arms the
-        // same abort earlier — momentarily leaving one zero-gas frame before the cascade completes.
+        // same abort earlier — that path unwinds a real on-stack frame and needs nothing here.
         // Either entry yields the same uncatchable, deterministic whole-tx revert.
-        if far_call_would_exceed_ceiling::<_, _, M>(vm, destination_address, is_evm_blob_format) {
-            vm.state.abort_transaction();
-            return ExecutionStatus::Running;
-        }
+        let ceiling_breached =
+            far_call_would_exceed_ceiling::<_, _, M>(vm, destination_address, is_evm_blob_format);
 
         let new_frame_is_static = IS_STATIC || vm.state.current_frame.is_static;
         vm.push_frame::<M>(
@@ -164,6 +172,14 @@ where
             calldata.memory_page,
             vm.world_diff.snapshot(),
         );
+
+        // Arm the uncatchable tx-wide abort on the just-pushed frame (see the ceiling comment
+        // above): zeroes its gas and points its pc at `spontaneous_panic`, so it panics on the next
+        // step and the `Ret<Panic>` cascade unwinds every frame up to the bootloader, burning all
+        // gas.
+        if ceiling_breached {
+            vm.state.abort_transaction();
+        }
 
         vm.state.flags = Flags::new(false, false, false);
 

--- a/crates/vm2/src/instruction_handlers/far_call.rs
+++ b/crates/vm2/src/instruction_handlers/far_call.rs
@@ -143,6 +143,11 @@ where
         // (which sees `aborting`) unwinds the whole transaction past every exception handler. This
         // differs from far_call's ordinary pre-push failures, which push a *panicking* frame (a
         // one-level, catchable panic) — the ceiling breach must be uncatchable.
+        //
+        // Note this is NOT the only way the ceiling aborts a far_call: `get_calldata` (inside
+        // `fallible_part` above) can itself grow a heap via `grow_heap`, so a breach there arms the
+        // same abort earlier — momentarily leaving one zero-gas frame before the cascade completes.
+        // Either entry yields the same uncatchable, deterministic whole-tx revert.
         if far_call_would_exceed_ceiling::<_, _, M>(vm, destination_address, is_evm_blob_format) {
             vm.state.abort_transaction();
             return ExecutionStatus::Running;
@@ -211,7 +216,11 @@ fn far_call_would_exceed_ceiling<T, W, M: TypeLevelCallingMode>(
     } else {
         NEW_FRAME_MEMORY_STIPEND
     };
-    vm.state.heaps.live_logical_bytes() + 2 * u64::from(stipend) > vm.state.memory_ceiling_bytes
+    vm.state
+        .heaps
+        .live_logical_bytes()
+        .saturating_add(2 * u64::from(stipend))
+        > vm.state.memory_ceiling_bytes
 }
 
 #[derive(Debug)]

--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -165,11 +165,28 @@ where
 
 /// Pays for more heap space. Doesn't acually grow the heap.
 /// That distinction is necessary because the bootloader gets `u32::MAX` heap for free.
-pub(crate) fn grow_heap<T, W, H: HeapFromState>(
+pub(crate) fn grow_heap<T: Tracer, W: World<T>, H: HeapFromState>(
     state: &mut State<T, W>,
     new_bound: u32,
 ) -> Result<(), ()> {
     if let Some(to_pay) = new_bound.checked_sub(*H::get_heap_size(state)) {
+        // Enforce the per-user-tx heap-bytes ceiling FIRST, on the PROSPECTIVE total, and only for
+        // non-kernel frames (kernel frames get huge free heaps by design and are never counted —
+        // see `Heaps::live_logical_bytes`). `to_pay` is exactly the growth over what has already
+        // been counted for this heap (counted size stays in sync with `heap_size` below), so
+        // `live_logical_bytes() + to_pay` is the total this grow would reach. On a breach we abort
+        // the whole transaction and bail *before* paying gas, growing the heap, or bumping the
+        // counter: `abort_transaction` arms the uncatchable tx-wide unwind (`aborting = true`), and
+        // the `Err(())` drives the caller onto its panic path where the next `Ret<Panic>` sees
+        // `aborting` and cascades. This overloads `Err` (also used for plain out-of-gas), but the
+        // two are distinguished by `aborting`: out-of-gas leaves it false (one-level panic), this
+        // sets it true (tx-wide unwind).
+        if !state.current_frame.is_kernel
+            && state.heaps.live_logical_bytes() + u64::from(to_pay) > state.memory_ceiling_bytes
+        {
+            state.abort_transaction();
+            return Err(());
+        }
         state.use_gas(to_pay)?;
         *H::get_heap_size(state) = new_bound;
         if !state.current_frame.is_kernel {

--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -182,7 +182,11 @@ pub(crate) fn grow_heap<T: Tracer, W: World<T>, H: HeapFromState>(
         // two are distinguished by `aborting`: out-of-gas leaves it false (one-level panic), this
         // sets it true (tx-wide unwind).
         if !state.current_frame.is_kernel
-            && state.heaps.live_logical_bytes() + u64::from(to_pay) > state.memory_ceiling_bytes
+            && state
+                .heaps
+                .live_logical_bytes()
+                .saturating_add(u64::from(to_pay))
+                > state.memory_ceiling_bytes
         {
             state.abort_transaction();
             return Err(());

--- a/crates/vm2/src/instruction_handlers/heap_access.rs
+++ b/crates/vm2/src/instruction_handlers/heap_access.rs
@@ -172,6 +172,10 @@ pub(crate) fn grow_heap<T, W, H: HeapFromState>(
     if let Some(to_pay) = new_bound.checked_sub(*H::get_heap_size(state)) {
         state.use_gas(to_pay)?;
         *H::get_heap_size(state) = new_bound;
+        if !state.current_frame.is_kernel {
+            let heap = H::get_heap(state);
+            state.heaps.set_counted_size(heap, new_bound);
+        }
     }
 
     Ok(())

--- a/crates/vm2/src/instruction_handlers/mod.rs
+++ b/crates/vm2/src/instruction_handlers/mod.rs
@@ -1,10 +1,7 @@
-#[cfg(feature = "single_instruction_test")]
-pub(crate) use ret::spontaneous_panic;
-
 pub(crate) use self::{
     context::address_into_u256,
     heap_access::{AuxHeap, Heap},
-    ret::invalid_instruction,
+    ret::{invalid_instruction, spontaneous_panic},
 };
 
 mod binop;

--- a/crates/vm2/src/instruction_handlers/ret.rs
+++ b/crates/vm2/src/instruction_handlers/ret.rs
@@ -32,7 +32,23 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
         snapshot,
     }) = vm.state.current_frame.pop_near_call()
     {
-        if TO_LABEL {
+        if vm.state.aborting {
+            // An uncatchable unwind is in progress: this near-call return must not stop at its
+            // label or exception handler either (`TO_LABEL`/`return_type` are irrelevant here).
+            if vm.state.previous_frames.is_empty() {
+                // We're already back in the bootloader's (frame 0's) own near-call context:
+                // deliver the panic normally so its handler runs, exactly like the ordinary
+                // failure path below. Frame 0 itself is never popped by a near-call return.
+                vm.state.aborting = false;
+                vm.state.current_frame.set_pc_from_u16(exception_handler);
+            } else {
+                // Not yet at the bootloader: keep re-panicking through the current frame's
+                // near-calls (or, once none remain, its far-frame caller) until the bootloader
+                // is reached; see the far-frame branch below for the terminal case.
+                vm.state.current_frame.gas = 0;
+                vm.state.current_frame.pc = spontaneous_panic();
+            }
+        } else if TO_LABEL {
             let pc = Immediate1::get_u16(args);
             vm.state.current_frame.set_pc_from_u16(pc);
         } else if return_type.is_failure() {
@@ -113,7 +129,20 @@ fn naked_ret<T: Tracer, W: World<T>, RT: TypeLevelReturnType, const TO_LABEL: bo
         }
         vm.state.register_pointer_flags = 2;
 
-        if return_type.is_failure() {
+        if vm.state.aborting {
+            // Same uncatchable-unwind handling as the near-call branch above.
+            if vm.state.previous_frames.is_empty() {
+                // We just returned into the bootloader (frame 0): deliver the panic normally so
+                // its handler runs. Frame 0 is never popped here (`pop_frame` returned `None`
+                // for that case above, taking the early-return branch instead).
+                vm.state.aborting = false;
+                vm.state.current_frame.set_pc_from_u16(exception_handler);
+            } else {
+                // Not yet at the bootloader: re-panic this frame too, skipping its handler.
+                vm.state.current_frame.gas = 0;
+                vm.state.current_frame.pc = spontaneous_panic();
+            }
+        } else if return_type.is_failure() {
             vm.state.current_frame.set_pc_from_u16(exception_handler);
         }
 

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -106,6 +106,14 @@ impl Heaps {
     // here, matching `deallocate`'s no-op above.
     pub(crate) fn set_counted_size(&mut self, _: HeapId, _: u32) {}
 
+    // No-op mirror of the counter above: always reports zero live bytes. The single-instruction
+    // fuzzer runs with the ceiling disabled (`memory_ceiling_bytes == u64::MAX`, see `Settings`'s
+    // `Arbitrary`), so the ceiling checks in `grow_heap`/`far_call` that consult this are always
+    // `0 + delta > u64::MAX == false` and never fire.
+    pub(crate) fn live_logical_bytes(&self) -> u64 {
+        0
+    }
+
     pub(crate) fn dynamic_len(&self) -> usize {
         unimplemented!()
     }

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -101,6 +101,11 @@ impl Heaps {
 
     pub(crate) fn deallocate(&mut self, _: HeapId) {}
 
+    // No-op: this mock `Heaps` doesn't model the logical-byte counter (it isn't exercised by the
+    // single-instruction property tests), so `push_frame`'s counting calls are simply ignored
+    // here, matching `deallocate`'s no-op above.
+    pub(crate) fn set_counted_size(&mut self, _: HeapId, _: u32) {}
+
     pub(crate) fn dynamic_len(&self) -> usize {
         unimplemented!()
     }

--- a/crates/vm2/src/single_instruction_test/heap.rs
+++ b/crates/vm2/src/single_instruction_test/heap.rs
@@ -123,11 +123,11 @@ impl Heaps {
         self.read.get_mut(heap).write_bytes(start_address, bytes);
     }
 
-    pub(crate) fn snapshot(&self) -> (usize, usize) {
+    pub(crate) fn snapshot(&self) -> (usize, usize, u64) {
         unimplemented!()
     }
 
-    pub(crate) fn rollback(&mut self, _: (usize, usize)) {
+    pub(crate) fn rollback(&mut self, _: (usize, usize, u64)) {
         unimplemented!()
     }
 

--- a/crates/vm2/src/single_instruction_test/vm.rs
+++ b/crates/vm2/src/single_instruction_test/vm.rs
@@ -78,6 +78,9 @@ impl<'a, T: Tracer, W: World<T>> Arbitrary<'a> for VirtualMachine<T, W> {
                 next_base_page: first_dynamic_base_page(),
                 dst1_was_updated: false,
                 aborting: false,
+                // Ceiling disabled for single-instruction fuzzing (matches `Settings`'s
+                // `Arbitrary`, which fixes `memory_ceiling_bytes` to `u64::MAX`).
+                memory_ceiling_bytes: u64::MAX,
             },
             settings: u.arbitrary()?,
             world_diff: WorldDiff::default(),
@@ -134,6 +137,7 @@ impl<'a> Arbitrary<'a> for Settings {
             default_aa_code_hash,
             evm_interpreter_code_hash,
             hook_address: 0, // Doesn't matter; we don't decode in bootloader mode
+            memory_ceiling_bytes: u64::MAX, // Disabled: single-instruction fuzzing must be unaffected
         })
     }
 }

--- a/crates/vm2/src/single_instruction_test/vm.rs
+++ b/crates/vm2/src/single_instruction_test/vm.rs
@@ -77,6 +77,7 @@ impl<'a, T: Tracer, W: World<T>> Arbitrary<'a> for VirtualMachine<T, W> {
                 context_u128: u.arbitrary()?,
                 next_base_page: first_dynamic_base_page(),
                 dst1_was_updated: false,
+                aborting: false,
             },
             settings: u.arbitrary()?,
             world_diff: WorldDiff::default(),

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -170,6 +170,11 @@ impl<T: Tracer, W: World<T>> State<T, W> {
                 self.heaps.deallocate(heap);
             }
         }
+        // Order matters for `live_logical_bytes`: `rollback` flat-overwrites the counter to its
+        // snapshotted value, and dynamic heap groups only ever grow within a snapshot's scope, so
+        // that overwrite already accounts for everything `truncate_dynamic_to` is about to drop.
+        // `truncate_dynamic_to` itself does not touch the counter (see its doc comment) — it
+        // relies on `rollback` having run first. Do not reorder these two calls.
         self.heaps.rollback(bootloader_heap_snapshot);
 
         // Pages created after the host snapshot may no longer be reachable from any frame-level

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -36,6 +36,12 @@ pub(crate) struct State<T, W> {
     /// Set when an invariant violation requires unwinding the whole transaction.
     /// Transient: consumed by the unwind in `naked_ret`; excluded from equality and snapshots.
     pub(crate) aborting: bool,
+    /// Mirror of [`Settings::memory_ceiling_bytes`](crate::Settings::memory_ceiling_bytes), copied
+    /// here because `grow_heap` only sees `&mut State`. Deterministic config, constant for the
+    /// life of the VM; excluded from equality and snapshots (like `aborting`/`dst1_was_updated`),
+    /// but — unlike those transient flags — it is NOT reset by `rollback`, since it is a fixed
+    /// configuration value, not per-instruction bookkeeping. `u64::MAX` disables the check.
+    pub(crate) memory_ceiling_bytes: u64,
 }
 
 impl<T, W> State<T, W> {
@@ -86,6 +92,9 @@ impl<T, W> State<T, W> {
             next_base_page: first_dynamic_base_page(),
             dst1_was_updated: false,
             aborting: false,
+            // Disabled by default; `VirtualMachine::new` overwrites this with the configured
+            // `Settings.memory_ceiling_bytes` immediately after construction.
+            memory_ceiling_bytes: u64::MAX,
         }
     }
 
@@ -229,6 +238,7 @@ impl<T, W> Clone for State<T, W> {
             next_base_page: self.next_base_page,
             dst1_was_updated: self.dst1_was_updated,
             aborting: self.aborting,
+            memory_ceiling_bytes: self.memory_ceiling_bytes,
         }
     }
 }
@@ -340,6 +350,7 @@ mod tests {
                 default_aa_code_hash: [0; 32],
                 evm_interpreter_code_hash: [0; 32],
                 hook_address: 0,
+                memory_ceiling_bytes: u64::MAX,
             },
         );
 

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -6,6 +6,7 @@ use crate::{
     callframe::{Callframe, CallframeSnapshot},
     fat_pointer::FatPointer,
     heap::Heaps,
+    instruction_handlers::spontaneous_panic,
     page_ids::{first_dynamic_base_page, next_page_group},
     predication::Flags,
     program::Program,
@@ -32,6 +33,9 @@ pub(crate) struct State<T, W> {
     /// Set by every `dst1` write; if still `false` after execution, `dst1` is cleared to zero,
     /// matching `zk_evm`. Transient per-instruction bookkeeping; excluded from equality and snapshots.
     pub(crate) dst1_was_updated: bool,
+    /// Set when an invariant violation requires unwinding the whole transaction.
+    /// Transient: consumed by the unwind in `naked_ret`; excluded from equality and snapshots.
+    pub(crate) aborting: bool,
 }
 
 impl<T, W> State<T, W> {
@@ -81,6 +85,7 @@ impl<T, W> State<T, W> {
             context_u128: 0,
             next_base_page: first_dynamic_base_page(),
             dst1_was_updated: false,
+            aborting: false,
         }
     }
 
@@ -184,10 +189,24 @@ impl<T: Tracer, W: World<T>> State<T, W> {
         // start of the next instruction before being read, so this is a functional no-op; we clear
         // it here to keep the invariant "never survives an instruction boundary" self-evident.
         self.dst1_was_updated = false;
+        // Not part of the snapshot either. A rollback undoes a frame's effects via its exception
+        // handler, which an active abort always bypasses (see `abort_transaction`'s doc comment),
+        // so this can't fire mid-unwind; cleared here for the same self-evidence reason as above.
+        self.aborting = false;
     }
 
     pub(crate) fn delete_history(&mut self) {
         self.heaps.delete_history();
+    }
+
+    /// Begin an uncatchable unwind of the entire current transaction.
+    /// Callable from inside any instruction handler. The unwind itself runs in
+    /// `naked_ret` on subsequent steps, skipping every frame's exception handler
+    /// until control returns to the bootloader (frame 0).
+    pub(crate) fn abort_transaction(&mut self) {
+        self.aborting = true;
+        self.current_frame.gas = 0;
+        self.current_frame.pc = spontaneous_panic();
     }
 }
 
@@ -204,6 +223,7 @@ impl<T, W> Clone for State<T, W> {
             context_u128: self.context_u128,
             next_base_page: self.next_base_page,
             dst1_was_updated: self.dst1_was_updated,
+            aborting: self.aborting,
         }
     }
 }
@@ -281,4 +301,49 @@ pub(crate) struct StateSnapshot {
     transaction_number: u16,
     context_u128: u128,
     next_base_page: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use zkevm_opcode_defs::ethereum_types::Address;
+
+    use crate::{
+        addressing_modes::{Arguments, Register, Register1},
+        instruction_handlers::spontaneous_panic,
+        testonly::{initial_decommit, TestWorld},
+        Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
+    };
+
+    #[test]
+    fn abort_transaction_arms_panic_and_burns_gas() {
+        let address = Address::from_low_u64_be(0x_1234_5678_90ab_cdef);
+        let instructions = vec![Instruction::from_ret(
+            Register1(Register::new(0)),
+            None,
+            Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        )];
+        let mut world = TestWorld::<()>::new(&[(address, Program::from_raw(instructions, vec![]))]);
+        let program = initial_decommit(&mut world, address);
+
+        let mut vm = VirtualMachine::new(
+            address,
+            program,
+            Address::zero(),
+            &[],
+            1000,
+            Settings {
+                default_aa_code_hash: [0; 32],
+                evm_interpreter_code_hash: [0; 32],
+                hook_address: 0,
+            },
+        );
+
+        let state = &mut vm.state;
+        state.current_frame.gas = 5000;
+        assert!(!state.aborting);
+        state.abort_transaction();
+        assert!(state.aborting);
+        assert_eq!(state.current_frame.gas, 0);
+        assert_eq!(state.current_frame.pc, spontaneous_panic::<(), _>());
+    }
 }

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -296,7 +296,7 @@ pub(crate) struct StateSnapshot {
     register_pointer_flags: u16,
     flags: Flags,
     bootloader_frame: CallframeSnapshot,
-    bootloader_heap_snapshot: (usize, usize),
+    bootloader_heap_snapshot: (usize, usize, u64),
     dynamic_heap_groups: usize,
     transaction_number: u16,
     context_u128: u128,

--- a/crates/vm2/src/state.rs
+++ b/crates/vm2/src/state.rs
@@ -318,7 +318,7 @@ pub(crate) struct StateSnapshot {
     next_base_page: u32,
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "single_instruction_test")))]
 mod tests {
     use zkevm_opcode_defs::ethereum_types::Address;
 

--- a/crates/vm2/src/tests/abort_unwind.rs
+++ b/crates/vm2/src/tests/abort_unwind.rs
@@ -190,6 +190,7 @@ fn abort_unwinds_past_exception_handlers_to_bootloader() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
 
@@ -329,6 +330,7 @@ fn abort_unwinds_frame_zero_near_call_terminal_case() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
 

--- a/crates/vm2/src/tests/abort_unwind.rs
+++ b/crates/vm2/src/tests/abort_unwind.rs
@@ -1,0 +1,231 @@
+//! Regression test for the uncatchable tx-wide unwind triggered by `State::abort_transaction`.
+//!
+//! Builds a four-deep call stack (bootloader -> A -> B -> C), each far call registering its own
+//! exception handler in the caller, then arms the abort while paused deep in C. The unwind must
+//! re-panic through every intermediate frame *without* running any of their exception handlers,
+//! stopping only once control returns to the bootloader (frame 0).
+
+use primitive_types::U256;
+use zkevm_opcode_defs::ethereum_types::Address;
+use zksync_vm2_interface::{
+    opcodes, CallframeInterface, GlobalStateInterface, OpcodeType, ShouldStop, StateInterface,
+    Tracer,
+};
+
+use crate::{
+    addressing_modes::{
+        Arguments, CodePage, Immediate1, Register, Register1, Register2, RegisterAndImmediate,
+    },
+    testonly::{initial_decommit, TestWorld},
+    ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
+    World,
+};
+
+const GAS_TO_PASS: u64 = 10_000;
+/// Index, within every `caller_program`, of the instruction reached if (and only if) its far
+/// call's exception handler actually runs. Shared across bootloader/A/B for convenience; the
+/// tracer disambiguates by also checking the frame's address.
+const CATCH_PC: u16 = 3;
+
+fn far_call_abi(gas: u64) -> U256 {
+    let mut abi = U256::zero();
+    abi.0[3] = gas;
+    abi
+}
+
+fn address_word(address: Address) -> U256 {
+    address.to_low_u64_be().into()
+}
+
+fn load_codepage<T: Tracer, W: World<T>>(immediate: u16, dest: Register) -> Instruction<T, W> {
+    let r0 = Register::new(0);
+    Instruction::from_add(
+        CodePage(RegisterAndImmediate {
+            immediate,
+            register: r0,
+        })
+        .into(),
+        Register2(r0),
+        Register1(dest).into(),
+        Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
+        false,
+        false,
+    )
+}
+
+fn far_call_to<T: Tracer, W: World<T>>(exception_handler: u16) -> Instruction<T, W> {
+    Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(exception_handler),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    )
+}
+
+fn ret_normal<T: Tracer, W: World<T>>() -> Instruction<T, W> {
+    Instruction::from_ret(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    )
+}
+
+/// A distinctive marker instruction for "this frame's exception handler ran". Distinct from the
+/// `Ret::Panic` opcode used by the abort cascade itself, so if it ever executes we know it wasn't
+/// the cascade's own spontaneous panic.
+fn catch_marker<T: Tracer, W: World<T>>() -> Instruction<T, W> {
+    Instruction::from_revert(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    )
+}
+
+/// Builds a program that loads `(abi, target_address)` from its code page (index 0 and 1
+/// respectively), far-calls `target` with `CATCH_PC` as the exception handler, and — only if
+/// that handler is reached — executes the `catch_marker` instruction at `CATCH_PC`.
+fn caller_program<T: Tracer, W: World<T>>(target: Address, gas_to_pass: u64) -> Program<T, W> {
+    Program::from_raw(
+        vec![
+            load_codepage(0, Register::new(1)),
+            load_codepage(1, Register::new(2)),
+            far_call_to(CATCH_PC),
+            catch_marker(),
+        ],
+        vec![far_call_abi(gas_to_pass), address_word(target)],
+    )
+}
+
+/// Stops the first `run()` once the VM is four far frames deep (bootloader, A, B, C); on any
+/// subsequent `run()`, also watches for the cascade delivering its final, normal panic into the
+/// bootloader, and records whether A's exception handler ever ran.
+struct AbortCascadeTracer {
+    target_depth: usize,
+    depth_reached: bool,
+    a_address: Address,
+    a_handler_ran: bool,
+    bootloader_address: Address,
+    bootloader_delivery_seen: bool,
+}
+
+impl AbortCascadeTracer {
+    fn new(target_depth: usize, a_address: Address, bootloader_address: Address) -> Self {
+        Self {
+            target_depth,
+            depth_reached: false,
+            a_address,
+            a_handler_ran: false,
+            bootloader_address,
+            bootloader_delivery_seen: false,
+        }
+    }
+}
+
+impl Tracer for AbortCascadeTracer {
+    fn before_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S) {
+        let frame = state.current_frame();
+        if frame.address() == self.a_address && frame.program_counter() == Some(CATCH_PC) {
+            self.a_handler_ran = true;
+        }
+    }
+
+    fn after_instruction<OP: OpcodeType, S: GlobalStateInterface>(
+        &mut self,
+        state: &mut S,
+    ) -> ShouldStop {
+        if !self.depth_reached && state.number_of_callframes() == self.target_depth {
+            self.depth_reached = true;
+            return ShouldStop::Stop;
+        }
+
+        let frame = state.current_frame();
+        let is_bootloader = frame.address() == self.bootloader_address;
+        let pc = frame.program_counter();
+        drop(frame);
+        // `flags().less_than` is how `Ret<Panic>` signals panic (see `naked_ret`'s
+        // `Flags::new(return_type == ReturnType::Panic, false, false)`).
+        let panicking = state.flags().less_than;
+        if is_bootloader && pc == Some(CATCH_PC) && panicking {
+            self.bootloader_delivery_seen = true;
+            return ShouldStop::Stop;
+        }
+        ShouldStop::Continue
+    }
+}
+
+#[test]
+fn abort_unwinds_past_exception_handlers_to_bootloader() {
+    let bootloader_address = Address::from_low_u64_be(0x_1000_0000_0000_0001);
+    let a_address = Address::from_low_u64_be(0x_2000_0000_0000_0001);
+    let b_address = Address::from_low_u64_be(0x_3000_0000_0000_0001);
+    let c_address = Address::from_low_u64_be(0x_4000_0000_0000_0001);
+
+    let bootloader_program: Program<AbortCascadeTracer, TestWorld<AbortCascadeTracer>> =
+        caller_program(a_address, GAS_TO_PASS);
+    let a_program: Program<AbortCascadeTracer, TestWorld<AbortCascadeTracer>> =
+        caller_program(b_address, GAS_TO_PASS);
+    let b_program: Program<AbortCascadeTracer, TestWorld<AbortCascadeTracer>> =
+        caller_program(c_address, GAS_TO_PASS);
+    let c_program: Program<AbortCascadeTracer, TestWorld<AbortCascadeTracer>> =
+        Program::from_raw(vec![ret_normal()], vec![]);
+
+    let mut world = TestWorld::new(&[
+        (bootloader_address, bootloader_program),
+        (a_address, a_program),
+        (b_address, b_program),
+        (c_address, c_program),
+    ]);
+    let program = initial_decommit(&mut world, bootloader_address);
+
+    let mut vm = VirtualMachine::new(
+        bootloader_address,
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+        },
+    );
+
+    // bootloader + A + B + C, no near calls => 4 far frames.
+    let mut tracer = AbortCascadeTracer::new(4, a_address, bootloader_address);
+
+    let end = vm.run(&mut world, &mut tracer);
+    assert_eq!(end, ExecutionEnd::StoppedByTracer);
+    assert!(tracer.depth_reached, "tracer never observed depth 4");
+    assert_eq!(
+        vm.state.previous_frames.len(),
+        3,
+        "should be paused deep in C, with bootloader/A/B suspended below it"
+    );
+
+    // Arm the abort as if C hit an invariant violation.
+    vm.state.abort_transaction();
+
+    // Resume: the cascade fires.
+    let end = vm.run(&mut world, &mut tracer);
+    assert_eq!(end, ExecutionEnd::StoppedByTracer);
+    assert!(
+        tracer.bootloader_delivery_seen,
+        "the panic never reached the bootloader"
+    );
+
+    // Uncatchability: despite A's exception handler being registered for B's failure, control
+    // unwound all the way back to frame 0 without ever stopping at it. If any intermediate
+    // handler had caught the panic, `previous_frames` would be non-empty here.
+    assert!(vm.state.previous_frames.is_empty());
+    assert!(!vm.state.aborting, "aborting flag must be cleared");
+    assert!(
+        !tracer.a_handler_ran,
+        "A's exception handler must not have run — the unwind is supposed to skip it"
+    );
+    assert!(
+        vm.flags().less_than,
+        "the panic must be delivered to the bootloader"
+    );
+}

--- a/crates/vm2/src/tests/abort_unwind.rs
+++ b/crates/vm2/src/tests/abort_unwind.rs
@@ -14,7 +14,8 @@ use zksync_vm2_interface::{
 
 use crate::{
     addressing_modes::{
-        Arguments, CodePage, Immediate1, Register, Register1, Register2, RegisterAndImmediate,
+        Arguments, CodePage, Immediate1, Immediate2, Register, Register1, Register2,
+        RegisterAndImmediate,
     },
     testonly::{initial_decommit, TestWorld},
     ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
@@ -227,5 +228,171 @@ fn abort_unwinds_past_exception_handlers_to_bootloader() {
     assert!(
         vm.flags().less_than,
         "the panic must be delivered to the bootloader"
+    );
+}
+
+/// Stops the first `run()` the instant a near call's `destination` is reached (near calls don't
+/// change `number_of_callframes()`, so depth-based stopping — used by the far-call test above —
+/// doesn't apply; we key off the program counter instead). On the resumed `run()`, also watches
+/// for the abort being delivered to the near call's own exception handler.
+struct StopAtNearCallTracer {
+    marker_pc: u16,
+    handler_pc: u16,
+    reached_marker: bool,
+    reached_handler_delivery: bool,
+}
+
+impl Tracer for StopAtNearCallTracer {
+    fn after_instruction<OP: OpcodeType, S: GlobalStateInterface>(
+        &mut self,
+        state: &mut S,
+    ) -> ShouldStop {
+        let frame = state.current_frame();
+        let pc = frame.program_counter();
+        drop(frame);
+
+        if !self.reached_marker && pc == Some(self.marker_pc) {
+            self.reached_marker = true;
+            return ShouldStop::Stop;
+        }
+        // `flags().less_than` is how `Ret<Panic>` signals panic (see `naked_ret`'s
+        // `Flags::new(return_type == ReturnType::Panic, false, false)`).
+        if !self.reached_handler_delivery && pc == Some(self.handler_pc) && state.flags().less_than
+        {
+            self.reached_handler_delivery = true;
+            return ShouldStop::Stop;
+        }
+        ShouldStop::Continue
+    }
+}
+
+/// Covers the *other* terminal case of the abort cascade: `naked_ret`'s near-call branch,
+/// `aborting && previous_frames.is_empty()` (`ret.rs:38`). The far-call test above only ever
+/// exercises the far-frame terminal case (`ret.rs:134`), because its terminal pop is always a
+/// `pop_frame`, never a `pop_near_call`. That branch is only reachable when the abort is armed
+/// while executing *inside a near-call of frame 0 itself*, with no far frames below — a
+/// scenario the far-call cascade can never produce, since by the time the cascade's terminal
+/// step runs it has already cleared `aborting` (and it always lands via `pop_frame`, not
+/// `pop_near_call`, because near calls don't nest across far-call boundaries). So this test
+/// arms the abort directly inside a frame-0 near call, as a synthetic seam for the primitive
+/// itself (in production, only the far-call cascade currently reaches `abort_transaction`, but
+/// the near-call terminal branch exists for the general case and must behave correctly too).
+#[test]
+fn abort_unwinds_frame_zero_near_call_terminal_case() {
+    // Held-back gas: the `NearCall` instruction itself costs `NEAR_CALL_COST` (charged by
+    // `full_boilerplate` before `push_near_call` runs), and then reserves `NEAR_CALL_GAS` for the
+    // near call, leaving `INITIAL_GAS - NEAR_CALL_COST - NEAR_CALL_GAS` held back on the frame to
+    // be restored when the near call pops. Using a nonzero, distinctive value makes "gas
+    // restored" unambiguous: 0 would be indistinguishable from the (wrong) "gas burned" behavior
+    // of the non-terminal re-panic branch.
+    const INITIAL_GAS: u32 = 1_000;
+    const NEAR_CALL_COST: u32 = 5;
+    const NEAR_CALL_GAS: u32 = 100;
+    const HELD_BACK_GAS: u32 = INITIAL_GAS - NEAR_CALL_COST - NEAR_CALL_GAS;
+
+    const MARKER_PC: u16 = 2;
+    const NEAR_CALL_EXCEPTION_HANDLER_PC: u16 = 3;
+
+    let bootloader_address = Address::from_low_u64_be(0x_5000_0000_0000_0001);
+
+    let program: Program<StopAtNearCallTracer, TestWorld<StopAtNearCallTracer>> = Program::from_raw(
+        vec![
+            // 0: near_call into the marker at MARKER_PC; on failure, jump to
+            // NEAR_CALL_EXCEPTION_HANDLER_PC. `gas` (r1) carries `gas_to_pass`.
+            Instruction::from_near_call(
+                Register1(Register::new(1)),
+                Immediate1(MARKER_PC),
+                Immediate2(NEAR_CALL_EXCEPTION_HANDLER_PC),
+                Arguments::new(Predicate::Always, NEAR_CALL_COST, ModeRequirements::none()),
+            ),
+            // 1: resumption point if the near call ever returned normally (unused here).
+            ret_normal(),
+            // 2: marker — the tracer pauses the VM right before this executes.
+            ret_normal(),
+            // 3: the near call's own exception handler. Only reached via *normal* (non-aborting)
+            // delivery — i.e. exactly what the terminal case is supposed to produce.
+            catch_marker(),
+        ],
+        vec![],
+    );
+
+    let mut world = TestWorld::new(&[(bootloader_address, program)]);
+    let program = initial_decommit(&mut world, bootloader_address);
+
+    let mut vm = VirtualMachine::new(
+        bootloader_address,
+        program,
+        Address::zero(),
+        &[],
+        INITIAL_GAS,
+        Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+        },
+    );
+
+    // r1 = NEAR_CALL_GAS (gas_to_pass for the near call). This is the very first instruction of
+    // the initial frame, so registers are still whatever `State::new` set them to (r1 normally
+    // holds the calldata fat pointer); overwrite it directly, as other in-crate tests do.
+    vm.state.registers[1] = U256::from(NEAR_CALL_GAS);
+    vm.state.register_pointer_flags &= !(1 << 1);
+
+    let mut tracer = StopAtNearCallTracer {
+        marker_pc: MARKER_PC,
+        handler_pc: NEAR_CALL_EXCEPTION_HANDLER_PC,
+        reached_marker: false,
+        reached_handler_delivery: false,
+    };
+
+    let end = vm.run(&mut world, &mut tracer);
+    assert_eq!(end, ExecutionEnd::StoppedByTracer);
+    assert!(tracer.reached_marker, "tracer never observed the marker pc");
+    assert!(
+        vm.state.previous_frames.is_empty(),
+        "no far frames exist in this test"
+    );
+    assert_eq!(
+        vm.current_frame().gas(),
+        NEAR_CALL_GAS,
+        "should be paused inside the near call, holding its own gas allocation"
+    );
+
+    // Arm the abort as if the near call hit an invariant violation.
+    vm.state.abort_transaction();
+
+    // Resume: the first `Ret<Panic>` pops the near call. Since `previous_frames` is empty, this
+    // must take `naked_ret`'s near-call *terminal* branch (`ret.rs:38`), not the re-panic branch
+    // (`ret.rs:48`) — there is nothing left to cascade through.
+    let end = vm.run(&mut world, &mut tracer);
+    assert_eq!(end, ExecutionEnd::StoppedByTracer);
+    assert!(
+        tracer.reached_handler_delivery,
+        "the panic never reached the near call's exception handler"
+    );
+
+    // The following three assertions are only jointly satisfiable by the terminal branch:
+    // - the re-panic branch would leave `aborting == true` and `pc` at `spontaneous_panic()`
+    //   (`program_counter()` would read `None`, not `Some(3)`);
+    // - the re-panic branch would also zero `current_frame.gas`, whereas the terminal branch
+    //   never touches it, so the pre-abort `HELD_BACK_GAS` must come back untouched.
+    assert!(!vm.state.aborting, "aborting flag must be cleared");
+    assert_eq!(
+        vm.current_frame().program_counter(),
+        Some(NEAR_CALL_EXCEPTION_HANDLER_PC),
+        "pc must be delivered to the near call's exception handler, not left at spontaneous_panic"
+    );
+    assert_eq!(
+        vm.current_frame().gas(),
+        HELD_BACK_GAS,
+        "the bootloader's held-back gas must be restored normally, not zeroed"
+    );
+    assert!(
+        vm.flags().less_than,
+        "the panic must still be delivered as a panic"
+    );
+    assert!(
+        vm.state.previous_frames.is_empty(),
+        "frame 0 must never be popped by a near-call return"
     );
 }

--- a/crates/vm2/src/tests/bytecode_behaviour.rs
+++ b/crates/vm2/src/tests/bytecode_behaviour.rs
@@ -28,6 +28,7 @@ fn call_to_invalid_address() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
     assert!(matches!(
@@ -65,6 +66,7 @@ fn storage_log_uses_vm_transaction_number() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
     vm.state.transaction_number = 7;

--- a/crates/vm2/src/tests/divergence_regressions.rs
+++ b/crates/vm2/src/tests/divergence_regressions.rs
@@ -29,6 +29,7 @@ fn default_settings() -> Settings {
         default_aa_code_hash: [0; 32],
         evm_interpreter_code_hash: [0; 32],
         hook_address: 0,
+        memory_ceiling_bytes: u64::MAX,
     }
 }
 
@@ -122,6 +123,7 @@ fn masked_default_aa_far_call(version_byte: u8) -> VirtualMachine<(), TestWorld<
             default_aa_code_hash: bytes32(default_aa_hash),
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
 

--- a/crates/vm2/src/tests/far_call_decommitment.rs
+++ b/crates/vm2/src/tests/far_call_decommitment.rs
@@ -126,6 +126,7 @@ fn test() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
 
@@ -202,6 +203,7 @@ fn test_with_initial_out_of_gas_error() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
 

--- a/crates/vm2/src/tests/far_call_decommitment.rs
+++ b/crates/vm2/src/tests/far_call_decommitment.rs
@@ -166,6 +166,7 @@ fn manual_decommit_warms_up_subsequent_decommits() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
 

--- a/crates/vm2/src/tests/frame_stipend_counter.rs
+++ b/crates/vm2/src/tests/frame_stipend_counter.rs
@@ -21,6 +21,7 @@ fn default_settings() -> Settings {
         default_aa_code_hash: [0; 32],
         evm_interpreter_code_hash: [0; 32],
         hook_address: 0,
+        memory_ceiling_bytes: u64::MAX,
     }
 }
 

--- a/crates/vm2/src/tests/frame_stipend_counter.rs
+++ b/crates/vm2/src/tests/frame_stipend_counter.rs
@@ -3,6 +3,7 @@
 //! and kernel frames (the bootloader/system contracts, which get huge free heaps) must never
 //! inflate the counter — it is a per-user-tx ceiling, not a kernel one.
 
+use primitive_types::U256;
 use zkevm_opcode_defs::{
     ethereum_types::Address,
     system_params::{NEW_FRAME_MEMORY_STIPEND, NEW_KERNEL_FRAME_MEMORY_STIPEND},
@@ -10,7 +11,7 @@ use zkevm_opcode_defs::{
 use zksync_vm2_interface::opcodes;
 
 use crate::{
-    addressing_modes::{Arguments, Register, Register1},
+    addressing_modes::{Arguments, Register, Register1, Register2},
     testonly::TestWorld,
     Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
 };
@@ -57,7 +58,21 @@ fn new_vm(root_address: Address) -> VirtualMachine<(), TestWorld<()>> {
 /// under test. This mirrors the pattern already used by `divergence_regressions.rs` for
 /// decommit-page tests.
 fn push_child_frame(vm: &mut VirtualMachine<(), TestWorld<()>>, child_address: Address) {
-    let program = Program::from_raw(vec![ret_instruction()], vec![]);
+    push_child_frame_with_program(
+        vm,
+        child_address,
+        Program::from_raw(vec![ret_instruction()], vec![]),
+    );
+}
+
+/// Like [`push_child_frame`], but lets the caller supply the child's program directly, so tests
+/// can drive real instruction handlers (e.g. a heap store, to exercise `grow_heap`) via
+/// [`execute_one_instruction`] instead of only poking `push_frame`/`pop_frame` state directly.
+fn push_child_frame_with_program(
+    vm: &mut VirtualMachine<(), TestWorld<()>>,
+    child_address: Address,
+    program: Program<(), TestWorld<()>>,
+) {
     let calldata_heap = vm.state.current_frame.calldata_heap;
     let snapshot = vm.world_diff.snapshot();
     vm.push_frame::<opcodes::Normal>(
@@ -70,6 +85,15 @@ fn push_child_frame(vm: &mut VirtualMachine<(), TestWorld<()>>, child_address: A
         calldata_heap,
         snapshot,
     );
+}
+
+/// Executes exactly the one instruction at the current frame's program counter, without looping
+/// (unlike `VirtualMachine::run`, which runs until something stops it). Mirrors the identically
+/// named helper in `divergence_regressions.rs`, specialized to this file's concrete `T`/`W`.
+fn execute_one_instruction(vm: &mut VirtualMachine<(), TestWorld<()>>, world: &mut TestWorld<()>) {
+    unsafe {
+        let _ = ((*vm.state.current_frame.pc).handler)(vm, world, &mut ());
+    }
 }
 
 #[test]
@@ -142,5 +166,69 @@ fn kept_returndata_heap_stays_counted_after_pop() {
         vm.state.heaps.live_logical_bytes(),
         base + stip,
         "the kept heap's stipend must remain counted; only the aux heap's is dropped"
+    );
+}
+
+#[test]
+fn grow_heap_raises_counter_and_reverts() {
+    // A store far past the stipend forces `grow_heap` to actually grow the heap (rather than
+    // being absorbed by the free stipend), which must raise `live_logical_bytes` by exactly the
+    // growth over the stipend.
+    const OFFSET: u32 = 100_000;
+    const NEW_BOUND: u32 = OFFSET + 32; // 100_032
+
+    const ADDR_REG: u8 = 2;
+    const VAL_REG: u8 = 3;
+    let heap_write = Instruction::from_heap_write(
+        Register1(Register::new(ADDR_REG)).into(),
+        Register2(Register::new(VAL_REG)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+        false,
+    );
+    let program = Program::from_raw(vec![heap_write], vec![]);
+
+    let mut vm = new_vm(kernel_address());
+    let mut world = TestWorld::new(&[]);
+    let base = vm.state.heaps.live_logical_bytes();
+
+    push_child_frame_with_program(&mut vm, non_kernel_address(), program);
+
+    let stip = u64::from(NEW_FRAME_MEMORY_STIPEND);
+    assert_eq!(
+        vm.state.heaps.live_logical_bytes(),
+        base + 2 * stip,
+        "sanity: pushing the frame counted both stipends before any growth"
+    );
+
+    // Clear both registers' pointer-tag bits (registers persist across our direct `push_frame`,
+    // which — unlike a real far call — does not reset them) so the store's address/value reads
+    // are treated as plain integers.
+    vm.state.register_pointer_flags &= !((1 << ADDR_REG) | (1 << VAL_REG));
+    vm.state.registers[usize::from(ADDR_REG)] = U256::from(OFFSET);
+    vm.state.registers[usize::from(VAL_REG)] = U256::from(0x1234_u64);
+
+    execute_one_instruction(&mut vm, &mut world);
+
+    assert_eq!(
+        vm.state.current_frame.heap_size, NEW_BOUND,
+        "the store must have grown the heap to cover its address"
+    );
+    assert_eq!(
+        vm.state.heaps.live_logical_bytes(),
+        base + stip + u64::from(NEW_BOUND),
+        "growth must raise the counter by the growth delta over the stipend \
+         (aux heap stays at its stipend, untouched)"
+    );
+
+    // Revert the frame (via a direct `pop_frame(None)`, exactly like the other tests in this
+    // file, rather than a real `Ret<Revert>` instruction — the return-ABI/fat-pointer forwarding
+    // machinery is irrelevant to what's under test here). Task 3/4's `pop_frame`/`deallocate`
+    // must restore the counter to baseline with no new code in `grow_heap` for this half.
+    vm.pop_frame(None).expect("child frame must be present");
+    assert_eq!(
+        vm.state.heaps.live_logical_bytes(),
+        base,
+        "reverting (popping) the frame must restore the counter to baseline"
     );
 }

--- a/crates/vm2/src/tests/frame_stipend_counter.rs
+++ b/crates/vm2/src/tests/frame_stipend_counter.rs
@@ -1,0 +1,146 @@
+//! Covers the wiring between `push_frame`/`pop_frame` and `Heaps::live_logical_bytes`: every
+//! non-kernel frame's stipend heaps (heap + aux heap) must be counted while the frame is live,
+//! and kernel frames (the bootloader/system contracts, which get huge free heaps) must never
+//! inflate the counter — it is a per-user-tx ceiling, not a kernel one.
+
+use zkevm_opcode_defs::{
+    ethereum_types::Address,
+    system_params::{NEW_FRAME_MEMORY_STIPEND, NEW_KERNEL_FRAME_MEMORY_STIPEND},
+};
+use zksync_vm2_interface::opcodes;
+
+use crate::{
+    addressing_modes::{Arguments, Register, Register1},
+    testonly::TestWorld,
+    Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
+};
+
+fn default_settings() -> Settings {
+    Settings {
+        default_aa_code_hash: [0; 32],
+        evm_interpreter_code_hash: [0; 32],
+        hook_address: 0,
+    }
+}
+
+/// First 18 bytes are zero, so this address executes in kernel mode (see `decommit::is_kernel`).
+fn kernel_address() -> Address {
+    Address::from_low_u64_be(1)
+}
+
+fn non_kernel_address() -> Address {
+    Address::repeat_byte(1)
+}
+
+fn ret_instruction() -> Instruction<(), TestWorld<()>> {
+    Instruction::from_ret(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    )
+}
+
+fn new_vm(root_address: Address) -> VirtualMachine<(), TestWorld<()>> {
+    let program = Program::from_raw(vec![ret_instruction()], vec![]);
+    VirtualMachine::new(
+        root_address,
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(),
+    )
+}
+
+/// Directly drives `push_frame`/`pop_frame` (bypassing the far-call/ret opcode ABI machinery,
+/// which has its own returndata-forwarding rules irrelevant here) to isolate the counter wiring
+/// under test. This mirrors the pattern already used by `divergence_regressions.rs` for
+/// decommit-page tests.
+fn push_child_frame(vm: &mut VirtualMachine<(), TestWorld<()>>, child_address: Address) {
+    let program = Program::from_raw(vec![ret_instruction()], vec![]);
+    let calldata_heap = vm.state.current_frame.calldata_heap;
+    let snapshot = vm.world_diff.snapshot();
+    vm.push_frame::<opcodes::Normal>(
+        child_address,
+        program,
+        200_000,
+        0,
+        false,
+        false,
+        calldata_heap,
+        snapshot,
+    );
+}
+
+#[test]
+fn push_pop_moves_counter_by_stipend_for_user_frames() {
+    let mut vm = new_vm(kernel_address());
+    let base = vm.state.heaps.live_logical_bytes();
+    assert_eq!(
+        base, 0,
+        "the root (kernel) frame's heaps must not be counted"
+    );
+
+    push_child_frame(&mut vm, non_kernel_address());
+
+    let stip = u64::from(NEW_FRAME_MEMORY_STIPEND);
+    assert_eq!(
+        vm.state.heaps.live_logical_bytes(),
+        base + 2 * stip,
+        "pushing a non-kernel frame must count both its heap and aux heap stipends"
+    );
+
+    vm.pop_frame(None).expect("child frame must be present");
+    assert_eq!(
+        vm.state.heaps.live_logical_bytes(),
+        base,
+        "popping with nothing kept alive must return the counter to baseline"
+    );
+}
+
+#[test]
+fn kernel_frame_not_counted() {
+    let mut vm = new_vm(kernel_address());
+    let base = vm.state.heaps.live_logical_bytes();
+
+    push_child_frame(&mut vm, kernel_address());
+
+    assert_eq!(
+        vm.state.heaps.live_logical_bytes(),
+        base,
+        "kernel frames must never inflate the per-user-tx counter"
+    );
+
+    // Sanity check: this really did allocate a kernel-sized stipend that we're deliberately not
+    // counting, not just a coincidentally-equal value.
+    assert_eq!(
+        vm.state.current_frame.heap_size,
+        NEW_KERNEL_FRAME_MEMORY_STIPEND
+    );
+    assert!(vm.state.current_frame.is_kernel);
+
+    vm.pop_frame(None).expect("child frame must be present");
+    assert_eq!(vm.state.heaps.live_logical_bytes(), base);
+}
+
+#[test]
+fn kept_returndata_heap_stays_counted_after_pop() {
+    // A frame that keeps one of its own heaps alive (e.g. as returndata bubbled to the caller)
+    // must not have that heap's stipend decremented on pop — only the discarded one should drop.
+    let mut vm = new_vm(kernel_address());
+    let base = vm.state.heaps.live_logical_bytes();
+
+    push_child_frame(&mut vm, non_kernel_address());
+    let stip = u64::from(NEW_FRAME_MEMORY_STIPEND);
+    assert_eq!(vm.state.heaps.live_logical_bytes(), base + 2 * stip);
+
+    let kept_heap = vm.state.current_frame.heap;
+    vm.pop_frame(Some(kept_heap))
+        .expect("child frame must be present");
+
+    assert_eq!(
+        vm.state.heaps.live_logical_bytes(),
+        base + stip,
+        "the kept heap's stipend must remain counted; only the aux heap's is dropped"
+    );
+}

--- a/crates/vm2/src/tests/memory_ceiling.rs
+++ b/crates/vm2/src/tests/memory_ceiling.rs
@@ -267,3 +267,157 @@ fn far_call_stipend_over_ceiling_reverts_whole_tx() {
 
     run_and_assert_uncatchable_revert(&programs);
 }
+
+/// Tracks the maximum call depth reached and stops when the panic is delivered to the bootloader.
+/// A ceiling-breaching `far_call` must still PUSH a (panicking) frame — so `max_depth` reaches the
+/// full nesting — then unwind completely. A regression that returned without pushing would leave
+/// the `FarCall` opcode unbalanced against its `Ret` (a phantom open call-tree node) and top
+/// `max_depth` out one short.
+struct DepthBalanceTracer {
+    bootloader_address: Address,
+    max_depth: usize,
+    bootloader_delivery_seen: bool,
+}
+
+impl Tracer for DepthBalanceTracer {
+    fn after_instruction<OP: OpcodeType, S: GlobalStateInterface>(
+        &mut self,
+        state: &mut S,
+    ) -> ShouldStop {
+        self.max_depth = self.max_depth.max(state.number_of_callframes());
+        let frame = state.current_frame();
+        let is_bootloader = frame.address() == self.bootloader_address;
+        let pc = frame.program_counter();
+        drop(frame);
+        if is_bootloader && pc == Some(CATCH_PC) && state.flags().less_than {
+            self.bootloader_delivery_seen = true;
+            return ShouldStop::Stop;
+        }
+        ShouldStop::Continue
+    }
+}
+
+#[test]
+fn far_call_ceiling_abort_keeps_call_tree_balanced() {
+    let bootloader_address = Address::from_low_u64_be(0x_1000_0000_0000_0001);
+    let a_address = Address::from_low_u64_be(0x_2000_0000_0000_0001);
+    let b_address = Address::from_low_u64_be(0x_3000_0000_0000_0001);
+    let c_address = Address::from_low_u64_be(0x_4000_0000_0000_0001);
+
+    let programs: Vec<(
+        Address,
+        Program<DepthBalanceTracer, TestWorld<DepthBalanceTracer>>,
+    )> = vec![
+        (bootloader_address, caller_program(a_address, GAS_TO_PASS)),
+        (a_address, caller_program(b_address, GAS_TO_PASS)),
+        (b_address, caller_program(c_address, GAS_TO_PASS)),
+        (c_address, Program::from_raw(vec![ret_normal()], vec![])),
+    ];
+
+    let mut world = TestWorld::new(&programs);
+    let program = initial_decommit(&mut world, bootloader_address);
+    let mut vm = VirtualMachine::new(
+        bootloader_address,
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+            memory_ceiling_bytes: CEILING,
+        },
+    );
+
+    let mut tracer = DepthBalanceTracer {
+        bootloader_address,
+        max_depth: 0,
+        bootloader_delivery_seen: false,
+    };
+
+    let end = vm.run(&mut world, &mut tracer);
+    assert_eq!(end, ExecutionEnd::StoppedByTracer);
+    assert!(
+        tracer.bootloader_delivery_seen,
+        "tx never unwound to the bootloader"
+    );
+    // The breaching far_call (B -> C) pushed a real (panicking) frame, so depth reached the full
+    // four (bootloader, A, B, C). A no-push regression would top out at three, leaving the FarCall
+    // opcode's traced callee node unbalanced against any Ret.
+    assert_eq!(
+        tracer.max_depth, 4,
+        "the ceiling-breaching far_call must still push a frame (balanced FarCall<->Ret)"
+    );
+    // ...and it unwound the whole way: back at frame 0 only.
+    assert!(
+        vm.state.previous_frames.is_empty(),
+        "must unwind to the bootloader"
+    );
+}
+
+/// A minimal single-(root-)frame VM with the ceiling disabled, for the `State`-equality guards.
+fn single_frame_vm() -> VirtualMachine<(), TestWorld<()>> {
+    let address = Address::from_low_u64_be(0x_2000_0000_0000_0001);
+    let program: Program<(), TestWorld<()>> = Program::from_raw(vec![ret_normal()], vec![]);
+    let mut world = TestWorld::new(&[(address, program)]);
+    let program = initial_decommit(&mut world, address);
+    VirtualMachine::new(
+        address,
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
+        },
+    )
+}
+
+#[test]
+fn transient_and_config_state_fields_excluded_from_eq() {
+    // Guards the consensus-invisibility invariant: `aborting` (transient) and `memory_ceiling_bytes`
+    // (config) must never leak into `State::eq`. Two states differing only in one of them compare
+    // equal; a future edit adding either to equality fails this test loudly. (The heap counter's
+    // exclusion is guarded in `heap.rs`'s `live_logical_bytes_excluded_from_heaps_eq`, since that
+    // field is private to the heap module.)
+    let vm = single_frame_vm();
+    let base = vm.state.clone();
+
+    let mut flipped = base.clone();
+    flipped.aborting = !flipped.aborting;
+    assert_eq!(
+        base, flipped,
+        "`aborting` must stay excluded from State::eq"
+    );
+
+    let mut reconfigured = base.clone();
+    reconfigured.memory_ceiling_bytes ^= 0xdead_beef;
+    assert_eq!(
+        base, reconfigured,
+        "`memory_ceiling_bytes` must stay excluded from State::eq"
+    );
+}
+
+#[test]
+fn excluded_state_fields_survive_snapshot_rollback() {
+    // A snapshot -> mutate-excluded-fields -> rollback round-trip must land on an equal state, even
+    // though rollback neither snapshots nor restores these fields (it resets `aborting` to false and
+    // leaves `memory_ceiling_bytes` as-is): they are excluded from equality, so the round-trip is
+    // consensus-invisible either way.
+    let mut vm = single_frame_vm();
+    vm.make_snapshot();
+    let before = vm.state.clone();
+
+    vm.state.aborting = true;
+    vm.state.memory_ceiling_bytes ^= 0xbeef;
+    vm.rollback();
+
+    assert_eq!(
+        before, vm.state,
+        "excluded fields must not perturb a snapshot round-trip"
+    );
+}

--- a/crates/vm2/src/tests/memory_ceiling.rs
+++ b/crates/vm2/src/tests/memory_ceiling.rs
@@ -1,0 +1,269 @@
+//! Enforcement tests for `Settings.memory_ceiling_bytes` (Task 6).
+//!
+//! Two production trigger sites can fire the uncatchable tx-wide abort when a *user* (non-kernel)
+//! transaction would push the summed logical heap bytes over the configured ceiling:
+//!
+//! * `grow_heap` — a heap store whose growth would cross the ceiling (`grow_over_ceiling_*`);
+//! * `far_call` — pushing the next frame, whose stipends would cross the ceiling
+//!   (`far_call_stipend_over_ceiling_*`).
+//!
+//! Both build a bootloader -> A -> B call stack (A registers its own exception handler for B's
+//! failure) with a LOW ceiling, drive the crossing, and assert the whole transaction unwound to
+//! the bootloader (frame 0) *without* running A's exception handler — i.e. the ceiling breach is
+//! uncatchable, exactly like the abort primitive in `abort_unwind.rs`. Both stipends are
+//! `NEW_FRAME_MEMORY_STIPEND` (non-EVM, non-kernel), so each pushed frame counts `2 * STIP`.
+
+use primitive_types::U256;
+use zkevm_opcode_defs::{ethereum_types::Address, system_params::NEW_FRAME_MEMORY_STIPEND};
+use zksync_vm2_interface::{
+    opcodes, CallframeInterface, GlobalStateInterface, OpcodeType, ShouldStop, StateInterface,
+    Tracer,
+};
+
+use crate::{
+    addressing_modes::{
+        Arguments, CodePage, Immediate1, Register, Register1, Register2, RegisterAndImmediate,
+    },
+    testonly::{initial_decommit, TestWorld},
+    ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
+    World,
+};
+
+const GAS_TO_PASS: u64 = 50_000;
+/// Index, within every `caller_program`, of the instruction reached only if that frame's far-call
+/// exception handler actually runs — i.e. only if the panic were *catchable*.
+const CATCH_PC: u16 = 3;
+/// Non-kernel frame heap stipend. Each pushed non-kernel frame counts `2 * STIP` (heap + aux heap)
+/// against `live_logical_bytes`.
+const STIP: u64 = NEW_FRAME_MEMORY_STIPEND as u64;
+/// Low ceiling shared by both tests. It admits bootloader -> A -> B (root frame is never counted;
+/// A and B each add `2 * STIP`, reaching `4 * STIP`), but rejects the next crossing:
+/// * grow test — B's heap growth (delta far exceeds `STIP`) pushes well past `5 * STIP`;
+/// * far-call test — pushing C would reach `6 * STIP > 5 * STIP`.
+const CEILING: u64 = 5 * STIP;
+
+fn far_call_abi(gas: u64) -> U256 {
+    let mut abi = U256::zero();
+    abi.0[3] = gas;
+    abi
+}
+
+fn address_word(address: Address) -> U256 {
+    address.to_low_u64_be().into()
+}
+
+fn load_codepage<T: Tracer, W: World<T>>(immediate: u16, dest: Register) -> Instruction<T, W> {
+    let r0 = Register::new(0);
+    Instruction::from_add(
+        CodePage(RegisterAndImmediate {
+            immediate,
+            register: r0,
+        })
+        .into(),
+        Register2(r0),
+        Register1(dest).into(),
+        Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
+        false,
+        false,
+    )
+}
+
+fn far_call_to<T: Tracer, W: World<T>>(exception_handler: u16) -> Instruction<T, W> {
+    Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(exception_handler),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    )
+}
+
+fn ret_normal<T: Tracer, W: World<T>>() -> Instruction<T, W> {
+    Instruction::from_ret(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    )
+}
+
+/// Marker instruction for "this frame's exception handler ran". Distinct from the `Ret::Panic`
+/// opcode that drives the abort cascade, so if it ever executes we know a handler actually caught.
+fn catch_marker<T: Tracer, W: World<T>>() -> Instruction<T, W> {
+    Instruction::from_revert(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    )
+}
+
+/// Loads `(abi, target_address)` from its code page, far-calls `target` with `CATCH_PC` as the
+/// exception handler, and — only if that handler is reached — executes `catch_marker` at `CATCH_PC`.
+fn caller_program<T: Tracer, W: World<T>>(target: Address, gas_to_pass: u64) -> Program<T, W> {
+    Program::from_raw(
+        vec![
+            load_codepage(0, Register::new(1)),
+            load_codepage(1, Register::new(2)),
+            far_call_to(CATCH_PC),
+            catch_marker(),
+        ],
+        vec![far_call_abi(gas_to_pass), address_word(target)],
+    )
+}
+
+/// Leaf program that stores to a heap offset far past the free stipend, forcing `grow_heap` to
+/// grow (and thus consult the ceiling). Loads the offset from its code page into r3 first, since a
+/// real far call resets registers.
+fn heap_grow_program<T: Tracer, W: World<T>>(offset: u32) -> Program<T, W> {
+    let r3 = Register::new(3);
+    Program::from_raw(
+        vec![
+            load_codepage(0, r3),
+            Instruction::from_heap_write(
+                Register1(r3).into(),
+                Register2(Register::new(0)),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+                false,
+            ),
+            ret_normal(),
+        ],
+        vec![U256::from(offset)],
+    )
+}
+
+/// Records whether A's exception handler ever ran, and stops the run the instant the panic is
+/// delivered to the bootloader's exception handler — the terminal state of the tx-wide unwind.
+struct CeilingTracer {
+    a_address: Address,
+    bootloader_address: Address,
+    a_handler_ran: bool,
+    bootloader_delivery_seen: bool,
+}
+
+impl Tracer for CeilingTracer {
+    fn before_instruction<OP: OpcodeType, S: GlobalStateInterface>(&mut self, state: &mut S) {
+        let frame = state.current_frame();
+        if frame.address() == self.a_address && frame.program_counter() == Some(CATCH_PC) {
+            self.a_handler_ran = true;
+        }
+    }
+
+    fn after_instruction<OP: OpcodeType, S: GlobalStateInterface>(
+        &mut self,
+        state: &mut S,
+    ) -> ShouldStop {
+        let frame = state.current_frame();
+        let is_bootloader = frame.address() == self.bootloader_address;
+        let pc = frame.program_counter();
+        drop(frame);
+        // `flags().less_than` is how `Ret<Panic>` signals panic (see `naked_ret`).
+        if is_bootloader && pc == Some(CATCH_PC) && state.flags().less_than {
+            self.bootloader_delivery_seen = true;
+            return ShouldStop::Stop;
+        }
+        ShouldStop::Continue
+    }
+}
+
+/// Builds the VM over `[bootloader, A, B, (C)]` programs with the low `CEILING`, runs to the
+/// tx-wide unwind, and asserts uncatchability. Shared by both trigger-site tests.
+fn run_and_assert_uncatchable_revert(
+    programs: &[(Address, Program<CeilingTracer, TestWorld<CeilingTracer>>)],
+) {
+    let bootloader_address = programs[0].0;
+    let a_address = programs[1].0;
+
+    let mut world = TestWorld::new(programs);
+    let program = initial_decommit(&mut world, bootloader_address);
+
+    let mut vm = VirtualMachine::new(
+        bootloader_address,
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        Settings {
+            default_aa_code_hash: [0; 32],
+            evm_interpreter_code_hash: [0; 32],
+            hook_address: 0,
+            memory_ceiling_bytes: CEILING,
+        },
+    );
+
+    let mut tracer = CeilingTracer {
+        a_address,
+        bootloader_address,
+        a_handler_ran: false,
+        bootloader_delivery_seen: false,
+    };
+
+    let end = vm.run(&mut world, &mut tracer);
+
+    assert_eq!(
+        end,
+        ExecutionEnd::StoppedByTracer,
+        "the run must stop at the panic's delivery to the bootloader"
+    );
+    assert!(
+        tracer.bootloader_delivery_seen,
+        "the panic never reached the bootloader — tx did not unwind to frame 0"
+    );
+    // Unwound all the way to frame 0: nothing left on the call stack.
+    assert!(
+        vm.state.previous_frames.is_empty(),
+        "the whole tx must have unwound to the bootloader (frame 0)"
+    );
+    // The panic is delivered to the bootloader as a panic.
+    assert!(
+        vm.flags().less_than,
+        "the bootloader must receive the delivery as a panic"
+    );
+    // Uncatchable: A's exception handler was registered for B's failure yet never ran.
+    assert!(
+        !tracer.a_handler_ran,
+        "A's exception handler must be skipped — the ceiling breach is uncatchable"
+    );
+    // The abort flag is consumed by the terminal step of the unwind.
+    assert!(
+        !vm.state.aborting,
+        "aborting must be cleared after the unwind"
+    );
+}
+
+#[test]
+fn grow_over_ceiling_reverts_whole_tx() {
+    let bootloader_address = Address::from_low_u64_be(0x_1000_0000_0000_0001);
+    let a_address = Address::from_low_u64_be(0x_2000_0000_0000_0001);
+    let b_address = Address::from_low_u64_be(0x_3000_0000_0000_0001);
+
+    // B grows its heap to ~100 KiB, a delta far larger than the whole `CEILING`, so the growth —
+    // not the frame push — is what trips the check. The ceiling check runs *before* gas payment,
+    // so B needing far more gas than it holds to actually pay for the growth is irrelevant.
+    let programs = vec![
+        (bootloader_address, caller_program(a_address, GAS_TO_PASS)),
+        (a_address, caller_program(b_address, GAS_TO_PASS)),
+        (b_address, heap_grow_program(100_000)),
+    ];
+
+    run_and_assert_uncatchable_revert(&programs);
+}
+
+#[test]
+fn far_call_stipend_over_ceiling_reverts_whole_tx() {
+    let bootloader_address = Address::from_low_u64_be(0x_1000_0000_0000_0001);
+    let a_address = Address::from_low_u64_be(0x_2000_0000_0000_0001);
+    let b_address = Address::from_low_u64_be(0x_3000_0000_0000_0001);
+    let c_address = Address::from_low_u64_be(0x_4000_0000_0000_0001);
+
+    // bootloader -> A -> B all push fine (reaching 4 * STIP); B's far-call to C would push the
+    // running total to 6 * STIP > CEILING, so the far_call trigger aborts before pushing C.
+    let programs = vec![
+        (bootloader_address, caller_program(a_address, GAS_TO_PASS)),
+        (a_address, caller_program(b_address, GAS_TO_PASS)),
+        (b_address, caller_program(c_address, GAS_TO_PASS)),
+        (c_address, Program::from_raw(vec![ret_normal()], vec![])),
+    ];
+
+    run_and_assert_uncatchable_revert(&programs);
+}

--- a/crates/vm2/src/tests/mod.rs
+++ b/crates/vm2/src/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Low-level VM tests.
 
+mod abort_unwind;
 mod bytecode_behaviour;
 mod divergence_regressions;
 mod far_call_decommitment;

--- a/crates/vm2/src/tests/mod.rs
+++ b/crates/vm2/src/tests/mod.rs
@@ -8,3 +8,4 @@ mod frame_stipend_counter;
 mod memory_ceiling;
 mod panic;
 mod trace_failing_far_call;
+mod tx_wide_revert;

--- a/crates/vm2/src/tests/mod.rs
+++ b/crates/vm2/src/tests/mod.rs
@@ -5,5 +5,6 @@ mod bytecode_behaviour;
 mod divergence_regressions;
 mod far_call_decommitment;
 mod frame_stipend_counter;
+mod memory_ceiling;
 mod panic;
 mod trace_failing_far_call;

--- a/crates/vm2/src/tests/mod.rs
+++ b/crates/vm2/src/tests/mod.rs
@@ -4,5 +4,6 @@ mod abort_unwind;
 mod bytecode_behaviour;
 mod divergence_regressions;
 mod far_call_decommitment;
+mod frame_stipend_counter;
 mod panic;
 mod trace_failing_far_call;

--- a/crates/vm2/src/tests/panic.rs
+++ b/crates/vm2/src/tests/panic.rs
@@ -43,6 +43,7 @@ proptest! {
                 default_aa_code_hash: [0; 32],
                 evm_interpreter_code_hash: [0; 32],
                 hook_address: 0,
+                memory_ceiling_bytes: u64::MAX,
             },
         );
 

--- a/crates/vm2/src/tests/trace_failing_far_call.rs
+++ b/crates/vm2/src/tests/trace_failing_far_call.rs
@@ -83,6 +83,7 @@ fn trace_failing_far_call() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
 
@@ -130,6 +131,7 @@ fn trace_static_memory_opcodes() {
             default_aa_code_hash: [0; 32],
             evm_interpreter_code_hash: [0; 32],
             hook_address: 0,
+            memory_ceiling_bytes: u64::MAX,
         },
     );
 

--- a/crates/vm2/src/tests/tx_wide_revert.rs
+++ b/crates/vm2/src/tests/tx_wide_revert.rs
@@ -1,0 +1,614 @@
+//! End-to-end tests for the tx-wide revert feature (uncatchable abort + heap-bytes ceiling +
+//! kept-returndata counter accounting), tying together Tasks 1-6.
+//!
+//! Three properties matter for consensus:
+//! * the abort point is fully deterministic (sequencer and verifier must diverge nowhere);
+//! * the ceiling check is inert (byte-identical output) for any tx that never approaches it;
+//! * `Heaps::live_logical_bytes` returns to its pre-tx baseline once a transaction full of
+//!   nested, returndata-forwarding calls has unwound and the bootloader has reclaimed its kept
+//!   heaps -- this is the drift guard for the kept-heap/rollback accounting added in Tasks 3-5.
+
+use primitive_types::U256;
+use zkevm_opcode_defs::{ethereum_types::Address, system_params::NEW_FRAME_MEMORY_STIPEND};
+use zksync_vm2_interface::{
+    opcodes, CallframeInterface, GlobalStateInterface, OpcodeType, ShouldStop, StateInterface,
+    Tracer,
+};
+
+use crate::{
+    addressing_modes::{
+        Arguments, CodePage, Immediate1, Register, Register1, Register2, RegisterAndImmediate,
+    },
+    testonly::{initial_decommit, TestWorld},
+    ExecutionEnd, Instruction, ModeRequirements, Predicate, Program, Settings, VirtualMachine,
+    World,
+};
+
+/// Index, within every program in this file, of the instruction reached both by natural
+/// fall-through after a successful far call and by the immediate far-call error handler. None of
+/// the scenarios below expect a far call to actually fail (aside from the deliberate ceiling
+/// breach in `abort_point_is_deterministic`), so the two paths sharing a PC is harmless -- it
+/// matches the convention used throughout the other test files in this module.
+const CATCH_PC: u16 = 3;
+
+fn far_call_abi(gas: u64) -> U256 {
+    let mut abi = U256::zero();
+    abi.0[3] = gas;
+    abi
+}
+
+fn address_word(address: Address) -> U256 {
+    address.to_low_u64_be().into()
+}
+
+fn load_codepage<T: Tracer, W: World<T>>(immediate: u16, dest: Register) -> Instruction<T, W> {
+    let r0 = Register::new(0);
+    Instruction::from_add(
+        CodePage(RegisterAndImmediate {
+            immediate,
+            register: r0,
+        })
+        .into(),
+        Register2(r0),
+        Register1(dest).into(),
+        Arguments::new(Predicate::Always, 6, ModeRequirements::none()),
+        false,
+        false,
+    )
+}
+
+fn far_call_to<T: Tracer, W: World<T>>(exception_handler: u16) -> Instruction<T, W> {
+    Instruction::from_far_call::<opcodes::Normal>(
+        Register1(Register::new(1)),
+        Register2(Register::new(2)),
+        Immediate1(exception_handler),
+        false,
+        false,
+        Arguments::new(Predicate::Always, 200, ModeRequirements::none()),
+    )
+}
+
+/// A plain `ret` whose return-ABI register is `r0` (always zero): a "fresh", zero-length pointer
+/// into the returning frame's own heap. Real callers use exactly this to end a call with no
+/// returndata -- and, per `naked_ret`, even this zero-length pointer causes the frame's heap to be
+/// kept alive and bubbled to the caller (see `kept_returndata_heap_stays_counted_after_pop` in
+/// `frame_stipend_counter.rs`).
+fn ret_normal<T: Tracer, W: World<T>>() -> Instruction<T, W> {
+    Instruction::from_ret(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    )
+}
+
+/// A `revert` used as a safety net / delivery marker: whichever frame runs this, at frame 0, ends
+/// the whole run deterministically via `ExecutionEnd::Reverted`.
+fn catch_marker<T: Tracer, W: World<T>>() -> Instruction<T, W> {
+    Instruction::from_revert(
+        Register1(Register::new(0)),
+        None,
+        Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+    )
+}
+
+/// A `(address, program)` list for the `T = (), W = TestWorld<()>` instantiation used by tests 1
+/// and 2 -- both build their program set once and reuse it across two separately-constructed VMs
+/// (see the doc comment on `ceiling_tripping_programs`).
+type NoTracerPrograms = Vec<(Address, Program<(), TestWorld<()>>)>;
+
+fn default_settings(memory_ceiling_bytes: u64) -> Settings {
+    Settings {
+        default_aa_code_hash: [0; 32],
+        evm_interpreter_code_hash: [0; 32],
+        hook_address: 0,
+        memory_ceiling_bytes,
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Test 1: abort_point_is_deterministic
+// ---------------------------------------------------------------------------------------------
+
+/// `caller_program`-style contract: far-calls `target`, and -- whether by the natural
+/// fall-through of a successful call or by the error handler of a failed one -- lands on
+/// `catch_marker` at `CATCH_PC`.
+fn caller_program<T: Tracer, W: World<T>>(target: Address, gas_to_pass: u64) -> Program<T, W> {
+    Program::from_raw(
+        vec![
+            load_codepage(0, Register::new(1)),
+            load_codepage(1, Register::new(2)),
+            far_call_to(CATCH_PC),
+            catch_marker(),
+        ],
+        vec![far_call_abi(gas_to_pass), address_word(target)],
+    )
+}
+
+const DETERMINISM_GAS_TO_PASS: u64 = 50_000;
+/// STIP-multiple ceiling that admits `bootloader -> A -> B` (4 * STIP: A and B each add
+/// `2 * STIP`) but rejects `B`'s far call pushing `C` (would reach `6 * STIP`), tripping the
+/// uncatchable tx-wide abort inside the `far_call` ceiling check.
+fn determinism_ceiling() -> u64 {
+    4 * u64::from(NEW_FRAME_MEMORY_STIPEND)
+}
+
+/// Builds the `bootloader -> A -> B -> (push C fails)` program set once. `Program` is
+/// `Arc`-backed (see `program.rs`), so cloning these entries into two separate `TestWorld`s (as
+/// `build_ceiling_tripping_scenario` does below) shares the same underlying instruction
+/// allocation across both -- which matters because `Callframe`'s `PartialEq` compares `pc` via
+/// `std::ptr::eq`. Rebuilding the programs from scratch per run would give each run its own,
+/// differently-addressed `Arc` allocation and make `dump_state()` spuriously unequal even for a
+/// perfectly deterministic run; this is a property of comparing state across independently
+/// constructed VMs; it has no bearing on production determinism.
+fn ceiling_tripping_programs() -> (Address, NoTracerPrograms) {
+    let bootloader_address = Address::from_low_u64_be(0x_1000_0000_0000_0101);
+    let a_address = Address::from_low_u64_be(0x_2000_0000_0000_0101);
+    let b_address = Address::from_low_u64_be(0x_3000_0000_0000_0101);
+    let c_address = Address::from_low_u64_be(0x_4000_0000_0000_0101);
+
+    let programs = vec![
+        (
+            bootloader_address,
+            caller_program(a_address, DETERMINISM_GAS_TO_PASS),
+        ),
+        (
+            a_address,
+            caller_program(b_address, DETERMINISM_GAS_TO_PASS),
+        ),
+        (
+            b_address,
+            caller_program(c_address, DETERMINISM_GAS_TO_PASS),
+        ),
+        (c_address, Program::from_raw(vec![ret_normal()], vec![])),
+    ];
+    (bootloader_address, programs)
+}
+
+/// Builds a fresh `VirtualMachine`/`TestWorld` pair from the (shared) program set above.
+fn build_ceiling_tripping_scenario(
+    bootloader_address: Address,
+    programs: &NoTracerPrograms,
+) -> (VirtualMachine<(), TestWorld<()>>, TestWorld<()>) {
+    let mut world = TestWorld::new(programs);
+    let program = initial_decommit(&mut world, bootloader_address);
+
+    let vm = VirtualMachine::new(
+        bootloader_address,
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(determinism_ceiling()),
+    );
+    (vm, world)
+}
+
+#[test]
+fn abort_point_is_deterministic() {
+    // Same ceiling-tripping batch, run twice from fresh VM/world pairs built off the same
+    // (shared) program set. If the abort point (frame depth, gas, world diff, heaps -- everything
+    // `dump_state` captures) ever depended on anything but the deterministic inputs, this would
+    // flake or diverge -- exactly the class of bug that would let a sequencer and a verifier
+    // disagree.
+    let (bootloader_address, programs) = ceiling_tripping_programs();
+    let run = || {
+        let (mut vm, mut world) = build_ceiling_tripping_scenario(bootloader_address, &programs);
+        let end = vm.run(&mut world, &mut ());
+        (end, vm.dump_state())
+    };
+
+    let (end1, state1) = run();
+    let (end2, state2) = run();
+
+    assert_eq!(
+        end1,
+        ExecutionEnd::Reverted(Vec::new()),
+        "the ceiling breach must unwind the whole tx and deliver a revert to the bootloader's \
+         own handler (frame 0 has no caller to panic into, so the terminal `ret` there is a \
+         plain revert with empty output)"
+    );
+    assert_eq!(
+        end1, end2,
+        "the ceiling-tripping abort must end the same way every run"
+    );
+    assert_eq!(
+        state1, state2,
+        "two fresh runs of the identical ceiling-tripping scenario must produce byte-identical \
+         final VM state -- the sequencer and verifier must abort at exactly the same point"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Test 2: below_ceiling_is_byte_identical_to_baseline
+// ---------------------------------------------------------------------------------------------
+
+const BELOW_CEILING_GAS_TO_PASS: u64 = 200_000;
+
+/// Leaf contract: grows its own heap by a modest, realistic amount and returns normally (kept,
+/// zero-length pointer -- see `ret_normal`).
+fn leaf_program<T: Tracer, W: World<T>>(heap_grow_offset: u32) -> Program<T, W> {
+    let r4 = Register::new(4);
+    Program::from_raw(
+        vec![
+            load_codepage(0, r4),
+            Instruction::from_heap_write(
+                Register1(r4).into(),
+                Register2(Register::new(0)),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+                false,
+            ),
+            ret_normal(),
+        ],
+        vec![U256::from(heap_grow_offset)],
+    )
+}
+
+/// Middle contract: far-calls `target`, then also grows its own heap a little, then returns
+/// normally. Not returndata-forwarding -- this test is about ceiling inertness, not counter
+/// balance (that's test 3).
+fn middle_program<T: Tracer, W: World<T>>(
+    target: Address,
+    gas_to_pass: u64,
+    heap_grow_offset: u32,
+) -> Program<T, W> {
+    let r4 = Register::new(4);
+    Program::from_raw(
+        vec![
+            load_codepage(0, Register::new(1)),
+            load_codepage(1, Register::new(2)),
+            far_call_to(CATCH_PC),
+            load_codepage(2, r4),
+            Instruction::from_heap_write(
+                Register1(r4).into(),
+                Register2(Register::new(0)),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+                false,
+            ),
+            ret_normal(),
+            catch_marker(),
+        ],
+        vec![
+            far_call_abi(gas_to_pass),
+            address_word(target),
+            U256::from(heap_grow_offset),
+        ],
+    )
+}
+
+/// Root contract: far-calls `target`, and ends the run normally (`ProgramFinished`) whether
+/// reached by success fall-through or (unexpectedly) by the error handler -- both land at
+/// `CATCH_PC`, which here is a plain `ret_normal`, not a revert, since a below-ceiling tx is
+/// never expected to fail.
+fn root_program<T: Tracer, W: World<T>>(target: Address, gas_to_pass: u64) -> Program<T, W> {
+    Program::from_raw(
+        vec![
+            load_codepage(0, Register::new(1)),
+            load_codepage(1, Register::new(2)),
+            far_call_to(CATCH_PC),
+            ret_normal(),
+        ],
+        vec![far_call_abi(gas_to_pass), address_word(target)],
+    )
+}
+
+/// Builds the `root -> A -> B` program set once (`B` and `A` each do a modest heap growth: a
+/// realistic shape of tx that comes nowhere near any sane ceiling). As in
+/// `ceiling_tripping_programs`, building this once and reusing it for both settings keeps the
+/// underlying (`Arc`-backed) instruction allocation identical across both runs, which
+/// `Callframe`'s `pc`-pointer-identity `PartialEq` requires for a meaningful `dump_state()` diff.
+fn below_ceiling_programs() -> (Address, NoTracerPrograms) {
+    let root_address = Address::from_low_u64_be(0x_1000_0000_0000_0102);
+    let a_address = Address::from_low_u64_be(0x_2000_0000_0000_0102);
+    let b_address = Address::from_low_u64_be(0x_3000_0000_0000_0102);
+
+    let programs = vec![
+        (
+            root_address,
+            root_program(a_address, BELOW_CEILING_GAS_TO_PASS),
+        ),
+        (
+            a_address,
+            middle_program(b_address, BELOW_CEILING_GAS_TO_PASS, 1_500),
+        ),
+        (b_address, leaf_program(3_000)),
+    ];
+    (root_address, programs)
+}
+
+fn build_below_ceiling_tx(
+    root_address: Address,
+    programs: &NoTracerPrograms,
+    memory_ceiling_bytes: u64,
+) -> (VirtualMachine<(), TestWorld<()>>, TestWorld<()>) {
+    let mut world = TestWorld::new(programs);
+    let program = initial_decommit(&mut world, root_address);
+
+    let vm = VirtualMachine::new(
+        root_address,
+        program,
+        Address::zero(),
+        &[],
+        1_000_000,
+        default_settings(memory_ceiling_bytes),
+    );
+    (vm, world)
+}
+
+#[test]
+fn below_ceiling_is_byte_identical_to_baseline() {
+    // A realistic tx (nested far calls + real heap growth) that never gets remotely close to
+    // either ceiling value must produce identical final state whether the ceiling is a high,
+    // unreached value or disabled outright (`u64::MAX`). This proves the ceiling check itself
+    // (the extra comparison/`saturating_add` in `grow_heap`/`far_call`) has no side effect beyond
+    // gating the abort -- it is inert when it doesn't fire.
+    let (root_address, programs) = below_ceiling_programs();
+
+    let (mut with_high_ceiling, mut world_high) =
+        build_below_ceiling_tx(root_address, &programs, 1 << 40);
+    let end_high = with_high_ceiling.run(&mut world_high, &mut ());
+
+    let (mut with_disabled_ceiling, mut world_disabled) =
+        build_below_ceiling_tx(root_address, &programs, u64::MAX);
+    let end_disabled = with_disabled_ceiling.run(&mut world_disabled, &mut ());
+
+    assert_eq!(
+        end_high,
+        ExecutionEnd::ProgramFinished(Vec::new()),
+        "the below-ceiling tx must finish normally"
+    );
+    assert_eq!(
+        end_high, end_disabled,
+        "the two settings must reach the same execution end"
+    );
+    assert_eq!(
+        with_high_ceiling.dump_state(),
+        with_disabled_ceiling.dump_state(),
+        "final VM state (registers, callframes, heaps) must be byte-identical between a high, \
+         unreached ceiling and the ceiling disabled outright -- `memory_ceiling_bytes` itself is \
+         excluded from `State`'s `PartialEq` on purpose (see state.rs), so this specifically \
+         proves the check's *behavior* (not just the field) is a no-op below the ceiling. Both \
+         runs execute the identical instruction trace (same programs, same gas, same growth), so \
+         `WorldDiff` (storage/events), which isn't `PartialEq`, is provably identical too."
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Test 3: counter_returns_to_baseline_after_nested_calls_with_kept_returndata (THE important one)
+// ---------------------------------------------------------------------------------------------
+
+/// Bit position of the fat-pointer return-ABI "forward as-is" tag consulted by
+/// `get_calldata`/`FatPointerSource::from_abi` (byte 28 of the 256-bit register, i.e.
+/// `raw_abi.0[3] >> 32`). Packing this into a register via `PointerPack` (whose low 128 bits
+/// must be zero, satisfied since 224 >= 128) turns a plain `ret` into one that forwards whatever
+/// fat pointer is already in the source register, instead of building a fresh one -- exactly
+/// what a real contract does to bubble a sub-call's returndata to its own caller.
+const FORWARD_ABI_SOURCE_BIT: u32 = 224;
+
+fn forward_marker() -> U256 {
+    U256::one() << FORWARD_ABI_SOURCE_BIT
+}
+
+/// An intermediate contract in the forwarding chain: grows its own heap a little (so its own,
+/// never-kept heap page has a real, non-stipend-only size to release), far-calls `target`, then
+/// re-packs whatever pointer it received in `r1` (a real far call always leaves the callee's
+/// returned pointer there, tagged, with every other register zeroed -- see `naked_ret`) with the
+/// forward tag and returns *that*, bubbling the callee's kept heap one level further up instead
+/// of returning a fresh pointer of its own. This is what makes returndata heaps accumulate
+/// through several levels rather than dying at the first pop.
+fn forwarder_program<T: Tracer, W: World<T>>(
+    target: Address,
+    gas_to_pass: u64,
+    own_heap_grow_offset: u32,
+) -> Program<T, W> {
+    const SAFETY_NET_PC: u16 = 8;
+
+    let r1 = Register::new(1);
+    let r3 = Register::new(3);
+    let r4 = Register::new(4);
+    let r5 = Register::new(5);
+
+    Program::from_raw(
+        vec![
+            load_codepage(0, r1),               // 0: far-call gas ABI
+            load_codepage(1, Register::new(2)), // 1: far-call target address
+            load_codepage(2, r4),               // 2: this frame's own heap-grow offset
+            Instruction::from_heap_write(
+                Register1(r4).into(),
+                Register2(Register::new(0)),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+                false,
+            ), // 3: grow own heap (never kept -- freed when this frame pops)
+            far_call_to(SAFETY_NET_PC),         // 4: call target; on (unexpected) failure -> 8
+            load_codepage(3, r3),               // 5: load the forward-ABI marker
+            Instruction::from_pointer_pack(
+                Register1(r1).into(),
+                Register2(r3),
+                Register1(r5).into(),
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+                false,
+            ), // 6: combine the callee's returned pointer (r1) with the forward tag
+            Instruction::from_ret(
+                Register1(r5),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+            ), // 7: forward the callee's kept heap upward instead of returning fresh
+            catch_marker(), // 8: safety net; only reached if the far call actually failed
+        ],
+        vec![
+            far_call_abi(gas_to_pass),
+            address_word(target),
+            U256::from(own_heap_grow_offset),
+            forward_marker(),
+        ],
+    )
+}
+
+/// The deepest contract in the chain: grows its own heap with a real, distinctive amount and
+/// returns normally. The `ret_normal` zero-length pointer still keeps this frame's (grown) heap
+/// alive and bubbles it to the caller -- see `ret_normal`'s doc comment.
+fn leaf_returning_program<T: Tracer, W: World<T>>(heap_grow_offset: u32) -> Program<T, W> {
+    let r4 = Register::new(4);
+    Program::from_raw(
+        vec![
+            load_codepage(0, r4),
+            Instruction::from_heap_write(
+                Register1(r4).into(),
+                Register2(Register::new(0)),
+                None,
+                Arguments::new(Predicate::Always, 5, ModeRequirements::none()),
+                false,
+            ),
+            ret_normal(),
+        ],
+        vec![U256::from(heap_grow_offset)],
+    )
+}
+
+/// Root contract: just far-calls `target`. Deliberately does *not* itself `ret` on return --
+/// doing so at frame 0 hits `naked_ret`'s early-return branch (`pop_frame` returns `None`
+/// because `previous_frames` is empty), which reads the returned bytes but never touches
+/// `heaps_i_am_keeping_alive` or deallocates anything. That branch is for a program that legitimately
+/// ends the whole VM, which the real bootloader never does mid-batch (it loops until a hook
+/// fires) -- so exercising it here would produce a dangling heap page that is an artifact of the
+/// test, not a real drift. Instead, the test's tracer stops the VM the instant control returns to
+/// this frame, before any further instruction (in particular, before any `ret`) executes.
+fn root_forwarding_program<T: Tracer, W: World<T>>(
+    target: Address,
+    gas_to_pass: u64,
+) -> Program<T, W> {
+    Program::from_raw(
+        vec![
+            load_codepage(0, Register::new(1)),
+            load_codepage(1, Register::new(2)),
+            far_call_to(CATCH_PC),
+            catch_marker(), // reached only if the chain unexpectedly failed
+        ],
+        vec![far_call_abi(gas_to_pass), address_word(target)],
+    )
+}
+
+/// Stops the VM the instant execution lands back in the root frame at `root_return_pc` -- i.e.
+/// the whole call tree has unwound, whether the chain succeeded or (unexpectedly) failed.
+struct LandedAtRootTracer {
+    root_address: Address,
+    root_return_pc: u16,
+    landed: bool,
+}
+
+impl Tracer for LandedAtRootTracer {
+    fn after_instruction<OP: OpcodeType, S: GlobalStateInterface>(
+        &mut self,
+        state: &mut S,
+    ) -> ShouldStop {
+        let frame = state.current_frame();
+        let hit = frame.address() == self.root_address
+            && frame.program_counter() == Some(self.root_return_pc);
+        drop(frame);
+        if hit {
+            self.landed = true;
+            return ShouldStop::Stop;
+        }
+        ShouldStop::Continue
+    }
+}
+
+#[test]
+fn counter_returns_to_baseline_after_nested_calls_with_kept_returndata() {
+    let root_address = Address::from_low_u64_be(0x_1000_0000_0000_0103);
+    let a_address = Address::from_low_u64_be(0x_2000_0000_0000_0103);
+    let b_address = Address::from_low_u64_be(0x_3000_0000_0000_0103);
+    let c_address = Address::from_low_u64_be(0x_4000_0000_0000_0103);
+    let d_address = Address::from_low_u64_be(0x_5000_0000_0000_0103);
+
+    // Generous, strictly decreasing gas budgets down the chain -- plenty of headroom over each
+    // frame's own overhead (a handful of cheap instructions + a modest heap growth) plus whatever
+    // it passes further down.
+    let programs = vec![
+        (root_address, root_forwarding_program(a_address, 1_500_000)),
+        (a_address, forwarder_program(b_address, 1_000_000, 5_000)),
+        (b_address, forwarder_program(c_address, 600_000, 8_000)),
+        (c_address, forwarder_program(d_address, 300_000, 3_000)),
+        (d_address, leaf_returning_program(12_000)),
+    ];
+
+    let mut world = TestWorld::new(&programs);
+    let program = initial_decommit(&mut world, root_address);
+
+    let mut vm = VirtualMachine::new(
+        root_address,
+        program,
+        Address::zero(),
+        &[],
+        2_000_000,
+        // Disabled: this test is about counter balance, not the ceiling, and must not have the
+        // ceiling interfere with the deliberately heap-heavy chain below.
+        default_settings(u64::MAX),
+    );
+
+    // `make_snapshot`/`pop_snapshot` mirror exactly how the real bootloader commits a transaction
+    // and reclaims the returndata heaps it kept alive (`reclaim_bootloader_returndata_heaps`,
+    // documented on `pop_snapshot` in vm.rs) -- both require being in frame 0 with an empty call
+    // stack, which holds here (fresh VM).
+    vm.make_snapshot();
+    let base = vm.state.heaps.live_logical_bytes();
+    assert_eq!(base, 0, "sanity: nothing is counted before the tx has run");
+
+    let mut tracer = LandedAtRootTracer {
+        root_address,
+        root_return_pc: CATCH_PC,
+        landed: false,
+    };
+    let end = vm.run(&mut world, &mut tracer);
+
+    assert_eq!(end, ExecutionEnd::StoppedByTracer);
+    assert!(
+        tracer.landed,
+        "never observed the call chain unwinding back to the root frame"
+    );
+    assert!(
+        vm.state.previous_frames.is_empty(),
+        "the whole call tree must have unwound back to frame 0"
+    );
+    assert!(
+        !vm.flags().less_than,
+        "the chain must complete successfully (forwarded all the way up), not panic"
+    );
+
+    // At this exact point -- fully unwound, but *before* the bootloader-level reclaim -- the
+    // deepest frame's kept (and forwarded-through-every-level) heap is still alive and counted.
+    // This is the "accumulates mid-chain" behavior the brief calls out as expected, not a bug.
+    let after_unwind = vm.state.heaps.live_logical_bytes();
+    assert!(
+        after_unwind > base,
+        "the forwarded returndata heap must still be counted immediately after the whole chain \
+         unwinds, before the bootloader-level reclaim -- if this is 0, the chain didn't actually \
+         forward anything and the test isn't exercising what it claims to"
+    );
+    // Exactly D's grown heap (12_000 + 32, its `heap_write`'s address + 32-byte word rounded up
+    // to the next bound) and nothing else: A/B/C's own heaps and aux heaps, and D's aux heap, must
+    // all have been freed as each frame popped, leaving only the one heap that was forwarded
+    // through every level all the way up to the root.
+    assert_eq!(
+        after_unwind,
+        12_000 + 32,
+        "only D's forwarded (grown) heap should still be counted at this point -- any other \
+         value means either a heap that should have been freed leaked, or the forwarded heap's \
+         growth wasn't tracked correctly through the chain"
+    );
+
+    // The real reclaim boundary: `pop_snapshot` (called by the bootloader once a transaction is
+    // fully committed) drains `heaps_i_am_keeping_alive` on the now-current root frame via
+    // `reclaim_bootloader_returndata_heaps`.
+    vm.pop_snapshot();
+
+    assert_eq!(
+        vm.state.heaps.live_logical_bytes(),
+        base,
+        "the counter must return to the pre-tx baseline once the bootloader reclaims the kept \
+         returndata heap -- a nonzero residual here is a real leak in the kept-heap/rollback \
+         accounting (Tasks 3-5), not a test artifact"
+    );
+}

--- a/crates/vm2/src/tracing.rs
+++ b/crates/vm2/src/tracing.rs
@@ -450,6 +450,7 @@ mod test {
                 default_aa_code_hash: [0; 32],
                 evm_interpreter_code_hash: [0; 32],
                 hook_address: 0,
+                memory_ceiling_bytes: u64::MAX,
             },
         );
 
@@ -513,6 +514,7 @@ mod test {
                 default_aa_code_hash: [0; 32],
                 evm_interpreter_code_hash: [0; 32],
                 hook_address: 0,
+                memory_ceiling_bytes: u64::MAX,
             },
         );
 

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -310,6 +310,23 @@ impl<T: Tracer, W> VirtualMachine<T, W> {
         );
         self.state.context_u128 = 0;
 
+        // Count this frame's stipend against the per-user-tx heap-bytes ceiling, but only for
+        // non-kernel frames: the bootloader/system contracts get huge free heaps by design and
+        // must not inflate a counter that exists to bound *user* memory usage (see
+        // `Heaps::live_logical_bytes`). `pop_frame` needs no matching special-case: its existing
+        // `deallocate` calls already decrement whatever was counted here (kernel frames were
+        // never counted, so deallocating them is a no-op against the counter), and heaps kept
+        // alive as returndata are, by construction, not deallocated — so they stay counted, which
+        // is exactly the desired accounting.
+        if !new_frame.is_kernel {
+            self.state
+                .heaps
+                .set_counted_size(heap_page, new_frame.heap_size);
+            self.state
+                .heaps
+                .set_counted_size(aux_heap_page, new_frame.aux_heap_size);
+        }
+
         std::mem::swap(&mut new_frame, &mut self.state.current_frame);
         self.state.previous_frames.push(new_frame);
     }

--- a/crates/vm2/src/vm.rs
+++ b/crates/vm2/src/vm.rs
@@ -23,6 +23,11 @@ pub struct Settings {
     pub evm_interpreter_code_hash: [u8; 32],
     /// Writing to this address in the bootloader's heap suspends execution
     pub hook_address: u32,
+    /// Global ceiling on summed logical heap bytes of non-kernel frames. A transaction
+    /// that would exceed it is reverted whole (see `State::abort_transaction`), keeping
+    /// the proving guest under its ~952 MiB heap cap. Deterministic VM state → sequencer
+    /// and verifier MUST pass the SAME value. `u64::MAX` disables the check.
+    pub memory_ceiling_bytes: u64,
 }
 
 /// High-performance out-of-circuit EraVM implementation.
@@ -49,17 +54,22 @@ impl<T: Tracer, W: World<T>> VirtualMachine<T, W> {
         let world_before_this_frame = world_diff.snapshot();
         let mut stack_pool = StackPool::default();
 
+        let mut state = State::new(
+            address,
+            caller,
+            calldata,
+            gas,
+            program,
+            world_before_this_frame,
+            stack_pool.get(),
+        );
+        // `grow_heap` only receives `&mut State`, not the whole VM, so the ceiling must live on
+        // `State` to be reachable from the heap-growth trigger. Copy it here (config → state).
+        state.memory_ceiling_bytes = settings.memory_ceiling_bytes;
+
         Self {
             world_diff,
-            state: State::new(
-                address,
-                caller,
-                calldata,
-                gas,
-                program,
-                world_before_this_frame,
-                stack_pool.get(),
-            ),
+            state,
             settings,
             stack_pool,
             snapshot: None,


### PR DESCRIPTION
## Problem

A transaction can inflate the interpreter's live heap past the proving guest's ~952 MiB cap, OOM-ing the guest. The batch then cannot be proven — and if it contains a priority (L1→L2) transaction, which cannot be skipped, that is an unrecoverable chain halt. The dominant amplifier is the free per-frame memory stipend across many far-calls, plus returndata heaps kept alive up the call stack.

## Change

Adds a general `abort_transaction()` primitive that **uncatchably unwinds the entire current transaction** to the bootloader — bypassing every intermediate exception handler, rolling back each frame, and burning all gas — then delivers a normal panic the bootloader handles as an ordinary failed tx. A memory-bomb tx therefore reverts (a valid, provable outcome) instead of halting the chain.

Its first trigger is a configurable per-transaction heap ceiling:

- `Settings.memory_ceiling_bytes` (mirrored onto `State`), supplied by the embedder. **Defaults to `u64::MAX` — disabled and a no-op** — so this is behavior-neutral until a value is set.
- A `live_logical_bytes` counter in `Heaps` sums the **logical** heap sizes of non-kernel frames: `+stipend` on frame push, `+delta` on heap growth, `-` on deallocate; kept returndata stays counted until released; saved/restored across snapshot/rollback.
- Checked on the two growth paths — far-call push (prospective `2 × stipend`) and `grow_heap` (prospective delta) — which call `abort_transaction()` on breach.

## Properties

- **Deterministic / consensus-safe.** Every input to the counter and the abort decision is deterministic VM state (logical sizes, the supplied ceiling) — never physical/sparse allocation, pointer identity, or iteration order. The counter is excluded from `PartialEq`/snapshot, so it is invisible to state comparison.
- **Uncatchable** — the cascade runs through real `Ret<Panic>` steps, so tracers see a faithful, balanced call tree; every `FarCall` still pushes exactly one frame.
- **Gas fully burned** on abort, so the attempt costs the sender its whole gas limit.

## Tests

78 pass. Coverage includes the uncatchable cascade (past intermediate handlers, both far-frame and near-call terminal cases), stipend/growth counting with kernel exclusion, end-to-end counter balance across a nested chain with kept returndata (returns exactly to baseline at the reclaim boundary), abort-point determinism, and disabled-ceiling byte-exactness.

## Follow-up (separate, verifier-side)

Derive and wire the production `memory_ceiling_bytes` in the verifier (identical value on sequencer and verifier), and add the transpiler guest-OOM regression. Not included here so this change can land disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
