### PR TITLE
ci: split fuzzing into its own job and pin AFL codegen to x86-64-v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,16 +33,10 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install cargo-afl
-        run: cargo install cargo-afl --version=^0.15 --locked --force
-
       - name: Build project
         run: |
-          # AFL fuzzing requires a separate command
+          # AFL fuzzing requires a separate command (see the `fuzz` job)
           cargo build --workspace --all-targets --exclude zksync_vm2_afl_fuzz
-
-      - name: Build fuzzer
-        run: cargo afl build -p zksync_vm2_afl_fuzz --release
 
       # Two runs are needed. One for normal VM, another for the mocked version
       - name: Run clippy
@@ -64,15 +58,73 @@ jobs:
       - name: Run doc tests
         run: cargo test --workspace --doc
 
-      - name: Run fuzzer for a bit
-        run: |
-          AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
-          cargo afl fuzz -i tests/afl-fuzz/in -o tests/afl-fuzz/out -V 60 -g $(cargo run --bin check_input_size) target/release/zksync_vm2_afl_fuzz
+  # Fuzzing runs in its own job so that an AFL toolchain or session failure cannot mask the
+  # results of clippy, fmt, tests and doc tests, and cannot block the docs deploy.
+  fuzz:
+    runs-on: ubuntu-latest
 
-      - name: Fail if the fuzzer found a crash
+    env:
+      # `cargo afl build` hardcodes `-C target-cpu=native` into the RUSTFLAGS it passes to
+      # rustc. Cargo fingerprints the literal flag, not the CPU it resolved to, so rust-cache
+      # can restore artifacts built on one runner onto a runner with a different ISA (GitHub's
+      # x64 pool mixes AVX-512 Intel with non-AVX-512 AMD), where they die with SIGILL.
+      # cargo-afl appends user RUSTFLAGS after its own and the last `-C target-cpu` wins, so
+      # this pins codegen to a baseline every GitHub x64 runner supports.
+      RUSTFLAGS: -C target-cpu=x86-64-v3
+
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_VERSION }}
+          components: rust-src
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Never share a cache between the plain and the AFL-instrumented builds.
+          key: afl
+
+      - name: Install cargo-afl
+        # Exact version, matching the `afl` pin in Cargo.lock.
+        run: cargo install cargo-afl --version=0.15.24 --locked --force
+
+      - name: Check cargo-afl matches the afl pin in Cargo.lock
+        # A cargo-afl binary driving a different afl crate version makes every exec abort at
+        # run time with no build error, so catch any drift here instead.
         run: |
-          if [ -n "$(ls tests/afl-fuzz/out/default/crashes)" ]; then
+          INSTALLED=$(cargo afl --version | awk '{print $2}')
+          PINNED=$(grep -A1 '^name = "afl"$' Cargo.lock | grep '^version' | cut -d'"' -f2)
+          echo "cargo-afl: $INSTALLED, afl in Cargo.lock: $PINNED"
+          test "$INSTALLED" = "$PINNED"
+
+      - name: Build fuzzer
+        run: cargo afl build -p zksync_vm2_afl_fuzz --release
+
+      - name: Run fuzzer for a bit
+        id: run_fuzzer
+        # An abort (the fuzzing session itself failed, no crash found) is reported by the next
+        # step, so that its diagnostics are never swallowed.
+        continue-on-error: true
+        run: |
+          # `cargo afl build` above already built this bin; don't compile the dependency tree
+          # a second time in the debug profile just to print one number.
+          MIN_LEN=$(./target/release/check_input_size)
+          # Fail loudly if this is not a number instead of feeding garbage to -g.
+          test "$MIN_LEN" -gt 0
+          AFL_I_DONT_CARE_ABOUT_MISSING_CRASHES=1 \
+          cargo afl fuzz -i tests/afl-fuzz/in -o tests/afl-fuzz/out -V 60 -g "$MIN_LEN" target/release/zksync_vm2_afl_fuzz
+
+      - name: Fail if the fuzzer found a crash or aborted
+        run: |
+          if [ -n "$(ls tests/afl-fuzz/out/default/crashes 2>/dev/null)" ]; then
             cd tests/afl-fuzz/ && sh show_crash.sh;
+            exit 1
+          fi
+          if [ "${{ steps.run_fuzzer.outcome }}" = "failure" ]; then
+            echo "::error::fuzzer step failed without producing a crash - session/toolchain failure, not a VM finding; see the step log"
             exit 1
           fi
 


### PR DESCRIPTION
# ci: split fuzzing into its own job and pin AFL codegen to x86-64-v3

## Problem

`cargo afl build` hardcodes `-C target-cpu=native` (cargo-afl 0.15.24, `src/main.rs:289`). Cargo
fingerprints the literal flag, not the resolved CPU, so `Swatinem/rust-cache` restores AFL
artifacts across runners with different ISAs (`ubuntu-latest` mixes AVX-512 Intel and non-AVX-512
AMD). Foreign-ISA artifacts then SIGILL:

- **at build time** — cached build scripts / proc-macro dylibs execute during compilation
  (RUSTFLAGS apply to host units without `--target`): master's `Build fuzzer` exits 101 in 2–3 s
  since the 0.6.2 bump (run 30989346856). A content-identical PR run passed 12 min before the
  failing master push with the same restorable cache — only the runner differed.
- **at run time** — cached rlibs linked into the fuzz binary crash every exec, so AFL's dry run
  reports both seeds as crashing → `We need at least one valid input seed` → exit 1: PR #116's
  run 31596189053, identical across 4 attempts. Forkserver init succeeds (startup never enters
  dep code); the same run's `check_input_size` (dev profile, no AFL flags, same cache) works.
  This variant is inferred from the signature — the signal itself isn't in the visible log.

Because the fuzzer steps sat mid-job, each failure also skipped clippy/fmt/tests/doc-tests and
blocked the `document` job: master has had no test signal since 2026-08-04.

## Changes (`.github/workflows/ci.yml` only)

- New `fuzz` job with `RUSTFLAGS: -C target-cpu=x86-64-v3`. cargo-afl appends user RUSTFLAGS
  last and the later `-C target-cpu` wins, so this overrides `native`; v3 (AVX2) is supported by
  all GitHub x64 runners. Scoped to the fuzz job — test/clippy codegen unchanged.
- Separate cache namespace (`key: afl`); instrumented and plain builds never share artifacts.
  New keys retire the poisoned entries — no manual cache deletion needed.
- `cargo-afl` pinned `=0.15.24` (matching `afl` in Cargo.lock) + a guard step comparing
  `cargo afl --version` to the lockfile pin: a drift makes every exec abort with no build error.
- Fuzzer abort (exit ≠ 0, no crashes) now fails with an explicit error instead of being
  swallowed by the skipped crash-report step (it had no `if: always()`).
- `-g` input hardened: `MIN_LEN` must be numeric; reuses `target/release/check_input_size` from
  `cargo afl build` instead of a second debug-profile dependency build (~1.5 min, ~half the
  cache entry).

## Verification

- Flag override: `rustc -C target-cpu=native -C target-cpu=x86-64-v3 --print cfg` → `avx512f`
  off, `avx2` on. Fingerprint records both flags, override last.
- Binary: 0 AVX-512 (`zmm`) instructions with the pin vs 47 with `native` on an AVX-512 host.
- Full fuzz-job sequence executed verbatim locally: `MIN_LEN=772`, seeds accepted, fuzz window
  completes, 0 crashes, crash-check passes. Negative paths tested: non-numeric `MIN_LEN`,
  missing binary, missing crashes dir, simulated version drift (0.16.0 vs 0.15.24) — all fail
  loudly.
- `actionlint` 1.7.12 clean. Independent adversarial review reproduced all claims, refuted none;
  its findings (version guard, evidence-grade wording, redundant debug build) are incorporated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
